### PR TITLE
Add attribute metadata metric

### DIFF
--- a/exporter/newrelicexporter/metrics.go
+++ b/exporter/newrelicexporter/metrics.go
@@ -29,18 +29,21 @@ import (
 )
 
 var (
-	tagGrpcStatusCode, _    = tag.NewKey("grpc_response_code")
-	tagHTTPStatusCode, _    = tag.NewKey("http_status_code")
-	tagRequestUserAgent, _  = tag.NewKey("user_agent")
-	tagAPIKey, _            = tag.NewKey("api_key")
-	tagDataType, _          = tag.NewKey("data_type")
-	tagMetricType, _        = tag.NewKey("metric_type")
-	tagMetricTemporality, _ = tag.NewKey("metric_temporality")
-	tagHasSpanEvents, _     = tag.NewKey("has_span_events")
-	tagHasSpanLinks, _      = tag.NewKey("has_span_links")
-	tagKeys                 = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType}
-	metricMetadataTagKeys   = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType, tagMetricType, tagMetricTemporality}
-	spanMetadataTagKeys     = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType, tagHasSpanEvents, tagHasSpanLinks}
+	tagGrpcStatusCode, _     = tag.NewKey("grpc_response_code")
+	tagHTTPStatusCode, _     = tag.NewKey("http_status_code")
+	tagRequestUserAgent, _   = tag.NewKey("user_agent")
+	tagAPIKey, _             = tag.NewKey("api_key")
+	tagDataType, _           = tag.NewKey("data_type")
+	tagMetricType, _         = tag.NewKey("metric_type")
+	tagMetricTemporality, _  = tag.NewKey("metric_temporality")
+	tagHasSpanEvents, _      = tag.NewKey("has_span_events")
+	tagHasSpanLinks, _       = tag.NewKey("has_span_links")
+	tagAttributeLocation, _  = tag.NewKey("attribute_location")
+	tagAttributeValueType, _ = tag.NewKey("attribute_type")
+	tagKeys                  = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType}
+	metricMetadataTagKeys    = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType, tagMetricType, tagMetricTemporality}
+	spanMetadataTagKeys      = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType, tagHasSpanEvents, tagHasSpanLinks}
+	attributeMetadataTagKeys = []tag.Key{tagGrpcStatusCode, tagHTTPStatusCode, tagRequestUserAgent, tagAPIKey, tagDataType, tagAttributeLocation, tagAttributeValueType}
 
 	statRequestCount         = stats.Int64("newrelicexporter_request_count", "Number of requests processed", stats.UnitDimensionless)
 	statOutputDatapointCount = stats.Int64("newrelicexporter_output_datapoint_count", "Number of data points sent to the HTTP API", stats.UnitDimensionless)
@@ -48,6 +51,7 @@ var (
 	statExternalTime         = stats.Float64("newrelicexporter_external_time", "Wall clock time (seconds) spent sending data to the HTTP API", stats.UnitSeconds)
 	statMetricMetadata       = stats.Int64("newrelicexporter_metric_metadata_count", "Number of metrics processed", stats.UnitDimensionless)
 	statSpanMetadata         = stats.Int64("newrelicexporter_span_metadata_count", "Number of spans processed", stats.UnitDimensionless)
+	statAttributeMetadata    = stats.Int64("newrelicexporter_attribute_metadata_count", "Number of attributes processed", stats.UnitDimensionless)
 )
 
 // MetricViews return metric views for Kafka receiver.
@@ -59,6 +63,7 @@ func MetricViews() []*view.View {
 		buildView(tagKeys, statExternalTime, view.Sum()),
 		buildView(metricMetadataTagKeys, statMetricMetadata, view.Sum()),
 		buildView(spanMetadataTagKeys, statSpanMetadata, view.Sum()),
+		buildView(attributeMetadataTagKeys, statAttributeMetadata, view.Sum()),
 	}
 }
 
@@ -82,6 +87,34 @@ type spanStatsKey struct {
 	hasLinks  bool
 }
 
