### PR TITLE
[receiver/postgresql] Add conflicts and blk read/write time metrics from pg_stat_database

### DIFF
--- a/.chloggen/postgresqlreceiver-42236-pg-stat-database-metrics.yaml
+++ b/.chloggen/postgresqlreceiver-42236-pg-stat-database-metrics.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/postgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `postgresql.database.conflicts`, `postgresql.database.blk_read_time`, and `postgresql.database.blk_write_time` metrics sourced from the `pg_stat_database` view. All three are disabled by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42236]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if the change is relevant to users of libraries or exported APIs.
+# Include 'developer' if the change is relevant only for developers of this repo.
+# Default: '[user]'
+change_logs: []

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -258,11 +258,14 @@ type databaseStats struct {
 	tupDeleted           int64
 	blksHit              int64
 	blksRead             int64
+	conflicts            int64
+	blkReadTime          float64
+	blkWriteTime         float64
 }
 
 func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []string) (map[databaseName]databaseStats, error) {
 	query := filterQueryByDatabases(
-		"SELECT datname, xact_commit, xact_rollback, deadlocks, temp_files, temp_bytes, tup_updated, tup_returned, tup_fetched, tup_inserted, tup_deleted, blks_hit, blks_read FROM pg_stat_database",
+		"SELECT datname, xact_commit, xact_rollback, deadlocks, temp_files, temp_bytes, tup_updated, tup_returned, tup_fetched, tup_inserted, tup_deleted, blks_hit, blks_read, conflicts, blk_read_time, blk_write_time FROM pg_stat_database",
 		databases,
 		false,
 	)
@@ -277,8 +280,9 @@ func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []str
 
 	for rows.Next() {
 		var datname string
-		var transactionCommitted, transactionRollback, deadlocks, tempIo, tempFiles, tupUpdated, tupReturned, tupFetched, tupInserted, tupDeleted, blksHit, blksRead int64
-		err = rows.Scan(&datname, &transactionCommitted, &transactionRollback, &deadlocks, &tempFiles, &tempIo, &tupUpdated, &tupReturned, &tupFetched, &tupInserted, &tupDeleted, &blksHit, &blksRead)
+		var transactionCommitted, transactionRollback, deadlocks, tempIo, tempFiles, tupUpdated, tupReturned, tupFetched, tupInserted, tupDeleted, blksHit, blksRead, conflicts int64
+		var blkReadTime, blkWriteTime float64
+		err = rows.Scan(&datname, &transactionCommitted, &transactionRollback, &deadlocks, &tempFiles, &tempIo, &tupUpdated, &tupReturned, &tupFetched, &tupInserted, &tupDeleted, &blksHit, &blksRead, &conflicts, &blkReadTime, &blkWriteTime)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
@@ -297,6 +301,9 @@ func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []str
 				tupDeleted:           tupDeleted,
 				blksHit:              blksHit,
 				blksRead:             blksRead,
+				conflicts:            conflicts,
+				blkReadTime:          blkReadTime,
+				blkWriteTime:         blkWriteTime,
 			}
 		}
 	}

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -269,6 +269,30 @@ Number of disk blocks read in this database.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {blks_read} | Sum | Int | Cumulative | true | Development |
 
+### postgresql.database.blk_read_time
+
+Time spent reading data file blocks by backends in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | true | Development |
+
+### postgresql.database.blk_write_time
+
+Time spent writing data file blocks by backends in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | true | Development |
+
+### postgresql.database.conflicts
+
+Number of queries canceled due to conflicts with recovery in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {conflict} | Sum | Int | Cumulative | true | Development |
+
 ### postgresql.database.locks
 
 The number of database locks.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config.go
@@ -341,6 +341,66 @@ func (ms *PostgresqlConnectionMaxMetricConfig) Unmarshal(parser *confmap.Conf) e
 	return nil
 }
 
