### PR TITLE
[receiver/postgresql] Add conflicts and block I/O time metrics from pg_stat_database

### DIFF
--- a/.chloggen/postgresqlreceiver-42236-pg-stat-database-metrics.yaml
+++ b/.chloggen/postgresqlreceiver-42236-pg-stat-database-metrics.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/postgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `postgresql.conflicts`, `postgresql.blk_read_time`, and `postgresql.blk_write_time` metrics sourced from the `pg_stat_database` view.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42236]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  All three metrics are disabled by default. Enable them under
+  `metrics:` in the receiver configuration to collect them. The
+  `blk_read_time` and `blk_write_time` metrics report non-zero values only
+  when the PostgreSQL server has `track_io_timing` enabled.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -258,11 +258,14 @@ type databaseStats struct {
 	tupDeleted           int64
 	blksHit              int64
 	blksRead             int64
+	conflicts            int64
+	blkReadTime          float64
+	blkWriteTime         float64
 }
 
 func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []string) (map[databaseName]databaseStats, error) {
 	query := filterQueryByDatabases(
-		"SELECT datname, xact_commit, xact_rollback, deadlocks, temp_files, temp_bytes, tup_updated, tup_returned, tup_fetched, tup_inserted, tup_deleted, blks_hit, blks_read FROM pg_stat_database",
+		"SELECT datname, xact_commit, xact_rollback, deadlocks, temp_files, temp_bytes, tup_updated, tup_returned, tup_fetched, tup_inserted, tup_deleted, blks_hit, blks_read, conflicts, blk_read_time, blk_write_time FROM pg_stat_database",
 		databases,
 		false,
 	)
@@ -277,8 +280,9 @@ func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []str
 
 	for rows.Next() {
 		var datname string
-		var transactionCommitted, transactionRollback, deadlocks, tempIo, tempFiles, tupUpdated, tupReturned, tupFetched, tupInserted, tupDeleted, blksHit, blksRead int64
-		err = rows.Scan(&datname, &transactionCommitted, &transactionRollback, &deadlocks, &tempFiles, &tempIo, &tupUpdated, &tupReturned, &tupFetched, &tupInserted, &tupDeleted, &blksHit, &blksRead)
+		var transactionCommitted, transactionRollback, deadlocks, tempIo, tempFiles, tupUpdated, tupReturned, tupFetched, tupInserted, tupDeleted, blksHit, blksRead, conflicts int64
+		var blkReadTime, blkWriteTime float64
+		err = rows.Scan(&datname, &transactionCommitted, &transactionRollback, &deadlocks, &tempFiles, &tempIo, &tupUpdated, &tupReturned, &tupFetched, &tupInserted, &tupDeleted, &blksHit, &blksRead, &conflicts, &blkReadTime, &blkWriteTime)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
@@ -297,6 +301,9 @@ func (c *postgreSQLClient) getDatabaseStats(ctx context.Context, databases []str
 				tupDeleted:           tupDeleted,
 				blksHit:              blksHit,
 				blksRead:             blksRead,
+				conflicts:            conflicts,
+				blkReadTime:          blkReadTime,
+				blkWriteTime:         blkWriteTime,
 			}
 		}
 	}

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -253,6 +253,22 @@ metrics:
     enabled: true
 ```
 
+### postgresql.blk_read_time
+
+Time spent reading data file blocks by backends in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | true | Development |
+
+### postgresql.blk_write_time
+
+Time spent writing data file blocks by backends in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | true | Development |
+
 ### postgresql.blks_hit
 
 Number of times disk blocks were found already in the buffer cache.
@@ -268,6 +284,14 @@ Number of disk blocks read in this database.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | {blks_read} | Sum | Int | Cumulative | true | Development |
+
+### postgresql.conflicts
+
+Number of queries canceled due to conflicts with recovery in this database.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {conflict} | Sum | Int | Cumulative | true | Development |
 
 ### postgresql.database.locks
 

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config.go
@@ -213,6 +213,46 @@ func (ms *PostgresqlBgwriterMaxwrittenMetricConfig) Unmarshal(parser *confmap.Co
 	return nil
 }
 
+// PostgresqlBlkReadTimeMetricConfig provides config for the postgresql.blk_read_time metric.
+type PostgresqlBlkReadTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlBlkReadTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PostgresqlBlkWriteTimeMetricConfig provides config for the postgresql.blk_write_time metric.
+type PostgresqlBlkWriteTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlBlkWriteTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // PostgresqlBlksHitMetricConfig provides config for the postgresql.blks_hit metric.
 type PostgresqlBlksHitMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -308,6 +348,26 @@ type PostgresqlCommitsMetricConfig struct {
 }
 
 func (ms *PostgresqlCommitsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// PostgresqlConflictsMetricConfig provides config for the postgresql.conflicts metric.
+type PostgresqlConflictsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *PostgresqlConflictsMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1049,10 +1109,13 @@ type MetricsConfig struct {
 	PostgresqlBgwriterCheckpointCount  PostgresqlBgwriterCheckpointCountMetricConfig  `mapstructure:"postgresql.bgwriter.checkpoint.count"`
 	PostgresqlBgwriterDuration         PostgresqlBgwriterDurationMetricConfig         `mapstructure:"postgresql.bgwriter.duration"`
 	PostgresqlBgwriterMaxwritten       PostgresqlBgwriterMaxwrittenMetricConfig       `mapstructure:"postgresql.bgwriter.maxwritten"`
+	PostgresqlBlkReadTime              PostgresqlBlkReadTimeMetricConfig              `mapstructure:"postgresql.blk_read_time"`
+	PostgresqlBlkWriteTime             PostgresqlBlkWriteTimeMetricConfig             `mapstructure:"postgresql.blk_write_time"`
 	PostgresqlBlksHit                  PostgresqlBlksHitMetricConfig                  `mapstructure:"postgresql.blks_hit"`
 	PostgresqlBlksRead                 PostgresqlBlksReadMetricConfig                 `mapstructure:"postgresql.blks_read"`
 	PostgresqlBlocksRead               PostgresqlBlocksReadMetricConfig               `mapstructure:"postgresql.blocks_read"`
 	PostgresqlCommits                  PostgresqlCommitsMetricConfig                  `mapstructure:"postgresql.commits"`
+	PostgresqlConflicts                PostgresqlConflictsMetricConfig                `mapstructure:"postgresql.conflicts"`
 	PostgresqlConnectionMax            PostgresqlConnectionMaxMetricConfig            `mapstructure:"postgresql.connection.max"`
 	PostgresqlDatabaseCount            PostgresqlDatabaseCountMetricConfig            `mapstructure:"postgresql.database.count"`
 	PostgresqlDatabaseLocks            PostgresqlDatabaseLocksMetricConfig            `mapstructure:"postgresql.database.locks"`
@@ -1107,6 +1170,12 @@ func DefaultMetricsConfig() MetricsConfig {
 		PostgresqlBgwriterMaxwritten: PostgresqlBgwriterMaxwrittenMetricConfig{
 			Enabled: true,
 		},
+		PostgresqlBlkReadTime: PostgresqlBlkReadTimeMetricConfig{
+			Enabled: false,
+		},
+		PostgresqlBlkWriteTime: PostgresqlBlkWriteTimeMetricConfig{
+			Enabled: false,
+		},
 		PostgresqlBlksHit: PostgresqlBlksHitMetricConfig{
 			Enabled: false,
 		},
@@ -1120,6 +1189,9 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		PostgresqlCommits: PostgresqlCommitsMetricConfig{
 			Enabled: true,
+		},
+		PostgresqlConflicts: PostgresqlConflictsMetricConfig{
+			Enabled: false,
 		},
 		PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
 			Enabled: true,

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
@@ -50,6 +50,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					PostgresqlBgwriterMaxwritten: PostgresqlBgwriterMaxwrittenMetricConfig{
 						Enabled: true,
 					},
+					PostgresqlBlkReadTime: PostgresqlBlkReadTimeMetricConfig{
+						Enabled: true,
+					},
+					PostgresqlBlkWriteTime: PostgresqlBlkWriteTimeMetricConfig{
+						Enabled: true,
+					},
 					PostgresqlBlksHit: PostgresqlBlksHitMetricConfig{
 						Enabled: true,
 					},
@@ -62,6 +68,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						EnabledAttributes:   []PostgresqlBlocksReadMetricAttributeKey{PostgresqlBlocksReadMetricAttributeKeySource},
 					},
 					PostgresqlCommits: PostgresqlCommitsMetricConfig{
+						Enabled: true,
+					},
+					PostgresqlConflicts: PostgresqlConflictsMetricConfig{
 						Enabled: true,
 					},
 					PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
@@ -194,6 +203,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					PostgresqlBgwriterMaxwritten: PostgresqlBgwriterMaxwrittenMetricConfig{
 						Enabled: false,
 					},
+					PostgresqlBlkReadTime: PostgresqlBlkReadTimeMetricConfig{
+						Enabled: false,
+					},
+					PostgresqlBlkWriteTime: PostgresqlBlkWriteTimeMetricConfig{
+						Enabled: false,
+					},
 					PostgresqlBlksHit: PostgresqlBlksHitMetricConfig{
 						Enabled: false,
 					},
@@ -206,6 +221,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						EnabledAttributes:   []PostgresqlBlocksReadMetricAttributeKey{PostgresqlBlocksReadMetricAttributeKeySource},
 					},
 					PostgresqlCommits: PostgresqlCommitsMetricConfig{
+						Enabled: false,
+					},
+					PostgresqlConflicts: PostgresqlConflictsMetricConfig{
 						Enabled: false,
 					},
 					PostgresqlConnectionMax: PostgresqlConnectionMaxMetricConfig{
@@ -314,7 +332,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(PostgresqlBackendsMetricConfig{}, PostgresqlBgwriterBuffersAllocatedMetricConfig{}, PostgresqlBgwriterBuffersWritesMetricConfig{}, PostgresqlBgwriterCheckpointCountMetricConfig{}, PostgresqlBgwriterDurationMetricConfig{}, PostgresqlBgwriterMaxwrittenMetricConfig{}, PostgresqlBlksHitMetricConfig{}, PostgresqlBlksReadMetricConfig{}, PostgresqlBlocksReadMetricConfig{}, PostgresqlCommitsMetricConfig{}, PostgresqlConnectionMaxMetricConfig{}, PostgresqlDatabaseCountMetricConfig{}, PostgresqlDatabaseLocksMetricConfig{}, PostgresqlDbSizeMetricConfig{}, PostgresqlDeadlocksMetricConfig{}, PostgresqlFunctionCallsMetricConfig{}, PostgresqlIndexScansMetricConfig{}, PostgresqlIndexSizeMetricConfig{}, PostgresqlOperationsMetricConfig{}, PostgresqlReplicationDataDelayMetricConfig{}, PostgresqlRollbacksMetricConfig{}, PostgresqlRowsMetricConfig{}, PostgresqlSequentialScansMetricConfig{}, PostgresqlTableCountMetricConfig{}, PostgresqlTableSizeMetricConfig{}, PostgresqlTableVacuumCountMetricConfig{}, PostgresqlTempIoMetricConfig{}, PostgresqlTempFilesMetricConfig{}, PostgresqlTupDeletedMetricConfig{}, PostgresqlTupFetchedMetricConfig{}, PostgresqlTupInsertedMetricConfig{}, PostgresqlTupReturnedMetricConfig{}, PostgresqlTupUpdatedMetricConfig{}, PostgresqlWalAgeMetricConfig{}, PostgresqlWalDelayMetricConfig{}, PostgresqlWalLagMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(PostgresqlBackendsMetricConfig{}, PostgresqlBgwriterBuffersAllocatedMetricConfig{}, PostgresqlBgwriterBuffersWritesMetricConfig{}, PostgresqlBgwriterCheckpointCountMetricConfig{}, PostgresqlBgwriterDurationMetricConfig{}, PostgresqlBgwriterMaxwrittenMetricConfig{}, PostgresqlBlkReadTimeMetricConfig{}, PostgresqlBlkWriteTimeMetricConfig{}, PostgresqlBlksHitMetricConfig{}, PostgresqlBlksReadMetricConfig{}, PostgresqlBlocksReadMetricConfig{}, PostgresqlCommitsMetricConfig{}, PostgresqlConflictsMetricConfig{}, PostgresqlConnectionMaxMetricConfig{}, PostgresqlDatabaseCountMetricConfig{}, PostgresqlDatabaseLocksMetricConfig{}, PostgresqlDbSizeMetricConfig{}, PostgresqlDeadlocksMetricConfig{}, PostgresqlFunctionCallsMetricConfig{}, PostgresqlIndexScansMetricConfig{}, PostgresqlIndexSizeMetricConfig{}, PostgresqlOperationsMetricConfig{}, PostgresqlReplicationDataDelayMetricConfig{}, PostgresqlRollbacksMetricConfig{}, PostgresqlRowsMetricConfig{}, PostgresqlSequentialScansMetricConfig{}, PostgresqlTableCountMetricConfig{}, PostgresqlTableSizeMetricConfig{}, PostgresqlTableVacuumCountMetricConfig{}, PostgresqlTempIoMetricConfig{}, PostgresqlTempFilesMetricConfig{}, PostgresqlTupDeletedMetricConfig{}, PostgresqlTupFetchedMetricConfig{}, PostgresqlTupInsertedMetricConfig{}, PostgresqlTupReturnedMetricConfig{}, PostgresqlTupUpdatedMetricConfig{}, PostgresqlWalAgeMetricConfig{}, PostgresqlWalDelayMetricConfig{}, PostgresqlWalLagMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -287,6 +287,12 @@ var MetricsInfo = metricsInfo{
 	PostgresqlBgwriterMaxwritten: metricInfo{
 		Name: "postgresql.bgwriter.maxwritten",
 	},
+	PostgresqlBlkReadTime: metricInfo{
+		Name: "postgresql.blk_read_time",
+	},
+	PostgresqlBlkWriteTime: metricInfo{
+		Name: "postgresql.blk_write_time",
+	},
 	PostgresqlBlksHit: metricInfo{
 		Name: "postgresql.blks_hit",
 	},
@@ -298,6 +304,9 @@ var MetricsInfo = metricsInfo{
 	},
 	PostgresqlCommits: metricInfo{
 		Name: "postgresql.commits",
+	},
+	PostgresqlConflicts: metricInfo{
+		Name: "postgresql.conflicts",
 	},
 	PostgresqlConnectionMax: metricInfo{
 		Name: "postgresql.connection.max",
@@ -386,10 +395,13 @@ type metricsInfo struct {
 	PostgresqlBgwriterCheckpointCount  metricInfo
 	PostgresqlBgwriterDuration         metricInfo
 	PostgresqlBgwriterMaxwritten       metricInfo
+	PostgresqlBlkReadTime              metricInfo
+	PostgresqlBlkWriteTime             metricInfo
 	PostgresqlBlksHit                  metricInfo
 	PostgresqlBlksRead                 metricInfo
 	PostgresqlBlocksRead               metricInfo
 	PostgresqlCommits                  metricInfo
+	PostgresqlConflicts                metricInfo
 	PostgresqlConnectionMax            metricInfo
 	PostgresqlDatabaseCount            metricInfo
 	PostgresqlDatabaseLocks            metricInfo
@@ -851,6 +863,110 @@ func newMetricPostgresqlBgwriterMaxwritten(cfg PostgresqlBgwriterMaxwrittenMetri
 	return m
 }
 
+type metricPostgresqlBlkReadTime struct {
+	data     pmetric.Metric                    // data buffer for generated metric.
+	config   PostgresqlBlkReadTimeMetricConfig // metric config provided by user.
+	capacity int                               // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.blk_read_time metric with initial data.
+func (m *metricPostgresqlBlkReadTime) init() {
+	m.data.SetName("postgresql.blk_read_time")
+	m.data.SetDescription("Time spent reading data file blocks by backends in this database.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlBlkReadTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlBlkReadTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlBlkReadTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlBlkReadTime(cfg PostgresqlBlkReadTimeMetricConfig) metricPostgresqlBlkReadTime {
+	m := metricPostgresqlBlkReadTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlBlkWriteTime struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   PostgresqlBlkWriteTimeMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.blk_write_time metric with initial data.
+func (m *metricPostgresqlBlkWriteTime) init() {
+	m.data.SetName("postgresql.blk_write_time")
+	m.data.SetDescription("Time spent writing data file blocks by backends in this database.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlBlkWriteTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlBlkWriteTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlBlkWriteTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlBlkWriteTime(cfg PostgresqlBlkWriteTimeMetricConfig) metricPostgresqlBlkWriteTime {
+	m := metricPostgresqlBlkWriteTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricPostgresqlBlksHit struct {
 	data     pmetric.Metric                // data buffer for generated metric.
 	config   PostgresqlBlksHitMetricConfig // metric config provided by user.
@@ -1090,6 +1206,58 @@ func (m *metricPostgresqlCommits) emit(metrics pmetric.MetricSlice) {
 
 func newMetricPostgresqlCommits(cfg PostgresqlCommitsMetricConfig) metricPostgresqlCommits {
 	m := metricPostgresqlCommits{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricPostgresqlConflicts struct {
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   PostgresqlConflictsMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
+}
+
+// init fills postgresql.conflicts metric with initial data.
+func (m *metricPostgresqlConflicts) init() {
+	m.data.SetName("postgresql.conflicts")
+	m.data.SetDescription("Number of queries canceled due to conflicts with recovery in this database.")
+	m.data.SetUnit("{conflict}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricPostgresqlConflicts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricPostgresqlConflicts) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricPostgresqlConflicts) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricPostgresqlConflicts(cfg PostgresqlConflictsMetricConfig) metricPostgresqlConflicts {
+	m := metricPostgresqlConflicts{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -2737,10 +2905,13 @@ type MetricsBuilder struct {
 	metricPostgresqlBgwriterCheckpointCount  metricPostgresqlBgwriterCheckpointCount
 	metricPostgresqlBgwriterDuration         metricPostgresqlBgwriterDuration
 	metricPostgresqlBgwriterMaxwritten       metricPostgresqlBgwriterMaxwritten
+	metricPostgresqlBlkReadTime              metricPostgresqlBlkReadTime
+	metricPostgresqlBlkWriteTime             metricPostgresqlBlkWriteTime
 	metricPostgresqlBlksHit                  metricPostgresqlBlksHit
 	metricPostgresqlBlksRead                 metricPostgresqlBlksRead
 	metricPostgresqlBlocksRead               metricPostgresqlBlocksRead
 	metricPostgresqlCommits                  metricPostgresqlCommits
+	metricPostgresqlConflicts                metricPostgresqlConflicts
 	metricPostgresqlConnectionMax            metricPostgresqlConnectionMax
 	metricPostgresqlDatabaseCount            metricPostgresqlDatabaseCount
 	metricPostgresqlDatabaseLocks            metricPostgresqlDatabaseLocks
@@ -2798,10 +2969,13 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricPostgresqlBgwriterCheckpointCount:  newMetricPostgresqlBgwriterCheckpointCount(mbc.Metrics.PostgresqlBgwriterCheckpointCount),
 		metricPostgresqlBgwriterDuration:         newMetricPostgresqlBgwriterDuration(mbc.Metrics.PostgresqlBgwriterDuration),
 		metricPostgresqlBgwriterMaxwritten:       newMetricPostgresqlBgwriterMaxwritten(mbc.Metrics.PostgresqlBgwriterMaxwritten),
+		metricPostgresqlBlkReadTime:              newMetricPostgresqlBlkReadTime(mbc.Metrics.PostgresqlBlkReadTime),
+		metricPostgresqlBlkWriteTime:             newMetricPostgresqlBlkWriteTime(mbc.Metrics.PostgresqlBlkWriteTime),
 		metricPostgresqlBlksHit:                  newMetricPostgresqlBlksHit(mbc.Metrics.PostgresqlBlksHit),
 		metricPostgresqlBlksRead:                 newMetricPostgresqlBlksRead(mbc.Metrics.PostgresqlBlksRead),
 		metricPostgresqlBlocksRead:               newMetricPostgresqlBlocksRead(mbc.Metrics.PostgresqlBlocksRead),
 		metricPostgresqlCommits:                  newMetricPostgresqlCommits(mbc.Metrics.PostgresqlCommits),
+		metricPostgresqlConflicts:                newMetricPostgresqlConflicts(mbc.Metrics.PostgresqlConflicts),
 		metricPostgresqlConnectionMax:            newMetricPostgresqlConnectionMax(mbc.Metrics.PostgresqlConnectionMax),
 		metricPostgresqlDatabaseCount:            newMetricPostgresqlDatabaseCount(mbc.Metrics.PostgresqlDatabaseCount),
 		metricPostgresqlDatabaseLocks:            newMetricPostgresqlDatabaseLocks(mbc.Metrics.PostgresqlDatabaseLocks),
@@ -2936,10 +3110,13 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricPostgresqlBgwriterCheckpointCount.emit(ils.Metrics())
 	mb.metricPostgresqlBgwriterDuration.emit(ils.Metrics())
 	mb.metricPostgresqlBgwriterMaxwritten.emit(ils.Metrics())
+	mb.metricPostgresqlBlkReadTime.emit(ils.Metrics())
+	mb.metricPostgresqlBlkWriteTime.emit(ils.Metrics())
 	mb.metricPostgresqlBlksHit.emit(ils.Metrics())
 	mb.metricPostgresqlBlksRead.emit(ils.Metrics())
 	mb.metricPostgresqlBlocksRead.emit(ils.Metrics())
 	mb.metricPostgresqlCommits.emit(ils.Metrics())
+	mb.metricPostgresqlConflicts.emit(ils.Metrics())
 	mb.metricPostgresqlConnectionMax.emit(ils.Metrics())
 	mb.metricPostgresqlDatabaseCount.emit(ils.Metrics())
 	mb.metricPostgresqlDatabaseLocks.emit(ils.Metrics())
@@ -3027,6 +3204,16 @@ func (mb *MetricsBuilder) RecordPostgresqlBgwriterMaxwrittenDataPoint(ts pcommon
 	mb.metricPostgresqlBgwriterMaxwritten.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordPostgresqlBlkReadTimeDataPoint adds a data point to postgresql.blk_read_time metric.
+func (mb *MetricsBuilder) RecordPostgresqlBlkReadTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricPostgresqlBlkReadTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlBlkWriteTimeDataPoint adds a data point to postgresql.blk_write_time metric.
+func (mb *MetricsBuilder) RecordPostgresqlBlkWriteTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricPostgresqlBlkWriteTime.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordPostgresqlBlksHitDataPoint adds a data point to postgresql.blks_hit metric.
 func (mb *MetricsBuilder) RecordPostgresqlBlksHitDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricPostgresqlBlksHit.recordDataPoint(mb.startTime, ts, val)
@@ -3045,6 +3232,11 @@ func (mb *MetricsBuilder) RecordPostgresqlBlocksReadDataPoint(ts pcommon.Timesta
 // RecordPostgresqlCommitsDataPoint adds a data point to postgresql.commits metric.
 func (mb *MetricsBuilder) RecordPostgresqlCommitsDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricPostgresqlCommits.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordPostgresqlConflictsDataPoint adds a data point to postgresql.conflicts metric.
+func (mb *MetricsBuilder) RecordPostgresqlConflictsDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricPostgresqlConflicts.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordPostgresqlConnectionMaxDataPoint adds a data point to postgresql.connection.max metric.

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -121,6 +121,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordPostgresqlBgwriterMaxwrittenDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordPostgresqlBlkReadTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordPostgresqlBlkWriteTimeDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordPostgresqlBlksHitDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -136,6 +142,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordPostgresqlCommitsDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordPostgresqlConflictsDataPoint(ts, 1)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -471,6 +480,34 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
+				case "postgresql.blk_read_time":
+					assert.False(t, validatedMetrics["postgresql.blk_read_time"], "Found a duplicate in the metrics slice: postgresql.blk_read_time")
+					validatedMetrics["postgresql.blk_read_time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Time spent reading data file blocks by backends in this database.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "postgresql.blk_write_time":
+					assert.False(t, validatedMetrics["postgresql.blk_write_time"], "Found a duplicate in the metrics slice: postgresql.blk_write_time")
+					validatedMetrics["postgresql.blk_write_time"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Time spent writing data file blocks by backends in this database.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "postgresql.blks_hit":
 					assert.False(t, validatedMetrics["postgresql.blks_hit"], "Found a duplicate in the metrics slice: postgresql.blks_hit")
 					validatedMetrics["postgresql.blks_hit"] = true
@@ -550,6 +587,20 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 					assert.Equal(t, "The number of commits.", mi.Description())
 					assert.Equal(t, "1", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "postgresql.conflicts":
+					assert.False(t, validatedMetrics["postgresql.conflicts"], "Found a duplicate in the metrics slice: postgresql.conflicts")
+					validatedMetrics["postgresql.conflicts"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Number of queries canceled due to conflicts with recovery in this database.", mi.Description())
+					assert.Equal(t, "{conflict}", mi.Unit())
 					assert.True(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)

--- a/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
@@ -16,6 +16,10 @@ all_set:
       attributes: ["type"]
     postgresql.bgwriter.maxwritten:
       enabled: true
+    postgresql.blk_read_time:
+      enabled: true
+    postgresql.blk_write_time:
+      enabled: true
     postgresql.blks_hit:
       enabled: true
     postgresql.blks_read:
@@ -24,6 +28,8 @@ all_set:
       enabled: true
       attributes: ["source"]
     postgresql.commits:
+      enabled: true
+    postgresql.conflicts:
       enabled: true
     postgresql.connection.max:
       enabled: true
@@ -117,6 +123,10 @@ reaggregate_set:
       attributes: []
     postgresql.bgwriter.maxwritten:
       enabled: true
+    postgresql.blk_read_time:
+      enabled: true
+    postgresql.blk_write_time:
+      enabled: true
     postgresql.blks_hit:
       enabled: true
     postgresql.blks_read:
@@ -125,6 +135,8 @@ reaggregate_set:
       enabled: true
       attributes: []
     postgresql.commits:
+      enabled: true
+    postgresql.conflicts:
       enabled: true
     postgresql.connection.max:
       enabled: true
@@ -218,6 +230,10 @@ none_set:
       attributes: ["type"]
     postgresql.bgwriter.maxwritten:
       enabled: false
+    postgresql.blk_read_time:
+      enabled: false
+    postgresql.blk_write_time:
+      enabled: false
     postgresql.blks_hit:
       enabled: false
     postgresql.blks_read:
@@ -226,6 +242,8 @@ none_set:
       enabled: false
       attributes: ["source"]
     postgresql.commits:
+      enabled: false
+    postgresql.conflicts:
       enabled: false
     postgresql.connection.max:
       enabled: false

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -320,6 +320,24 @@ metrics:
       monotonic: true
       value_type: int
     unit: "1"
+  postgresql.blk_read_time:
+    enabled: false
+    description: Time spent reading data file blocks by backends in this database.
+    stability: development
+    unit: ms
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.blk_write_time:
+    enabled: false
+    description: Time spent writing data file blocks by backends in this database.
+    stability: development
+    unit: ms
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation_temporality: cumulative
   postgresql.blks_hit:
     enabled: false
     description: Number of times disk blocks were found already in the buffer cache.
@@ -353,6 +371,15 @@ metrics:
     description: The number of commits.
     stability: development
     unit: "1"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+  postgresql.conflicts:
+    enabled: false
+    description: Number of queries canceled due to conflicts with recovery in this database.
+    stability: development
+    unit: "{conflict}"
     sum:
       value_type: int
       monotonic: true

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -445,6 +445,9 @@ func (p *postgreSQLScraper) recordDatabase(now pcommon.Timestamp, db string, r *
 		p.mb.RecordPostgresqlTupDeletedDataPoint(now, stats.tupDeleted)
 		p.mb.RecordPostgresqlBlksHitDataPoint(now, stats.blksHit)
 		p.mb.RecordPostgresqlBlksReadDataPoint(now, stats.blksRead)
+		p.mb.RecordPostgresqlBlkReadTimeDataPoint(now, stats.blkReadTime)
+		p.mb.RecordPostgresqlBlkWriteTimeDataPoint(now, stats.blkWriteTime)
+		p.mb.RecordPostgresqlConflictsDataPoint(now, stats.conflicts)
 	}
 	rb := p.setupResourceBuilder(p.mb.NewResourceBuilder(), db, "", "", "")
 	p.mb.EmitForResource(metadata.WithResource(rb.Emit()))


### PR DESCRIPTION
## Description

The PostgreSQL receiver already scrapes the `pg_stat_database` view (in `getDatabaseStats`), but only extracts a subset of its columns. This PR surfaces three additional, operationally useful columns as new metrics. They are sourced from the **existing** query — the `SELECT` column list and row scan are extended; no extra round-trip to the database is added.

| Metric | Type | Unit | value_type | Source column |
| --- | --- | --- | --- | --- |
| `postgresql.conflicts` | sum (cumulative, monotonic) | `{conflict}` | int | `conflicts` |
| `postgresql.blk_read_time` | sum (cumulative, monotonic) | `ms` | double | `blk_read_time` |
| `postgresql.blk_write_time` | sum (cumulative, monotonic) | `ms` | double | `blk_write_time` |

These let operators compare time spent reading vs. writing data-file blocks (I/O contention) and track queries canceled due to conflicts with recovery — useful when correlating with deadlocks to spot workload stress.

## Why these shapes

- The other `pg_stat_database`-row metrics in this receiver use the flat `postgresql.<column>` form (`postgresql.deadlocks`, `postgresql.blks_hit`, `postgresql.blks_read`, `postgresql.temp_files`, `postgresql.commits`, …). The new metrics join that family and reuse the same naming convention.
- `blk_read_time` / `blk_write_time` are exposed by Postgres as double-precision milliseconds → `unit: ms`, `value_type: double`, matching the established `postgresql.bgwriter.duration` shape.
- `conflicts` is a per-database counter → int monotonic sum, `unit: {conflict}`, matching `postgresql.deadlocks`.

## Compatibility

Non-breaking. All three metrics are **disabled by default** (`enabled: false`), so the default emitted metric set is unchanged; no existing metric or attribute is removed or renamed. The two time metrics report non-zero values only when the server has `track_io_timing` enabled.

## Testing

- `go generate ./...` (mdatagen) regenerates `internal/metadata` and `documentation.md` cleanly and idempotently.
- `go build ./...`, `go vet ./...`, and `go test ./...` pass for the receiver and its generated metadata package.
- `gci` clean on edited files; changelog entry validated by chloggen.