### PR TITLE
Derives version information from the collector parameter.

### DIFF
--- a/exporter/newrelicexporter/config.go
+++ b/exporter/newrelicexporter/config.go
@@ -67,7 +67,7 @@ func (c Config) HarvestOption(cfg *telemetry.Config) {
 	cfg.HarvestTimeout = c.Timeout
 	cfg.CommonAttributes = c.CommonAttributes
 	cfg.Product = product
-	cfg.ProductVersion = version
+	cfg.ProductVersion = ""
 	var prefix string
 	if c.metricsInsecure {
 		prefix = "http://"

--- a/exporter/newrelicexporter/config_test.go
+++ b/exporter/newrelicexporter/config_test.go
@@ -77,6 +77,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 		MetricsURLOverride: "https://alt.metrics.newrelic.com",
 		Product:            product,
-		ProductVersion:     version,
+		ProductVersion:     "",
 	})
 }

--- a/exporter/newrelicexporter/factory.go
+++ b/exporter/newrelicexporter/factory.go
@@ -45,7 +45,7 @@ func createLogsExporter(
 	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.LogsExporter, error) {
-	exp, err := newLogsExporter(params.Logger, cfg)
+	exp, err := newLogsExporter(params.Logger, params.ApplicationStartInfo, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func createTraceExporter(
 	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.TracesExporter, error) {
-	exp, err := newTraceExporter(params.Logger, cfg)
+	exp, err := newTraceExporter(params.Logger, params.ApplicationStartInfo, cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR generates version information (and user agent strings) from the application startup info provided to the OpenTelemetry collector executable.

This will ensure that version is picked up reliably from the OpenTelemetry-Collector binary.