+// PostgresqlDatabaseBlkReadTimeMetricConfig provides config for the postgresql.database.blk_read_time metric.
+type PostgresqlDatabaseBlkReadTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlDatabaseBlkReadTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PostgresqlDatabaseBlkWriteTimeMetricConfig provides config for the postgresql.database.blk_write_time metric.
+type PostgresqlDatabaseBlkWriteTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlDatabaseBlkWriteTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PostgresqlDatabaseConflictsMetricConfig provides config for the postgresql.database.conflicts metric.
+type PostgresqlDatabaseConflictsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlDatabaseConflictsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // PostgresqlDatabaseCountMetricConfig provides config for the postgresql.database.count metric.
 type PostgresqlDatabaseCountMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -1054,6 +1114,9 @@ type MetricsConfig struct {
 	PostgresqlBlocksRead               PostgresqlBlocksReadMetricConfig               `mapstructure:"postgresql.blocks_read"`
 	PostgresqlCommits                  PostgresqlCommitsMetricConfig                  `mapstructure:"postgresql.commits"`
 	PostgresqlConnectionMax            PostgresqlConnectionMaxMetricConfig            `mapstructure:"postgresql.connection.max"`
+	PostgresqlDatabaseBlkReadTime      PostgresqlDatabaseBlkReadTimeMetricConfig      `mapstructure:"postgresql.database.blk_read_time"`
+	PostgresqlDatabaseBlkWriteTime     PostgresqlDatabaseBlkWriteTimeMetricConfig     `mapstructure:"postgresql.database.blk_write_time"`
+	PostgresqlDatabaseConflicts        PostgresqlDatabaseConflictsMetricConfig        `mapstructure:"postgresql.database.conflicts"`
 	PostgresqlDatabaseCount            PostgresqlDatabaseCountMetricConfig            `mapstructure:"postgresql.database.count"`
 	PostgresqlDatabaseLocks            PostgresqlDatabaseLocksMetricConfig            `mapstructure:"postgresql.database.locks"`
 	PostgresqlDbSize                   PostgresqlDbSizeMetricConfig                   `mapstructure:"postgresql.db_size"`
@@ -1123,6 +1186,15 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
 			Enabled: true,
+		},
+		PostgresqlDatabaseBlkReadTime: PostgresqlDatabaseBlkReadTimeMetricConfig{
+			Enabled: false,
+		},
+		PostgresqlDatabaseBlkWriteTime: PostgresqlDatabaseBlkWriteTimeMetricConfig{
+			Enabled: false,
+		},
+		PostgresqlDatabaseConflicts: PostgresqlDatabaseConflictsMetricConfig{
+			Enabled: false,
 		},
 		PostgresqlDatabaseCount: PostgresqlDatabaseCountMetricConfig{
 			Enabled: true,

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
@@ -67,6 +67,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
 						Enabled: true,
 					},
+					PostgresqlDatabaseBlkReadTime: PostgresqlDatabaseBlkReadTimeMetricConfig{
+						Enabled: true,
+					},
+					PostgresqlDatabaseBlkWriteTime: PostgresqlDatabaseBlkWriteTimeMetricConfig{
+						Enabled: true,
+					},
+					PostgresqlDatabaseConflicts: PostgresqlDatabaseConflictsMetricConfig{
+						Enabled: true,
+					},
 					PostgresqlDatabaseCount: PostgresqlDatabaseCountMetricConfig{
 						Enabled: true,
 					},
@@ -211,6 +220,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
 						Enabled: false,
 					},
+					PostgresqlDatabaseBlkReadTime: PostgresqlDatabaseBlkReadTimeMetricConfig{
+						Enabled: false,
+					},
+					PostgresqlDatabaseBlkWriteTime: PostgresqlDatabaseBlkWriteTimeMetricConfig{
+						Enabled: false,
+					},
+					PostgresqlDatabaseConflicts: PostgresqlDatabaseConflictsMetricConfig{
+						Enabled: false,
+					},
 					PostgresqlDatabaseCount: PostgresqlDatabaseCountMetricConfig{
 						Enabled: false,
 					},