+type attributeLocation int
+
+const (
+	attributeLocationResource attributeLocation = iota
+	attributeLocationSpan
+	attributeLocationSpanEvent
+	attributeLocationLog
+)
+
+func (al attributeLocation) String() string {
+	switch al {
+	case attributeLocationResource:
+		return "resource"
+	case attributeLocationSpan:
+		return "span"
+	case attributeLocationSpanEvent:
+		return "span_event"
+	case attributeLocationLog:
+		return "log"
+	}
+	return ""
+}
+
+type attributeStatsKey struct {
+	location      attributeLocation
+	attributeType pdata.AttributeValueType
+}
+
 type exportMetadata struct {
 	// Metric tags
 	grpcResponseCode codes.Code // The gRPC response code
@@ -91,12 +124,13 @@ type exportMetadata struct {
 	dataType         string     // The type of data being recorded
 
 	// Metric values
-	dataInputCount      int                    // Number of resource spans in the request
-	dataOutputCount     int                    // Number of spans sent to the trace API
-	exporterTime        time.Duration          // Total time spent in the newrelic exporter
-	externalDuration    time.Duration          // Time spent sending to the trace API
-	metricMetadataCount map[metricStatsKey]int // Number of metrics by type and temporality
-	spanMetadataCount   map[spanStatsKey]int   // Number of spans by whether or not they have events or links
+	dataInputCount         int                       // Number of resource spans in the request
+	dataOutputCount        int                       // Number of spans sent to the trace API
+	exporterTime           time.Duration             // Total time spent in the newrelic exporter
+	externalDuration       time.Duration             // Time spent sending to the trace API
+	metricMetadataCount    map[metricStatsKey]int    // Number of metrics by type and temporality
+	spanMetadataCount      map[spanStatsKey]int      // Number of spans by whether or not they have events or links
+	attributeMetadataCount map[attributeStatsKey]int // Number of attributes by location and type
 }
 
 func newTraceMetadata(ctx context.Context) exportMetadata {
@@ -120,11 +154,12 @@ func initMetadata(ctx context.Context, dataType string) exportMetadata {
 	}
 
 	return exportMetadata{
-		userAgent:           userAgent,
-		apiKey:              "not_present",
-		dataType:            dataType,
-		metricMetadataCount: make(map[metricStatsKey]int),
-		spanMetadataCount:   make(map[spanStatsKey]int),
+		userAgent:              userAgent,
+		apiKey:                 "not_present",
+		dataType:               dataType,
+		metricMetadataCount:    make(map[metricStatsKey]int, 8*3 /* 8 metric types by 3 temporarilities */),
+		spanMetadataCount:      make(map[spanStatsKey]int, 2*2 /* combinations of the 2 bool key values */),
+		attributeMetadataCount: make(map[attributeStatsKey]int, 3*7 /* spans can have 7 value types in 4 different locations */),
 	}
 }
 
@@ -177,6 +212,23 @@ func (d exportMetadata) recordMetrics(ctx context.Context) error {
 			spanMetadataTagMutators[len(spanMetadataTagMutators)-1] = hasSpanLinksTag
 
 			e := stats.RecordWithTags(ctx, spanMetadataTagMutators, statSpanMetadata.M(int64(v)))
+			if e != nil {
+				errors = append(errors, e)
+			}
+		}
+	}
+
+	if len(d.attributeMetadataCount) > 0 {
+		attributeMetadataMutators := make([]tag.Mutator, len(tags)+2)
+		copy(attributeMetadataMutators, tags)
+		for k, v := range d.attributeMetadataCount {
+			locationTag := tag.Insert(tagAttributeLocation, k.location.String())
+			attributeMetadataMutators[len(attributeMetadataMutators)-2] = locationTag
+
+			typeTag := tag.Insert(tagAttributeValueType, k.attributeType.String())
+			attributeMetadataMutators[len(attributeMetadataMutators)-1] = typeTag
+
+			e := stats.RecordWithTags(ctx, attributeMetadataMutators, statAttributeMetadata.M(int64(v)))
 			if e != nil {
 				errors = append(errors, e)
 			}

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -62,7 +62,9 @@ func newTransformer(startInfo *component.ApplicationStartInfo, details *exportMe
 }
 
 func (t *transformer) CommonAttributes(resource pdata.Resource, lib pdata.InstrumentationLibrary) map[string]interface{} {
-	commonAttrs := tracetranslator.AttributeMapToMap(resource.Attributes())
+	resourceAttrs := resource.Attributes()
+	commonAttrs := tracetranslator.AttributeMapToMap(resourceAttrs)
+	t.TrackAttributes(attributeLocationResource, resourceAttrs)
 
 	if n := lib.Name(); n != "" {
 		commonAttrs[instrumentationNameKey] = n
@@ -122,14 +124,16 @@ func (t *transformer) Log(log pdata.LogRecord) (telemetry.Log, error) {
 		message = log.Name()
 	}
 
-	attrs := make(map[string]interface{}, log.Attributes().Len()+5)
+	logAttrs := log.Attributes()
+	attrs := make(map[string]interface{}, logAttrs.Len()+5)
 
-	for k, v := range tracetranslator.AttributeMapToMap(log.Attributes()) {
+	for k, v := range tracetranslator.AttributeMapToMap(logAttrs) {
 		// Only include attribute if not an override attribute
 		if _, isOverrideKey := t.OverrideAttributes[k]; !isOverrideKey {
 			attrs[k] = v
 		}
 	}
+	t.TrackAttributes(attributeLocationLog, logAttrs)
 
 	attrs["name"] = log.Name()
 	if !log.TraceID().IsEmpty() {
@@ -156,7 +160,8 @@ func (t *transformer) Log(log pdata.LogRecord) (telemetry.Log, error) {
 }
 
 func (t *transformer) SpanAttributes(span pdata.Span) map[string]interface{} {
-	length := span.Attributes().Len()
+	spanAttrs := span.Attributes()
+	length := spanAttrs.Len()
 
 	var hasStatusCode, hasStatusDesc bool
 	s := span.Status()
@@ -190,12 +195,13 @@ func (t *transformer) SpanAttributes(span pdata.Span) map[string]interface{} {
 		attrs[spanKindKey] = strings.ToLower(kind)
 	}
 
-	for k, v := range tracetranslator.AttributeMapToMap(span.Attributes()) {
+	for k, v := range tracetranslator.AttributeMapToMap(spanAttrs) {
 		// Only include attribute if not an override attribute
 		if _, isOverrideKey := t.OverrideAttributes[k]; !isOverrideKey {
 			attrs[k] = v
 		}
 	}
+	t.TrackAttributes(attributeLocationSpan, spanAttrs)
 
 	return attrs
 }
@@ -211,11 +217,13 @@ func (t *transformer) SpanEvents(span pdata.Span) []telemetry.Event {
 
 	for i := 0; i < length; i++ {
 		event := span.Events().At(i)
+		eventAttrs := event.Attributes()
 		events[i] = telemetry.Event{
 			EventType:  event.Name(),
 			Timestamp:  event.Timestamp().AsTime(),
-			Attributes: tracetranslator.AttributeMapToMap(event.Attributes()),
+			Attributes: tracetranslator.AttributeMapToMap(eventAttrs),
 		}
+		t.TrackAttributes(attributeLocationSpanEvent, eventAttrs)
 	}
 	return events
 }
@@ -417,4 +425,11 @@ func (t *transformer) MetricAttributes(baseAttributes map[string]interface{}, at
 	})
 
 	return rawMap
+}
+
+func (t *transformer) TrackAttributes(location attributeLocation, attributeMap pdata.AttributeMap) {
+	attributeMap.ForEach(func(k string, v pdata.AttributeValue) {
+		statsKey := attributeStatsKey{location: location, attributeType: v.Type()}
+		t.details.attributeMetadataCount[statsKey]++
+	})
 }

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -43,12 +43,35 @@ func TestCommonAttributes(t *testing.T) {
 	ilm.SetName("test name")
 	ilm.SetVersion("test version")
 
-	commonAttrs := newTransformer(startInfo, nil).CommonAttributes(resource, ilm)
+	details := newTraceMetadata(context.TODO())
+	commonAttrs := newTransformer(startInfo, &details).CommonAttributes(resource, ilm)
 	assert.Equal(t, "the-collector", commonAttrs[collectorNameKey])
 	assert.Equal(t, "0.0.1", commonAttrs[collectorVersionKey])
 	assert.Equal(t, "R1", commonAttrs["resource"])
 	assert.Equal(t, "test name", commonAttrs[instrumentationNameKey])
 	assert.Equal(t, "test version", commonAttrs[instrumentationVersionKey])
+
+	assert.Equal(t, 1, len(details.attributeMetadataCount))
+	assert.Equal(t, 1, details.attributeMetadataCount[attributeStatsKey{location: attributeLocationResource, attributeType: pdata.AttributeValueSTRING}])
+}
+
+func TestDoesNotCaptureResourceAttributeMetadata(t *testing.T) {
+	startInfo := &component.ApplicationStartInfo{
+		ExeName: "the-collector",
+		Version: "0.0.1",
+	}
+
+	resource := pdata.NewResource()
+
+	ilm := pdata.NewInstrumentationLibrary()
+	ilm.SetName("test name")
+	ilm.SetVersion("test version")
+
+	details := newTraceMetadata(context.TODO())
+	commonAttrs := newTransformer(startInfo, &details).CommonAttributes(resource, ilm)
+
+	assert.Greater(t, len(commonAttrs), 0)
+	assert.Equal(t, 0, len(details.attributeMetadataCount))
 }
 
 func TestCaptureSpanMetadata(t *testing.T) {
@@ -123,6 +146,48 @@ func TestCaptureSpanMetadata(t *testing.T) {
 			assert.Equal(t, 1, details.spanMetadataCount[test.wantKey])
 		})
 	}
+}
+
+func TestCaptureSpanAttributeMetadata(t *testing.T) {
+	details := newTraceMetadata(context.TODO())
+	transform := newTransformer(nil, &details)
+
+	se := pdata.NewSpanEvent()
+	se.Attributes().InsertBool("testattr", true)
+
+	s := pdata.NewSpan()
+	s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 2}))
+	s.SetParentSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	s.SetName("test span")
+	s.Events().Append(se)
+	s.Attributes().InsertInt("spanattr", 42)
+
+	_, err := transform.Span(s)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(details.attributeMetadataCount))
+	assert.Equal(t, 1, details.attributeMetadataCount[attributeStatsKey{location: attributeLocationSpan, attributeType: pdata.AttributeValueINT}])
+	assert.Equal(t, 1, details.attributeMetadataCount[attributeStatsKey{location: attributeLocationSpanEvent, attributeType: pdata.AttributeValueBOOL}])
+}
+
+func TestDoesNotCaptureSpanAttributeMetadata(t *testing.T) {
+	details := newTraceMetadata(context.TODO())
+	transform := newTransformer(nil, &details)
+
+	se := pdata.NewSpanEvent()
+
+	s := pdata.NewSpan()
+	s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 2}))
+	s.SetParentSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	s.SetName("test span")
+	s.Events().Append(se)
+
+	_, err := transform.Span(s)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(details.attributeMetadataCount))
 }
 
 func TestTransformSpan(t *testing.T) {
@@ -707,9 +772,38 @@ func TestTransformer_Log(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			transform := newTransformer(nil, nil)
+			details := newLogMetadata(context.TODO())
+			transform := newTransformer(nil, &details)
 			got, _ := transform.Log(test.logFunc())
 			assert.EqualValues(t, test.want, got)
 		})
 	}
+}
+
+func TestCaptureLogAttributeMetadata(t *testing.T) {
+	log := pdata.NewLogRecord()
+	log.SetName("bloopbleep")
+	log.Attributes().InsertString("foo", "bar")
+	log.Body().SetStringVal("Hello World")
+
+	details := newLogMetadata(context.TODO())
+	transform := newTransformer(nil, &details)
+	_, err := transform.Log(log)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(details.attributeMetadataCount))
+	assert.Equal(t, 1, details.attributeMetadataCount[attributeStatsKey{location: attributeLocationLog, attributeType: pdata.AttributeValueSTRING}])
+}
+
+func TestDoesNotCaptureLogAttributeMetadata(t *testing.T) {
+	log := pdata.NewLogRecord()
+	log.SetName("bloopbleep")
+	log.Body().SetStringVal("Hello World")
+
+	details := newLogMetadata(context.TODO())
+	transform := newTransformer(nil, &details)
+	_, err := transform.Log(log)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(details.attributeMetadataCount))
 }


### PR DESCRIPTION
Adds a metric for tracking the different types of attributes that are received.

Metric attributes are always a string so they are ignored for now.