### PR TITLE
Regenerate config.schema.yaml files via make generate-schemas

### DIFF
--- a/receiver/sqlserverreceiver/config.schema.yaml
+++ b/receiver/sqlserverreceiver/config.schema.yaml
@@ -24,6 +24,13 @@ $defs:
 description: Config defines configuration for a sqlserver receiver.
 type: object
 properties:
+  allowed_comment_keys:
+    type: array
+    items:
+      type: string
+  collect_full_query_text:
+    description: CollectFullQueryText enables collection of the full SQL batch text (st.text) in addition to the statement-level substring already captured in db.query.text. When enabled, db.query.full_text and query.comments are populated in log records.
+    type: boolean
   computer_name:
     type: string
   datasource:


### PR DESCRIPTION
- Runs `make generate-schemas` to update `receiver/sqlserverreceiver/config.schema.yaml` with new fields added from the `pp-release` 
  merge (`allowed_comment_keys`, `collect_full_query_text`)                                                                            