@@ -314,7 +332,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(PostgresqlBackendsMetricConfig{}, PostgresqlBgwriterBuffersAllocatedMetricConfig{}, PostgresqlBgwriterBuffersWritesMetricConfig{}, PostgresqlBgwriterCheckpointCountMetricConfig{}, PostgresqlBgwriterDurationMetricConfig{}, PostgresqlBgwriterMaxwrittenMetricConfig{}, PostgresqlBlksHitMetricConfig{}, PostgresqlBlksReadMetricConfig{}, PostgresqlBlocksReadMetricConfig{}, PostgresqlCommitsMetricConfig{}, PostgresqlConnectionMaxMetricConfig{}, PostgresqlDatabaseCountMetricConfig{}, PostgresqlDatabaseLocksMetricConfig{}, PostgresqlDbSizeMetricConfig{}, PostgresqlDeadlocksMetricConfig{}, PostgresqlFunctionCallsMetricConfig{}, PostgresqlIndexScansMetricConfig{}, PostgresqlIndexSizeMetricConfig{}, PostgresqlOperationsMetricConfig{}, PostgresqlReplicationDataDelayMetricConfig{}, PostgresqlRollbacksMetricConfig{}, PostgresqlRowsMetricConfig{}, PostgresqlSequentialScansMetricConfig{}, PostgresqlTableCountMetricConfig{}, PostgresqlTableSizeMetricConfig{}, PostgresqlTableVacuumCountMetricConfig{}, PostgresqlTempIoMetricConfig{}, PostgresqlTempFilesMetricConfig{}, PostgresqlTupDeletedMetricConfig{}, PostgresqlTupFetchedMetricConfig{}, PostgresqlTupInsertedMetricConfig{}, PostgresqlTupReturnedMetricConfig{}, PostgresqlTupUpdatedMetricConfig{}, PostgresqlWalAgeMetricConfig{}, PostgresqlWalDelayMetricConfig{}, PostgresqlWalLagMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(PostgresqlBackendsMetricConfig{}, PostgresqlBgwriterBuffersAllocatedMetricConfig{}, PostgresqlBgwriterBuffersWritesMetricConfig{}, PostgresqlBgwriterCheckpointCountMetricConfig{}, PostgresqlBgwriterDurationMetricConfig{}, PostgresqlBgwriterMaxwrittenMetricConfig{}, PostgresqlBlksHitMetricConfig{}, PostgresqlBlksReadMetricConfig{}, PostgresqlBlocksReadMetricConfig{}, PostgresqlCommitsMetricConfig{}, PostgresqlConnectionMaxMetricConfig{}, PostgresqlDatabaseBlkReadTimeMetricConfig{}, PostgresqlDatabaseBlkWriteTimeMetricConfig{}, PostgresqlDatabaseConflictsMetricConfig{}, PostgresqlDatabaseCountMetricConfig{}, PostgresqlDatabaseLocksMetricConfig{}, PostgresqlDbSizeMetricConfig{}, PostgresqlDeadlocksMetricConfig{}, PostgresqlFunctionCallsMetricConfig{}, PostgresqlIndexScansMetricConfig{}, PostgresqlIndexSizeMetricConfig{}, PostgresqlOperationsMetricConfig{}, PostgresqlReplicationDataDelayMetricConfig{}, PostgresqlRollbacksMetricConfig{}, PostgresqlRowsMetricConfig{}, PostgresqlSequentialScansMetricConfig{}, PostgresqlTableCountMetricConfig{}, PostgresqlTableSizeMetricConfig{}, PostgresqlTableVacuumCountMetricConfig{}, PostgresqlTempIoMetricConfig{}, PostgresqlTempFilesMetricConfig{}, PostgresqlTupDeletedMetricConfig{}, PostgresqlTupFetchedMetricConfig{}, PostgresqlTupInsertedMetricConfig{}, PostgresqlTupReturnedMetricConfig{}, PostgresqlTupUpdatedMetricConfig{}, PostgresqlWalAgeMetricConfig{}, PostgresqlWalDelayMetricConfig{}, PostgresqlWalLagMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -302,6 +302,15 @@ var MetricsInfo = metricsInfo{
 	PostgresqlConnectionMax: metricInfo{
 		Name: "postgresql.connection.max",
 	},
+	PostgresqlDatabaseBlkReadTime: metricInfo{
+		Name: "postgresql.database.blk_read_time",
+	},
+	PostgresqlDatabaseBlkWriteTime: metricInfo{
+		Name: "postgresql.database.blk_write_time",
+	},
+	PostgresqlDatabaseConflicts: metricInfo{
+		Name: "postgresql.database.conflicts",
+	},
 	PostgresqlDatabaseCount: metricInfo{
 		Name: "postgresql.database.count",
 	},
@@ -391,6 +400,9 @@ type metricsInfo struct {
 	PostgresqlBlocksRead               metricInfo
 	PostgresqlCommits                  metricInfo
 	PostgresqlConnectionMax            metricInfo
+	PostgresqlDatabaseBlkReadTime      metricInfo
+	PostgresqlDatabaseBlkWriteTime     metricInfo
+	PostgresqlDatabaseConflicts        metricInfo
 	PostgresqlDatabaseCount            metricInfo
 	PostgresqlDatabaseLocks            metricInfo
 	PostgresqlDbSize                   metricInfo
@@ -1140,6 +1152,162 @@ func (m *metricPostgresqlConnectionMax) emit(metrics pmetric.MetricSlice) {
 
 func newMetricPostgresqlConnectionMax(cfg PostgresqlConnectionMaxMetricConfig) metricPostgresqlConnectionMax {
 	m := metricPostgresqlConnectionMax{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlDatabaseBlkReadTime struct {
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   PostgresqlDatabaseBlkReadTimeMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.database.blk_read_time metric with initial data.
+func (m *metricPostgresqlDatabaseBlkReadTime) init() {
+	m.data.SetName("postgresql.database.blk_read_time")
+	m.data.SetDescription("Time spent reading data file blocks by backends in this database.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlDatabaseBlkReadTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlDatabaseBlkReadTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlDatabaseBlkReadTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlDatabaseBlkReadTime(cfg PostgresqlDatabaseBlkReadTimeMetricConfig) metricPostgresqlDatabaseBlkReadTime {
+	m := metricPostgresqlDatabaseBlkReadTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlDatabaseBlkWriteTime struct {
+	data     pmetric.Metric                             // data buffer for generated metric.
+	config   PostgresqlDatabaseBlkWriteTimeMetricConfig // metric config provided by user.
+	capacity int                                        // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.database.blk_write_time metric with initial data.
+func (m *metricPostgresqlDatabaseBlkWriteTime) init() {
+	m.data.SetName("postgresql.database.blk_write_time")
+	m.data.SetDescription("Time spent writing data file blocks by backends in this database.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlDatabaseBlkWriteTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlDatabaseBlkWriteTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlDatabaseBlkWriteTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlDatabaseBlkWriteTime(cfg PostgresqlDatabaseBlkWriteTimeMetricConfig) metricPostgresqlDatabaseBlkWriteTime {
+	m := metricPostgresqlDatabaseBlkWriteTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlDatabaseConflicts struct {
+	data     pmetric.Metric                          // data buffer for generated metric.
+	config   PostgresqlDatabaseConflictsMetricConfig // metric config provided by user.
+	capacity int                                     // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.database.conflicts metric with initial data.
+func (m *metricPostgresqlDatabaseConflicts) init() {
+	m.data.SetName("postgresql.database.conflicts")
+	m.data.SetDescription("Number of queries canceled due to conflicts with recovery in this database.")
+	m.data.SetUnit("{conflict}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlDatabaseConflicts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlDatabaseConflicts) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlDatabaseConflicts) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlDatabaseConflicts(cfg PostgresqlDatabaseConflictsMetricConfig) metricPostgresqlDatabaseConflicts {
+	m := metricPostgresqlDatabaseConflicts{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -2742,6 +2910,9 @@ type MetricsBuilder struct {
 	metricPostgresqlBlocksRead               metricPostgresqlBlocksRead
 	metricPostgresqlCommits                  metricPostgresqlCommits
 	metricPostgresqlConnectionMax            metricPostgresqlConnectionMax
+	metricPostgresqlDatabaseBlkReadTime      metricPostgresqlDatabaseBlkReadTime
+	metricPostgresqlDatabaseBlkWriteTime     metricPostgresqlDatabaseBlkWriteTime
+	metricPostgresqlDatabaseConflicts        metricPostgresqlDatabaseConflicts
 	metricPostgresqlDatabaseCount            metricPostgresqlDatabaseCount
 	metricPostgresqlDatabaseLocks            metricPostgresqlDatabaseLocks
 	metricPostgresqlDbSize                   metricPostgresqlDbSize
@@ -2803,6 +2974,9 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricPostgresqlBlocksRead:               newMetricPostgresqlBlocksRead(mbc.Metrics.PostgresqlBlocksRead),
 		metricPostgresqlCommits:                  newMetricPostgresqlCommits(mbc.Metrics.PostgresqlCommits),
 		metricPostgresqlConnectionMax:            newMetricPostgresqlConnectionMax(mbc.Metrics.PostgresqlConnectionMax),
+		metricPostgresqlDatabaseBlkReadTime:      newMetricPostgresqlDatabaseBlkReadTime(mbc.Metrics.PostgresqlDatabaseBlkReadTime),
+		metricPostgresqlDatabaseBlkWriteTime:     newMetricPostgresqlDatabaseBlkWriteTime(mbc.Metrics.PostgresqlDatabaseBlkWriteTime),
+		metricPostgresqlDatabaseConflicts:        newMetricPostgresqlDatabaseConflicts(mbc.Metrics.PostgresqlDatabaseConflicts),
 		metricPostgresqlDatabaseCount:            newMetricPostgresqlDatabaseCount(mbc.Metrics.PostgresqlDatabaseCount),
 		metricPostgresqlDatabaseLocks:            newMetricPostgresqlDatabaseLocks(mbc.Metrics.PostgresqlDatabaseLocks),
 		metricPostgresqlDbSize:                   newMetricPostgresqlDbSize(mbc.Metrics.PostgresqlDbSize),
@@ -2941,6 +3115,9 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricPostgresqlBlocksRead.emit(ils.Metrics())
 	mb.metricPostgresqlCommits.emit(ils.Metrics())
 	mb.metricPostgresqlConnectionMax.emit(ils.Metrics())
+	mb.metricPostgresqlDatabaseBlkReadTime.emit(ils.Metrics())
+	mb.metricPostgresqlDatabaseBlkWriteTime.emit(ils.Metrics())
+	mb.metricPostgresqlDatabaseConflicts.emit(ils.Metrics())
 	mb.metricPostgresqlDatabaseCount.emit(ils.Metrics())
 	mb.metricPostgresqlDatabaseLocks.emit(ils.Metrics())
 	mb.metricPostgresqlDbSize.emit(ils.Metrics())
@@ -3050,6 +3227,21 @@ func (mb *MetricsBuilder) RecordPostgresqlCommitsDataPoint(ts pcommon.Timestamp,
 // RecordPostgresqlConnectionMaxDataPoint adds a data point to postgresql.connection.max metric.
 func (mb *MetricsBuilder) RecordPostgresqlConnectionMaxDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricPostgresqlConnectionMax.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlDatabaseBlkReadTimeDataPoint adds a data point to postgresql.database.blk_read_time metric.
+func (mb *MetricsBuilder) RecordPostgresqlDatabaseBlkReadTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricPostgresqlDatabaseBlkReadTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlDatabaseBlkWriteTimeDataPoint adds a data point to postgresql.database.blk_write_time metric.
+func (mb *MetricsBuilder) RecordPostgresqlDatabaseBlkWriteTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricPostgresqlDatabaseBlkWriteTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlDatabaseConflictsDataPoint adds a data point to postgresql.database.conflicts metric.
+func (mb *MetricsBuilder) RecordPostgresqlDatabaseConflictsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricPostgresqlDatabaseConflicts.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPostgresqlDatabaseCountDataPoint adds a data point to postgresql.database.count metric.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -141,6 +141,15 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordPostgresqlConnectionMaxDataPoint(ts, 1)
 
+			allMetricsCount++
+			mb.RecordPostgresqlDatabaseBlkReadTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordPostgresqlDatabaseBlkWriteTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordPostgresqlDatabaseConflictsDataPoint(ts, 1)
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordPostgresqlDatabaseCountDataPoint(ts, 1)
@@ -565,6 +574,48 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, "Configured maximum number of client connections allowed", mi.Description())
 					assert.Equal(t, "{connections}", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "postgresql.database.blk_read_time":
+					assert.False(t, validatedMetrics["postgresql.database.blk_read_time"], "Found a duplicate in the metrics slice: postgresql.database.blk_read_time")
+					validatedMetrics["postgresql.database.blk_read_time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Time spent reading data file blocks by backends in this database.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "postgresql.database.blk_write_time":
+					assert.False(t, validatedMetrics["postgresql.database.blk_write_time"], "Found a duplicate in the metrics slice: postgresql.database.blk_write_time")
+					validatedMetrics["postgresql.database.blk_write_time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Time spent writing data file blocks by backends in this database.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "postgresql.database.conflicts":
+					assert.False(t, validatedMetrics["postgresql.database.conflicts"], "Found a duplicate in the metrics slice: postgresql.database.conflicts")
+					validatedMetrics["postgresql.database.conflicts"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of queries canceled due to conflicts with recovery in this database.", mi.Description())
+					assert.Equal(t, "{conflict}", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())

--- a/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
@@ -27,6 +27,12 @@ all_set:
       enabled: true
     postgresql.connection.max:
       enabled: true
+    postgresql.database.blk_read_time:
+      enabled: true
+    postgresql.database.blk_write_time:
+      enabled: true
+    postgresql.database.conflicts:
+      enabled: true
     postgresql.database.count:
       enabled: true
     postgresql.database.locks:
@@ -128,6 +134,12 @@ reaggregate_set:
       enabled: true
     postgresql.connection.max:
       enabled: true
+    postgresql.database.blk_read_time:
+      enabled: true
+    postgresql.database.blk_write_time:
+      enabled: true
+    postgresql.database.conflicts:
+      enabled: true
     postgresql.database.count:
       enabled: true
     postgresql.database.locks:
@@ -228,6 +240,12 @@ none_set:
     postgresql.commits:
       enabled: false
     postgresql.connection.max:
+      enabled: false
+    postgresql.database.blk_read_time:
+      enabled: false
+    postgresql.database.blk_write_time:
+      enabled: false
+    postgresql.database.conflicts:
       enabled: false
     postgresql.database.count:
       enabled: false

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -364,6 +364,33 @@ metrics:
     unit: "{connections}"
     gauge:
       value_type: int
+  postgresql.database.blk_read_time:
+    enabled: false
+    description: Time spent reading data file blocks by backends in this database.
+    stability: development
+    unit: ms
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.database.blk_write_time:
+    enabled: false
+    description: Time spent writing data file blocks by backends in this database.
+    stability: development
+    unit: ms
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.database.conflicts:
+    enabled: false
+    description: Number of queries canceled due to conflicts with recovery in this database.
+    stability: development
+    unit: "{conflict}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
   postgresql.database.count:
     description: Number of user databases.
     stability: development

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -445,6 +445,9 @@ func (p *postgreSQLScraper) recordDatabase(now pcommon.Timestamp, db string, r *
 		p.mb.RecordPostgresqlTupDeletedDataPoint(now, stats.tupDeleted)
 		p.mb.RecordPostgresqlBlksHitDataPoint(now, stats.blksHit)
 		p.mb.RecordPostgresqlBlksReadDataPoint(now, stats.blksRead)
+		p.mb.RecordPostgresqlDatabaseConflictsDataPoint(now, stats.conflicts)
+		p.mb.RecordPostgresqlDatabaseBlkReadTimeDataPoint(now, stats.blkReadTime)
+		p.mb.RecordPostgresqlDatabaseBlkWriteTimeDataPoint(now, stats.blkWriteTime)
 	}
 	rb := p.setupResourceBuilder(p.mb.NewResourceBuilder(), db, "", "", "")
 	p.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -69,6 +69,9 @@ func TestScraper(t *testing.T) {
 		cfg.Metrics.PostgresqlBlksRead.Enabled = true
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, factory, newCache(1), newTTLCache[string](1, time.Second))
 
@@ -123,6 +126,9 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		require.False(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled)
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, factory, newCache(1), newTTLCache[string](1, time.Second))
 		actualMetrics, err := scraper.scrape(t.Context())
@@ -148,6 +154,9 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 		cfg.Metrics.PostgresqlBlksRead.Enabled = false
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = false
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = false
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = false
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = false
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = false
 
 		scraper = newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, factory, newCache(1), newTTLCache[string](1, time.Second))
 		actualMetrics, err = scraper.scrape(t.Context())
@@ -201,6 +210,9 @@ func TestScraperNoDatabaseMultipleWithoutPreciseLag(t *testing.T) {
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		require.False(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled)
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, &factory, newCache(1), newTTLCache[string](1, time.Second))
 
 		actualMetrics, err := scraper.scrape(t.Context())
@@ -254,6 +266,9 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		require.False(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled)
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, &factory, newCache(1), newTTLCache[string](1, time.Second))
 
 		actualMetrics, err := scraper.scrape(t.Context())
@@ -307,6 +322,9 @@ func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		require.False(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled)
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, &factory, newCache(1), newTTLCache[string](1, time.Second))
 
@@ -361,6 +379,9 @@ func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
 		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
 		require.False(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled)
 		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseConflicts.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkReadTime.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseBlkWriteTime.Enabled = true
 		scraper := newPostgreSQLScraper(receivertest.NewNopSettings(metadata.Type), cfg, &factory, newCache(1), newTTLCache[string](1, time.Second))
 
 		actualMetrics, err := scraper.scrape(t.Context())
@@ -1134,6 +1155,9 @@ func (m *mockClient) initMocks(database, schema string, databases []string, inde
 				blksHit:              int64(idx + 10),
 				blksRead:             int64(idx + 11),
 				tempIo:               int64(idx + 12),
+				conflicts:            int64(idx + 13),
+				blkReadTime:          float64(idx + 14),
+				blkWriteTime:         float64(idx + 15),
 			}
 			dbSize[databaseName(db)] = int64(idx + 4)
 			backends[databaseName(db)] = int64(idx + 3)

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -221,7 +221,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -231,7 +231,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -240,7 +240,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -251,6 +251,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "14"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -318,7 +348,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -338,7 +368,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -358,7 +388,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_updated}'             
+            unit: '{tup_updated}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
@@ -378,7 +408,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -388,7 +418,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -397,7 +427,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -408,6 +438,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -475,7 +535,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -495,7 +555,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -515,7 +575,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_updated}'             
+            unit: '{tup_updated}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
@@ -535,7 +595,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -545,7 +605,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -554,7 +614,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -565,6 +625,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 17
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -632,7 +722,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -652,7 +742,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -672,7 +762,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_updated}'              
+            unit: '{tup_updated}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
@@ -221,7 +221,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -231,7 +231,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -240,7 +240,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -251,6 +251,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "14"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -318,7 +348,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -338,7 +368,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -378,7 +408,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -388,7 +418,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -397,7 +427,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -408,6 +438,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -475,7 +535,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -495,7 +555,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -535,7 +595,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -545,7 +605,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -554,7 +614,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -565,6 +625,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 17
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -632,7 +722,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -652,7 +742,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
@@ -221,7 +221,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -231,7 +231,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -240,7 +240,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -251,6 +251,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "14"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -318,7 +348,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -338,7 +368,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -378,7 +408,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -388,7 +418,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -397,7 +427,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -408,6 +438,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -475,7 +535,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -495,7 +555,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -535,7 +595,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -545,7 +605,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -554,7 +614,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -565,6 +625,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 17
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -632,7 +722,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -652,7 +742,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
@@ -221,7 +221,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -231,7 +231,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -240,7 +240,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -251,6 +251,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "14"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -318,7 +348,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -338,7 +368,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -358,7 +388,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_updated}'            
+            unit: '{tup_updated}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
@@ -378,7 +408,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -388,7 +418,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -397,7 +427,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -408,6 +438,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -475,7 +535,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -495,7 +555,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -535,7 +595,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Number of times disk blocks were found already in the buffer cache. 
+          - description: Number of times disk blocks were found already in the buffer cache.
             name: postgresql.blks_hit
             sum:
               aggregationTemporality: 2
@@ -545,7 +605,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{blks_hit}'
-          - description: Number of disk blocks read in this database. 
+          - description: Number of disk blocks read in this database.
             name: postgresql.blks_read
             sum:
               aggregationTemporality: 2
@@ -554,7 +614,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{blks_read}'            
+            unit: '{blks_read}'
           - description: The number of commits.
             name: postgresql.commits
             sum:
@@ -565,6 +625,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 16
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 17
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:
@@ -632,7 +722,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_deleted}'            
+            unit: '{tup_deleted}'
           - description: Number of rows fetched by queries in the database.
             name: postgresql.tup_fetched
             sum:
@@ -652,7 +742,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_inserted}'            
+            unit: '{tup_inserted}'
           - description: Number of rows returned by queries in the database.
             name: postgresql.tup_returned
             sum:
@@ -672,7 +762,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: '{tup_updated}'            
+            unit: '{tup_updated}'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -258,6 +258,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
@@ -258,6 +258,36 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: Time spent reading data file blocks by backends in this database.
+            name: postgresql.database.blk_read_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 14
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Time spent writing data file blocks by backends in this database.
+            name: postgresql.database.blk_write_time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 15
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of queries canceled due to conflicts with recovery in this database.
+            name: postgresql.database.conflicts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "13"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{conflict}'
           - description: The database disk usage.
             name: postgresql.db_size
             sum:


### PR DESCRIPTION
## Description

The PostgreSQL receiver already queries `pg_stat_database` in `getDatabaseStats`, but does not extract three useful columns. This PR adds them as new, **disabled-by-default** metrics:

| metric | unit | type | source column |
|---|---|---|---|
| `postgresql.database.conflicts` | `{conflict}` | int sum (monotonic, cumulative) | `conflicts` |
| `postgresql.database.blk_read_time` | `ms` | double sum (monotonic, cumulative) | `blk_read_time` |
| `postgresql.database.blk_write_time` | `ms` | double sum (monotonic, cumulative) | `blk_write_time` |

These expose query-conflict counts and block read/write timing, useful for diagnosing recovery conflicts and read-vs-write I/O contention.

## Implementation
- `metadata.yaml`: three new metric definitions (`enabled: false`, `stability: development`), matching the existing `postgresql.database.*` namespace and the opt-in convention of the other `pg_stat_database` metrics.
- `client.go`: extend the existing `pg_stat_database` SELECT, the `databaseStats` struct, and the row Scan. No new query.
- `scraper.go`: record the three new data points.
- Regenerated `internal/metadata/*` and `documentation.md` via mdatagen.
- Scraper golden fixtures + unit-test mocks updated; chloggen entry added.

## Breaking changes
None. Three metrics added; nothing removed or renamed; all disabled by default, so default emitted telemetry is unchanged.

## Testing
`go test ./...` passes; gofumpt / gci / golangci-lint / chloggen validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
