### PR TITLE
feat(sqlserver): add 11 opt-in instance, database, and wait-stats metrics

### DIFF
--- a/.chloggen/sqlserver-instance-database-metrics.yaml
+++ b/.chloggen/sqlserver-instance-database-metrics.yaml
@@ -1,0 +1,39 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add 11 opt-in instance, per-database, and wait-stats metrics covering the PP/NRDOT Core Metrics audit for the `enable_instance_metrics`, `enable_database_metrics`, and `enable_wait_time_metrics` categories.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48643]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  New metrics (all disabled by default, `stability: development`, direct-DB connection mode only):
+    - `sqlserver.batch.compilation.utilization`
+    - `sqlserver.batch.page_split.utilization`
+    - `sqlserver.database.page_file.size` (attr: `page_file.state` ∈ {used, free, total})
+    - `sqlserver.database.transactions.active`
+    - `sqlserver.kill_connection.error.rate`
+    - `sqlserver.os.disk.size`
+    - `sqlserver.os.memory.usage` (attr: `memory.state` ∈ {available, total})
+    - `sqlserver.os.memory.utilization`
+    - `sqlserver.os.scheduler.runnable_tasks.count`
+    - `sqlserver.os.wait.tasks.count` (attr: `wait.category`, `wait.type`)
+    - `sqlserver.process.count` (attr: `process.status` ∈ {background, dormant, preconnect, runnable, running, sleeping, suspended})
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/docs/superpowers/specs/2026-06-22-sqlserver-instance-database-metrics-design.md
+++ b/docs/superpowers/specs/2026-06-22-sqlserver-instance-database-metrics-design.md
@@ -1,0 +1,266 @@
+# SQL Server: missing instance + database metrics
+
+**Date:** 2026-06-22
+**Branch (planned):** `sqlserver-instance-database-metrics` (cut from `sqlserver-core-metrics`)
+**Receivers touched:** `receiver/sqlserverreceiver` (upstream copy in `newrelic-forks/opentelemetry-collector-contrib`) and `receiver/nrsqlserverreceiver` (NR fork). Identical changes applied to both.
+
+## Background
+
+The Confluence audit "PP / NRDOT vs OTel sqlserverreceiver — Core Metrics Comparison & Validation" (page 5734137875) catalogs 78 PP/NRDOT metrics that are currently "Not Available" in the OTel `sqlserverreceiver`. This spec scopes the first slice of that work: the `enable_instance_metrics` and `enable_database_metrics` categories — 18 PP entries total. The remaining categories (failover_cluster, database_principals, database_role_membership, security, lock, thread_pool, tempdb, database_buffer) are explicitly out of scope and will be handled by follow-up branches.
+
+NRDOT reference implementation lives at:
+
+- `/Users/spathlavath/nrdot-collector-components` on branch `feature/otel-mssql-qpm-receiver`
+- Key files: `receiver/newrelicsqlserverreceiver/queries/instance_metrics.go`, `database_metrics.go`
+
+## Goals
+
+- Add 10 new OTel metrics that fully cover the 18 PP "Not Available" entries in the instance + database categories (process status and memory variants collapse into attributes per OTel conventions).
+- Default all new metrics to `enabled: false`, `stability: development`. Users opt in.
+- Follow OTel semantic naming conventions (https://opentelemetry.io/docs/specs/semconv/general/naming/).
+- Direct-connection collection mode only. PDH/perf-counter mode untouched.
+- Same set of changes mirrored to upstream `sqlserverreceiver` and `nrsqlserverreceiver`.
+
+## Non-goals
+
+- Azure SQL Database / Azure Managed Instance edition-specific query variants. Scrape fails gracefully (debug log, no metrics emitted) on editions where required DMVs are unavailable.
+- PDH/perf-counter collection mode.
+- Other PP categories from the Confluence doc (failover_cluster, principals, role_membership, security, lock, thread_pool, tempdb, database_buffer).
+- Manual end-to-end verification against a real SQL Server (will happen after merge, not part of this branch).
+
+## Metric catalog
+
+10 new metrics covering all 18 PP entries.
+
+### Instance (8 metrics → 15 PP entries)
+
+| # | OTel metric | Type / unit | Attributes | PP entries covered |
+|---|---|---|---|---|
+| 1 | `sqlserver.batch.compilation.utilization` | gauge / `1` | — | `compilations_per_batch` |
+| 2 | `sqlserver.batch.page_split.utilization` | gauge / `1` | — | `page_splits_per_batch` |
+| 3 | `sqlserver.os.memory.usage` | gauge / `By` | `memory.state ∈ {available, total}` | `memory_available`, `memory_total` |
+| 4 | `sqlserver.os.memory.utilization` | gauge / `1` | — | `memory_utilization_percent` |
+| 5 | `sqlserver.os.disk.size` | gauge / `By` | — | `disk_in_bytes` |
+| 6 | `sqlserver.os.scheduler.runnable_tasks.count` | gauge / `{tasks}` | — | `runnable_tasks` |
+| 7 | `sqlserver.process.count` | gauge / `{processes}` | `process.status ∈ {background, dormant, preconnect, runnable, running, sleeping, suspended}` | `background_processes_count`, `dormant_processes_count`, `preconnect_processes_count`, `runnable_processes_count`, `running_processes_count`, `sleeping_processes_count`, `suspended_processes_count` |
+| 8 | `sqlserver.kill_connection.error.rate` | sum (cumulative, monotonic) / `{errors}` | — | `stats.kill_connection_errors_per_sec` |
+
+### Database (2 metrics → 3 PP entries)
+
+Per-DB scoping uses the existing `db.namespace` metric attribute, matching how other per-DB metrics in this receiver (e.g. `sqlserver.database.file.size`) are scoped.
+
+| # | OTel metric | Type / unit | Attributes | PP entries covered |
+|---|---|---|---|---|
+| 9 | `sqlserver.database.page_file.size` | gauge / `By` | `db.namespace`, `page_file.state ∈ {used, free, total}` | `page_file_available_bytes`, `page_file_total_bytes` |
+| 10 | `sqlserver.database.transactions.active` | gauge / `{transactions}` | `db.namespace` | `transactions.active` |
+
+### New enum attributes (added to `metadata.yaml` under `attributes:`)
+
+```yaml
+memory.state:
+  description: The memory state.
+  type: string
+  enum: [available, total]
+page_file.state:
+  description: The state of the database page file space.
+  type: string
+  enum: [used, free, total]
+process.status:
+  description: The status of the SQL Server process/session.
+  type: string
+  enum: [background, dormant, preconnect, runnable, running, sleeping, suspended]
+```
+
+The 7 process statuses come from `sys.dm_exec_sessions.status`. NRDOT's "blocked" status is omitted because the existing `sqlserver.processes.blocked` metric already covers blocked-session counts.
+
+## Query strategy
+
+### Reuse: `sqlServerPerformanceCountersQuery`
+
+The existing perf-counter query already harvests the rows we need for the 4 counter-derived metrics. **No SQL change required.** Wiring:
+
+| New metric | How | Where |
+|---|---|---|
+| `sqlserver.batch.compilation.utilization` | Computed in Go: `sql_compilations_rate / batch_request_rate` | Post-processing in `recordDatabasePerfCounterMetrics` |
+| `sqlserver.batch.page_split.utilization` | Computed in Go: `page_splits_rate / batch_request_rate` | Same |
+| `sqlserver.kill_connection.error.rate` | New row handler for `SQL Errors / Kill Connection Errors` | New entry in `perfCounterRecorders` |
+| `sqlserver.database.transactions.active` | New row handler for `Databases / Active Transactions` | Merged into the existing `Databases` block in `perfCounterRecorders` (instance `*` → one datapoint per database, scoped by `db.namespace`) |
+
+### New (5 small DMV queries added to `queries.go`)
+
+Each becomes a new `const` plus a corresponding scraper method.
+
+```go
+// 1. OS memory: available + total bytes, plus utilization percent.
+const sqlServerOSMemoryQuery = `SELECT
+    MAX(sys_mem.total_physical_memory_kb * 1024.0)     AS total_physical_memory_bytes,
+    MAX(sys_mem.available_physical_memory_kb * 1024.0) AS available_physical_memory_bytes,
+    (MAX(proc_mem.physical_memory_in_use_kb) /
+     (MAX(sys_mem.total_physical_memory_kb) * 1.0)) * 100 AS memory_utilization_percent
+  FROM sys.dm_os_process_memory proc_mem,
+       sys.dm_os_sys_memory     sys_mem`
+
+// 2. Total disk size across volumes hosting database files.
+const sqlServerOSDiskQuery = `SELECT SUM(total_bytes) AS total_disk_space_bytes FROM (
+    SELECT DISTINCT dovs.volume_mount_point, dovs.total_bytes
+    FROM sys.master_files mf WITH (NOLOCK)
+    CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+  ) drives`
+
+// 3. Runnable tasks summed across OS schedulers.
+const sqlServerOSSchedulerRunnableTasksQuery = `SELECT
+    SUM(runnable_tasks_count) AS runnable_tasks_count
+  FROM sys.dm_os_schedulers
+  WHERE scheduler_id < 255 AND status = 'VISIBLE ONLINE'`
+
+// 4. Process counts pivoted by status. One row, 7 columns.
+const sqlServerProcessCountQuery = `SELECT
+    MAX(CASE WHEN status='background' THEN counts ELSE 0 END) AS background,
+    MAX(CASE WHEN status='dormant'    THEN counts ELSE 0 END) AS dormant,
+    MAX(CASE WHEN status='preconnect' THEN counts ELSE 0 END) AS preconnect,
+    MAX(CASE WHEN status='runnable'   THEN counts ELSE 0 END) AS runnable,
+    MAX(CASE WHEN status='running'    THEN counts ELSE 0 END) AS running,
+    MAX(CASE WHEN status='sleeping'   THEN counts ELSE 0 END) AS sleeping,
+    MAX(CASE WHEN status='suspended'  THEN counts ELSE 0 END) AS suspended
+  FROM (
+    SELECT status, COUNT(*) counts FROM (
+      SELECT COALESCE(req.status, sess.status) AS status
+      FROM sys.dm_exec_sessions sess
+      LEFT JOIN sys.dm_exec_requests req ON sess.session_id = req.session_id
+      WHERE sess.session_id > 50
+    ) statuses
+    GROUP BY status) sessions`
+
+// 5. Per-database page file: total + used bytes (free is derived as total - used).
+const sqlServerDatabasePageFileQuery = `SELECT
+    DB_NAME() AS db_name,
+    SUM(a.total_pages) * 8.0 * 1024 AS reserved_space_bytes,
+    (SUM(a.total_pages) - SUM(a.used_pages)) * 8.0 * 1024 AS reserved_space_not_used_bytes
+  FROM sys.partitions p WITH (NOLOCK)
+  INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id
+  LEFT JOIN sys.internal_tables it WITH (NOLOCK) ON p.object_id = it.object_id`
+```
+
+The page_file query runs once per user database (existing receiver pattern: iterate `sys.databases` list and execute the query in each DB's context). The exact iteration mechanism (USE statement vs. database-scoped exec) is determined during implementation to match the receiver's existing per-DB patterns.
+
+### Edition handling
+
+DMVs used: `sys.dm_os_process_memory`, `sys.dm_os_sys_memory`, `sys.master_files`, `sys.dm_os_volume_stats`, `sys.dm_os_schedulers`, `sys.dm_exec_sessions`, `sys.dm_exec_requests`, `sys.partitions`, `sys.allocation_units`. These work on standard SQL Server and Azure Managed Instance. On Azure SQL Database, queries error → existing scraper error handling logs a debug message and emits no metrics. No Azure-specific fallback queries in this branch.
+
+## Scraper changes
+
+### Extend `perfCounterRecorders` (`recorders.go`)
+
+- New top-level block for `SQL Errors / Kill Connection Errors` → calls `RecordSqlserverKillConnectionErrorRateDataPoint`.
+- One additional entry merged into the existing `Databases` block: `Active Transactions` → `RecordSqlserverDatabaseTransactionsActiveDataPoint`. Because the existing block uses `instance: "*"`, this becomes per-DB automatically.
+
+### Ratio post-processing (`scraper.go`)
+
+Inside `recordDatabasePerfCounterMetrics`, while iterating perf-counter rows, capture three values into locals:
+
+- `batch_request_rate` (object `SQL Statistics`, counter `Batch Requests/sec`)
+- `sql_compilation_rate` (`SQL Statistics`, `SQL Compilations/sec`)
+- `page_split_rate` (`Access Methods`, `Page Splits/sec`, instance `_Total`)
+
+After the row loop, if `batch_request_rate > 0`, emit:
+
+- `sqlserver.batch.compilation.utilization = sql_compilation_rate / batch_request_rate`
+- `sqlserver.batch.page_split.utilization = page_split_rate / batch_request_rate`
+
+When `batch_request_rate == 0` or any of the three counters are missing from the result set, skip emission (no datapoint, no error).
+
+### Five new scraper functions
+
+Each follows existing receiver convention (`recordDatabaseSizeMetrics`, `recordMemoryTargetMetrics`): take `ctx`, run a query via `s.client`, iterate rows, call recorders, return error aggregated via `scrapererror.ScrapeErrors`.
+
+| Function | Query | Metrics emitted |
+|---|---|---|
+| `recordOSMemoryMetrics` | `sqlServerOSMemoryQuery` | `sqlserver.os.memory.usage` (2 datapoints: `available`, `total`), `sqlserver.os.memory.utilization` |
+| `recordOSDiskMetrics` | `sqlServerOSDiskQuery` | `sqlserver.os.disk.size` |
+| `recordOSSchedulerMetrics` | `sqlServerOSSchedulerRunnableTasksQuery` | `sqlserver.os.scheduler.runnable_tasks.count` |
+| `recordProcessCountMetrics` | `sqlServerProcessCountQuery` | `sqlserver.process.count` (7 datapoints by `process.status`) |
+| `recordDatabasePageFileMetrics` | `sqlServerDatabasePageFileQuery` (per DB) | `sqlserver.database.page_file.size` (3 datapoints per DB: `used`, `free`, `total`) |
+
+Each is invoked from `ScrapeMetrics` after the existing block of `s.recordXxx(ctx)` calls, in the same error-aggregation pattern.
+
+### Enabled-gating short-circuit
+
+Defaults are `enabled: false`. `RecordXxxDataPoint` calls are no-ops when disabled, but a query roundtrip is still wasted unless guarded. Each new scraper function exits early when none of its target metrics are enabled — matching the existing `recordDatabaseSizeMetrics` pattern:
+
+```go
+mc := s.config.Metrics
+if !mc.SqlserverOsMemoryUsage.Enabled && !mc.SqlserverOsMemoryUtilization.Enabled {
+    return nil
+}
+```
+
+## File touch list (per receiver)
+
+Applied identically to both `receiver/sqlserverreceiver/` and `receiver/nrsqlserverreceiver/`:
+
+| File | Change |
+|---|---|
+| `metadata.yaml` | +3 attribute defs, +10 metric defs |
+| `queries.go` | +5 query consts (~80 lines) |
+| `recorders.go` | +1 block for `SQL Errors`, +1 line for `Active Transactions` inside the existing `Databases` block |
+| `scraper.go` | +5 record functions (~150 lines), +ratio post-processing (~20 lines), +5 calls in `ScrapeMetrics` |
+| `recorders_test.go` | +2 cases (kill_connection, active_transactions) |
+| `scraper_test.go` | +5 cases (one per new record func) plus ratio post-processing case |
+| `testdata/*.yaml` | regenerated expectations, plus new fixtures for new queries |
+| `internal/metadata/generated_*.go` | regenerated by `mdatagen` |
+| `documentation.md` | regenerated by `mdatagen` |
+
+Plus one shared changelog entry: `.chloggen/sqlserver-instance-database-metrics.yaml` (`change_type: enhancement`, components `receiver/sqlserver` and `receiver/nrsqlserver`).
+
+## Testing strategy
+
+### Unit tests
+
+`recorders_test.go` — extend the existing table-driven test:
+- Add row for `SQL Errors / Kill Connection Errors / Errors/sec` → assert kill_connection.error.rate recorded.
+- Add row for `Databases / Active Transactions` → assert database.transactions.active recorded with the right `db.namespace` metric attribute.
+
+`scraper_test.go` — one case per new record function, mocking `sqlquery.DBProviderFunc` with fixture rows:
+- `recordOSMemoryMetrics`: total=`16777216000`, available=`4194304000`, util=`75.0` → 3 datapoints.
+- `recordOSDiskMetrics`: total=`500000000000` → 1 datapoint.
+- `recordOSSchedulerMetrics`: tasks=`5` → 1 datapoint.
+- `recordProcessCountMetrics`: row with all 7 status columns → 7 datapoints with correct attribute values.
+- `recordDatabasePageFileMetrics`: 2 DBs × (total, used) → 6 datapoints (2 DBs × 3 states).
+- Ratio post-processing: counters → `compilation.utilization=0.1`, `page_split.utilization=0.05`. Zero-denominator case asserts no datapoint emitted.
+
+Fixtures placed in `testdata/` follow existing naming. Each new scraper function gets a paired result-set fixture and an `expected<Name>.yaml` (and `RemoveServerResourceAttributes.yaml` variant where the existing receiver maintains both — e.g. matching the `expectedDatabaseSize.yaml` + `expectedDatabaseSizeRemoveServerResourceAttributes.yaml` pattern).
+
+### Integration test
+
+Existing `integration_test.go` is not modified (defaults `enabled: false` → no expectation diff). Add one new `TestIntegration_NewInstanceDatabaseMetrics` that explicitly enables all 10 new metrics and asserts they appear, reusing the existing Docker-based fixture pattern with appropriate build tags.
+
+### Generated code verification
+
+After `mdatagen`:
+- `internal/metadata/generated_metrics.go` has 10 new `RecordSqlserver*DataPoint` methods.
+- `internal/metadata/generated_metrics_test.go` has 10 new test cases.
+- `internal/metadata/generated_config.go` has 10 new metric configs with `Enabled: false` defaults.
+- `documentation.md` lists 10 new entries.
+
+### Pre-commit gate
+
+```bash
+cd receiver/sqlserverreceiver  && go generate ./... && make fmt && make gci && make lint && go test ./...
+cd receiver/nrsqlserverreceiver && go generate ./... && make fmt && make gci && make lint && go test ./...
+```
+
+All must pass.
+
+## Rollout
+
+1. New branch `sqlserver-instance-database-metrics` cut from `sqlserver-core-metrics`.
+2. Implement, verify locally, push.
+3. Open PR against `newrelic-fork`'s default branch (matching prior NR-fork PRs).
+4. After merge, follow-up branches address the remaining 60 metrics across the other PP categories.
+
+## Implementation notes
+
+These are details to confirm while writing the code, not blockers on the design:
+
+- Exact per-DB iteration shape for `recordDatabasePageFileMetrics` — pick the pattern that minimizes deviation from `recordDatabaseSizeMetrics` / similar existing per-DB scrapers.
+- Whether `Page Splits/sec` is reachable from the existing perf-counter result set under instance `_Total` or `*`; verify during implementation against the existing query's WHERE filter (line ~244 in `queries.go` already gates `Page Splits/sec` to instance `_Total`, so it should be available).

--- a/receiver/nrsqlserverreceiver/documentation.md
+++ b/receiver/nrsqlserverreceiver/documentation.md
@@ -228,6 +228,26 @@ Number of SQL attentions (client cancellation interrupts) received per second.
 | ---- | ----------- | ---------- | --------- |
 | {attentions}/s | Gauge | Double | Development |
 
+### sqlserver.batch.compilation.utilization
+
+Number of SQL compilations per batch request.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
+### sqlserver.batch.page_split.utilization
+
+Number of page splits per batch request.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
 ### sqlserver.computer.uptime
 
 Computer uptime.
@@ -358,6 +378,23 @@ This metric is only available when the receiver is configured to directly connec
 | file_type | The type of file being monitored. | Any Str | Recommended | - |
 | direction | The direction of flow of bytes or operations. | Str: ``read``, ``write`` | Recommended | - |
 
+### sqlserver.database.page_file.size
+
+Reserved space allocated to the database, broken down by usage state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| page_file.state | The state of the database page file (reserved space) allocation. | Str: ``used``, ``free``, ``total`` | Recommended | - |
+
 ### sqlserver.database.security.role_membership.count
 
 Number of members in a database role.
@@ -397,6 +434,22 @@ TempDB version store size.
 | ---- | ----------- | ---------- | --------- |
 | KB | Gauge | Double | Development |
 
+### sqlserver.database.transactions.active
+
+Number of active transactions in the database.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
 ### sqlserver.deadlock.rate
 
 Total number of deadlocks.
@@ -412,6 +465,16 @@ Total number of index searches.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {searches}/s | Gauge | Double | Development |
+
+### sqlserver.kill_connection.error.rate
+
+Number of kill-connection errors per second.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {errors}/s | Gauge | Double | Development |
 
 ### sqlserver.latch.superlatch.count
 
@@ -577,6 +640,52 @@ Total memory in use.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | KB | Sum | Double | Cumulative | false | Development |
 
+### sqlserver.os.disk.size
+
+Total disk space across volumes hosting SQL Server database files.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+### sqlserver.os.memory.usage
+
+Amount of system physical memory observed by SQL Server.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| memory.state | The state of system memory observed by SQL Server. | Str: ``available``, ``total`` | Recommended | - |
+
+### sqlserver.os.memory.utilization
+
+Fraction of system physical memory in use by the SQL Server process.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
+### sqlserver.os.scheduler.runnable_tasks.count
+
+Total number of runnable tasks across online schedulers.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tasks} | Gauge | Int | Development |
+
 ### sqlserver.os.wait.duration
 
 Total wait time for this wait type
@@ -586,6 +695,23 @@ This metric is only available when the receiver is configured to directly connec
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| wait.category | Category of the reason for a wait. | Any Str | Recommended | - |
+| wait.type | Type of the wait, view [WaitTypes documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql?view=sql-server-ver16#WaitTypes) for more information. | Any Str | Recommended | - |
+
+### sqlserver.os.wait.tasks.count
+
+Cumulative number of tasks that have waited on this wait type since SQL Server startup.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {tasks} | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -637,6 +763,22 @@ Rate of plan executions, classified by plan guide result.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | sqlserver.plan.guidance.result | Whether a SQL plan execution successfully used a matching plan guide (guided) or did not (misguided). | Str: ``guided``, ``misguided`` | Recommended | - |
+
+### sqlserver.process.count
+
+Number of SQL Server processes (user sessions), broken down by status.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {processes} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| process.status | The status of the SQL Server process/session. | Str: ``background``, ``dormant``, ``preconnect``, ``runnable``, ``running``, ``sleeping``, ``suspended`` | Recommended | - |
 
 ### sqlserver.processes.blocked
 

--- a/receiver/nrsqlserverreceiver/documentation.md
+++ b/receiver/nrsqlserverreceiver/documentation.md
@@ -382,7 +382,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Reserved space allocated to the database, broken down by usage state.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
@@ -654,7 +654,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Amount of system physical memory observed by SQL Server.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
@@ -707,7 +707,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Cumulative number of tasks that have waited on this wait type since SQL Server startup.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -768,7 +768,7 @@ Rate of plan executions, classified by plan guide result.
 
 Number of SQL Server processes (user sessions), broken down by status.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+This metric is only available when the receiver is configured to directly connect to SQL Server. Use sqlserver.processes.blocked for blocked-session counts.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/nrsqlserverreceiver/factory.go
+++ b/receiver/nrsqlserverreceiver/factory.go
@@ -102,6 +102,26 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabaseSecurityRoleMembersQuery(cfg.InstanceName))
 	}
 
+	if cfg.Metrics.SqlserverOsMemoryUsage.Enabled || cfg.Metrics.SqlserverOsMemoryUtilization.Enabled {
+		queries = append(queries, getSQLServerOSMemoryQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverOsDiskSize.Enabled {
+		queries = append(queries, getSQLServerOSDiskQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverOsSchedulerRunnableTasksCount.Enabled {
+		queries = append(queries, getSQLServerOSSchedulerRunnableTasksQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverProcessCount.Enabled {
+		queries = append(queries, getSQLServerProcessCountQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverDatabasePageFileSize.Enabled {
+		queries = append(queries, getSQLServerDatabasePageFileQuery(cfg.InstanceName))
+	}
+
 	return queries
 }
 
@@ -280,12 +300,16 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	return metrics.SqlserverBatchRequestRate.Enabled ||
+	return metrics.SqlserverBatchCompilationUtilization.Enabled ||
+		metrics.SqlserverBatchPageSplitUtilization.Enabled ||
+		metrics.SqlserverBatchRequestRate.Enabled ||
 		metrics.SqlserverBatchSQLCompilationRate.Enabled ||
 		metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
 		metrics.SqlserverDatabaseBackupOrRestoreRate.Enabled ||
 		metrics.SqlserverDatabaseExecutionErrors.Enabled ||
 		metrics.SqlserverDatabaseFullScanRate.Enabled ||
+		metrics.SqlserverDatabaseTransactionsActive.Enabled ||
+		metrics.SqlserverKillConnectionErrorRate.Enabled ||
 		metrics.SqlserverDatabaseTempdbSpace.Enabled ||
 		metrics.SqlserverDatabaseTempdbVersionStoreSize.Enabled ||
 		metrics.SqlserverDeadlockRate.Enabled ||
@@ -328,5 +352,6 @@ func isWaitStatsQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	return metrics.SqlserverOsWaitDuration.Enabled
+	return metrics.SqlserverOsWaitDuration.Enabled ||
+		metrics.SqlserverOsWaitTasksCount.Enabled
 }

--- a/receiver/nrsqlserverreceiver/factory_test.go
+++ b/receiver/nrsqlserverreceiver/factory_test.go
@@ -262,7 +262,7 @@ func TestSetupQueries(t *testing.T) {
 
 	metricsMetadata, ok := metadata["metrics"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, metricsMetadata, 67, "Every time metrics are added or removed, the function `setupQueries` must "+
+	require.Len(t, metricsMetadata, 78, "Every time metrics are added or removed, the function `setupQueries` must "+
 		"be modified to properly account for the change. Please update `setupQueries` and then, "+
 		"and only then, update the expected metric count here.")
 }

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_config.go
@@ -30,6 +30,46 @@ func (ms *SqlserverAttentionRateMetricConfig) Unmarshal(parser *confmap.Conf) er
 	return nil
 }
 
+// SqlserverBatchCompilationUtilizationMetricConfig provides config for the sqlserver.batch.compilation.utilization metric.
+type SqlserverBatchCompilationUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverBatchCompilationUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverBatchPageSplitUtilizationMetricConfig provides config for the sqlserver.batch.page_split.utilization metric.
+type SqlserverBatchPageSplitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverBatchPageSplitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverBatchRequestRateMetricConfig provides config for the sqlserver.batch.request.rate metric.
 type SqlserverBatchRequestRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -440,6 +480,55 @@ func (ms *SqlserverDatabaseOperationsMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverDatabasePageFileSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.database.page_file.size metric.
+type SqlserverDatabasePageFileSizeMetricAttributeKey string
+
+const (
+	SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace   SqlserverDatabasePageFileSizeMetricAttributeKey = "db.namespace"
+	SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState SqlserverDatabasePageFileSizeMetricAttributeKey = "page_file.state"
+)
+
+// SqlserverDatabasePageFileSizeMetricConfig provides config for the sqlserver.database.page_file.size metric.
+type SqlserverDatabasePageFileSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePageFileSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePageFileSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePageFileSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState:
+		default:
+			return fmt.Errorf("metric sqlserver.database.page_file.size doesn't have an attribute %v, valid attributes: [db.namespace, page_file.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.security.role_membership.count metric.
 type SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey string
 
@@ -557,6 +646,54 @@ func (ms *SqlserverDatabaseTempdbVersionStoreSizeMetricConfig) Unmarshal(parser 
 	return nil
 }
 
+// SqlserverDatabaseTransactionsActiveMetricAttributeKey specifies the key of an attribute for the sqlserver.database.transactions.active metric.
+type SqlserverDatabaseTransactionsActiveMetricAttributeKey string
+
+const (
+	SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace SqlserverDatabaseTransactionsActiveMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabaseTransactionsActiveMetricConfig provides config for the sqlserver.database.transactions.active metric.
+type SqlserverDatabaseTransactionsActiveMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseTransactionsActiveMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseTransactionsActiveMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseTransactionsActiveMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.transactions.active doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDeadlockRateMetricConfig provides config for the sqlserver.deadlock.rate metric.
 type SqlserverDeadlockRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -584,6 +721,26 @@ type SqlserverIndexSearchRateMetricConfig struct {
 }
 
 func (ms *SqlserverIndexSearchRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverKillConnectionErrorRateMetricConfig provides config for the sqlserver.kill_connection.error.rate metric.
+type SqlserverKillConnectionErrorRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverKillConnectionErrorRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1049,6 +1206,114 @@ func (ms *SqlserverMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) erro
 	return nil
 }
 
+// SqlserverOsDiskSizeMetricConfig provides config for the sqlserver.os.disk.size metric.
+type SqlserverOsDiskSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsDiskSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverOsMemoryUsageMetricAttributeKey specifies the key of an attribute for the sqlserver.os.memory.usage metric.
+type SqlserverOsMemoryUsageMetricAttributeKey string
+
+const (
+	SqlserverOsMemoryUsageMetricAttributeKeyMemoryState SqlserverOsMemoryUsageMetricAttributeKey = "memory.state"
+)
+
+// SqlserverOsMemoryUsageMetricConfig provides config for the sqlserver.os.memory.usage metric.
+type SqlserverOsMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverOsMemoryUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverOsMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverOsMemoryUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverOsMemoryUsageMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric sqlserver.os.memory.usage doesn't have an attribute %v, valid attributes: [memory.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverOsMemoryUtilizationMetricConfig provides config for the sqlserver.os.memory.utilization metric.
+type SqlserverOsMemoryUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsMemoryUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverOsSchedulerRunnableTasksCountMetricConfig provides config for the sqlserver.os.scheduler.runnable_tasks.count metric.
+type SqlserverOsSchedulerRunnableTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsSchedulerRunnableTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverOsWaitDurationMetricAttributeKey specifies the key of an attribute for the sqlserver.os.wait.duration metric.
 type SqlserverOsWaitDurationMetricAttributeKey string
 
@@ -1086,6 +1351,55 @@ func (ms *SqlserverOsWaitDurationMetricConfig) Validate() error {
 		case SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType:
 		default:
 			return fmt.Errorf("metric sqlserver.os.wait.duration doesn't have an attribute %v, valid attributes: [wait.category, wait.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverOsWaitTasksCountMetricAttributeKey specifies the key of an attribute for the sqlserver.os.wait.tasks.count metric.
+type SqlserverOsWaitTasksCountMetricAttributeKey string
+
+const (
+	SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory SqlserverOsWaitTasksCountMetricAttributeKey = "wait.category"
+	SqlserverOsWaitTasksCountMetricAttributeKeyWaitType     SqlserverOsWaitTasksCountMetricAttributeKey = "wait.type"
+)
+
+// SqlserverOsWaitTasksCountMetricConfig provides config for the sqlserver.os.wait.tasks.count metric.
+type SqlserverOsWaitTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverOsWaitTasksCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverOsWaitTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverOsWaitTasksCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType:
+		default:
+			return fmt.Errorf("metric sqlserver.os.wait.tasks.count doesn't have an attribute %v, valid attributes: [wait.category, wait.type]", val)
 		}
 	}
 
@@ -1398,6 +1712,54 @@ func (ms *SqlserverPlanExecutionRateMetricConfig) Validate() error {
 		case SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult:
 		default:
 			return fmt.Errorf("metric sqlserver.plan.execution.rate doesn't have an attribute %v, valid attributes: [sqlserver.plan.guidance.result]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverProcessCountMetricAttributeKey specifies the key of an attribute for the sqlserver.process.count metric.
+type SqlserverProcessCountMetricAttributeKey string
+
+const (
+	SqlserverProcessCountMetricAttributeKeyProcessStatus SqlserverProcessCountMetricAttributeKey = "process.status"
+)
+
+// SqlserverProcessCountMetricConfig provides config for the sqlserver.process.count metric.
+type SqlserverProcessCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverProcessCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverProcessCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverProcessCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverProcessCountMetricAttributeKeyProcessStatus:
+		default:
+			return fmt.Errorf("metric sqlserver.process.count doesn't have an attribute %v, valid attributes: [process.status]", val)
 		}
 	}
 
@@ -1926,6 +2288,8 @@ func (ms *SqlserverUserConnectionCountMetricConfig) Unmarshal(parser *confmap.Co
 // MetricsConfig provides config for nrsqlserver metrics.
 type MetricsConfig struct {
 	SqlserverAttentionRate                       SqlserverAttentionRateMetricConfig                       `mapstructure:"sqlserver.attention.rate"`
+	SqlserverBatchCompilationUtilization         SqlserverBatchCompilationUtilizationMetricConfig         `mapstructure:"sqlserver.batch.compilation.utilization"`
+	SqlserverBatchPageSplitUtilization           SqlserverBatchPageSplitUtilizationMetricConfig           `mapstructure:"sqlserver.batch.page_split.utilization"`
 	SqlserverBatchRequestRate                    SqlserverBatchRequestRateMetricConfig                    `mapstructure:"sqlserver.batch.request.rate"`
 	SqlserverBatchSQLCompilationRate             SqlserverBatchSQLCompilationRateMetricConfig             `mapstructure:"sqlserver.batch.sql_compilation.rate"`
 	SqlserverBatchSQLRecompilationRate           SqlserverBatchSQLRecompilationRateMetricConfig           `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
@@ -1939,11 +2303,14 @@ type MetricsConfig struct {
 	SqlserverDatabaseIo                          SqlserverDatabaseIoMetricConfig                          `mapstructure:"sqlserver.database.io"`
 	SqlserverDatabaseLatency                     SqlserverDatabaseLatencyMetricConfig                     `mapstructure:"sqlserver.database.latency"`
 	SqlserverDatabaseOperations                  SqlserverDatabaseOperationsMetricConfig                  `mapstructure:"sqlserver.database.operations"`
+	SqlserverDatabasePageFileSize                SqlserverDatabasePageFileSizeMetricConfig                `mapstructure:"sqlserver.database.page_file.size"`
 	SqlserverDatabaseSecurityRoleMembershipCount SqlserverDatabaseSecurityRoleMembershipCountMetricConfig `mapstructure:"sqlserver.database.security.role_membership.count"`
 	SqlserverDatabaseTempdbSpace                 SqlserverDatabaseTempdbSpaceMetricConfig                 `mapstructure:"sqlserver.database.tempdb.space"`
 	SqlserverDatabaseTempdbVersionStoreSize      SqlserverDatabaseTempdbVersionStoreSizeMetricConfig      `mapstructure:"sqlserver.database.tempdb.version_store.size"`
+	SqlserverDatabaseTransactionsActive          SqlserverDatabaseTransactionsActiveMetricConfig          `mapstructure:"sqlserver.database.transactions.active"`
 	SqlserverDeadlockRate                        SqlserverDeadlockRateMetricConfig                        `mapstructure:"sqlserver.deadlock.rate"`
 	SqlserverIndexSearchRate                     SqlserverIndexSearchRateMetricConfig                     `mapstructure:"sqlserver.index.search.rate"`
+	SqlserverKillConnectionErrorRate             SqlserverKillConnectionErrorRateMetricConfig             `mapstructure:"sqlserver.kill_connection.error.rate"`
 	SqlserverLatchSuperlatchCount                SqlserverLatchSuperlatchCountMetricConfig                `mapstructure:"sqlserver.latch.superlatch.count"`
 	SqlserverLatchSuperlatchTransitionRate       SqlserverLatchSuperlatchTransitionRateMetricConfig       `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
 	SqlserverLatchWaitRate                       SqlserverLatchWaitRateMetricConfig                       `mapstructure:"sqlserver.latch.wait.rate"`
@@ -1961,7 +2328,12 @@ type MetricsConfig struct {
 	SqlserverMemoryPageCount                     SqlserverMemoryPageCountMetricConfig                     `mapstructure:"sqlserver.memory.page.count"`
 	SqlserverMemoryTarget                        SqlserverMemoryTargetMetricConfig                        `mapstructure:"sqlserver.memory.target"`
 	SqlserverMemoryUsage                         SqlserverMemoryUsageMetricConfig                         `mapstructure:"sqlserver.memory.usage"`
+	SqlserverOsDiskSize                          SqlserverOsDiskSizeMetricConfig                          `mapstructure:"sqlserver.os.disk.size"`
+	SqlserverOsMemoryUsage                       SqlserverOsMemoryUsageMetricConfig                       `mapstructure:"sqlserver.os.memory.usage"`
+	SqlserverOsMemoryUtilization                 SqlserverOsMemoryUtilizationMetricConfig                 `mapstructure:"sqlserver.os.memory.utilization"`
+	SqlserverOsSchedulerRunnableTasksCount       SqlserverOsSchedulerRunnableTasksCountMetricConfig       `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
 	SqlserverOsWaitDuration                      SqlserverOsWaitDurationMetricConfig                      `mapstructure:"sqlserver.os.wait.duration"`
+	SqlserverOsWaitTasksCount                    SqlserverOsWaitTasksCountMetricConfig                    `mapstructure:"sqlserver.os.wait.tasks.count"`
 	SqlserverPageBufferCacheFreeListStallsRate   SqlserverPageBufferCacheFreeListStallsRateMetricConfig   `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
 	SqlserverPageBufferCacheHitRatio             SqlserverPageBufferCacheHitRatioMetricConfig             `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
 	SqlserverPageCheckpointFlushRate             SqlserverPageCheckpointFlushRateMetricConfig             `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
@@ -1972,6 +2344,7 @@ type MetricsConfig struct {
 	SqlserverPageSplitRate                       SqlserverPageSplitRateMetricConfig                       `mapstructure:"sqlserver.page.split.rate"`
 	SqlserverParameterizationRate                SqlserverParameterizationRateMetricConfig                `mapstructure:"sqlserver.parameterization.rate"`
 	SqlserverPlanExecutionRate                   SqlserverPlanExecutionRateMetricConfig                   `mapstructure:"sqlserver.plan.execution.rate"`
+	SqlserverProcessCount                        SqlserverProcessCountMetricConfig                        `mapstructure:"sqlserver.process.count"`
 	SqlserverProcessesBlocked                    SqlserverProcessesBlockedMetricConfig                    `mapstructure:"sqlserver.processes.blocked"`
 	SqlserverRecompilationRatio                  SqlserverRecompilationRatioMetricConfig                  `mapstructure:"sqlserver.recompilation.ratio"`
 	SqlserverReplicaDataRate                     SqlserverReplicaDataRateMetricConfig                     `mapstructure:"sqlserver.replica.data.rate"`
@@ -1997,6 +2370,12 @@ type MetricsConfig struct {
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+			Enabled: false,
+		},
+		SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
 			Enabled: false,
 		},
 		SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
@@ -2048,6 +2427,11 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 		},
+		SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+		},
 		SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
@@ -2061,10 +2445,18 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 			Enabled: false,
 		},
+		SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+		},
 		SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 			Enabled: false,
 		},
 		SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 			Enabled: false,
 		},
 		SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -2126,10 +2518,29 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 			Enabled: false,
 		},
+		SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+			Enabled: false,
+		},
+		SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+		},
+		SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+			Enabled: false,
+		},
+		SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+			Enabled: false,
+		},
 		SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+		},
+		SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 		},
 		SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 			Enabled: false,
@@ -2168,6 +2579,11 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+		},
+		SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 		},
 		SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 			Enabled: false,

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_config_test.go
@@ -30,6 +30,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
 						Enabled: true,
 					},
+					SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+						Enabled: true,
+					},
+					SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
+						Enabled: true,
+					},
 					SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
 						Enabled: true,
 					},
@@ -79,6 +85,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 					},
+					SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -92,10 +103,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 						Enabled: true,
 					},
+					SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -157,10 +176,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 						Enabled: true,
 					},
+					SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+						Enabled: true,
+					},
+					SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+					},
+					SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+						Enabled: true,
+					},
+					SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+						Enabled: true,
+					},
 					SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+					},
+					SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 					},
 					SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 						Enabled: true,
@@ -199,6 +237,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+					},
+					SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 					},
 					SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 						Enabled: true,
@@ -289,6 +332,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
 						Enabled: false,
 					},
+					SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+						Enabled: false,
+					},
+					SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
+						Enabled: false,
+					},
 					SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
 						Enabled: false,
 					},
@@ -338,6 +387,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 					},
+					SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -351,10 +405,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 						Enabled: false,
 					},
+					SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -416,10 +478,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 						Enabled: false,
 					},
+					SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+						Enabled: false,
+					},
+					SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+					},
+					SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+						Enabled: false,
+					},
+					SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+						Enabled: false,
+					},
 					SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+					},
+					SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 					},
 					SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 						Enabled: false,
@@ -458,6 +539,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+					},
+					SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 					},
 					SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 						Enabled: false,
@@ -545,7 +631,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -611,6 +697,18 @@ func TestSqlserverDatabaseOperationsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverDatabasePageFileSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePageFileSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePageFileSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.page_file.size doesn't have an attribute invalid, valid attributes: [db.namespace, page_file.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePageFileSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverDatabaseSecurityRoleMembershipCountMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverDatabaseSecurityRoleMembershipCount
 	require.NoError(t, cfg.Validate())
@@ -631,6 +729,18 @@ func TestSqlserverDatabaseTempdbSpaceMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.tempdb.space doesn't have an attribute invalid, valid attributes: [tempdb.state]")
 
 	cfg = DefaultMetricsConfig().SqlserverDatabaseTempdbSpace
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseTransactionsActiveMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseTransactionsActive
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseTransactionsActiveMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.transactions.active doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseTransactionsActive
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -683,6 +793,18 @@ func TestSqlserverMemoryPageCountMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverOsMemoryUsageMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverOsMemoryUsage
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverOsMemoryUsageMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.memory.usage doesn't have an attribute invalid, valid attributes: [memory.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverOsMemoryUsage
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverOsWaitDurationMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverOsWaitDuration
 	require.NoError(t, cfg.Validate())
@@ -691,6 +813,18 @@ func TestSqlserverOsWaitDurationMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.wait.duration doesn't have an attribute invalid, valid attributes: [wait.category, wait.type]")
 
 	cfg = DefaultMetricsConfig().SqlserverOsWaitDuration
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverOsWaitTasksCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverOsWaitTasksCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverOsWaitTasksCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.wait.tasks.count doesn't have an attribute invalid, valid attributes: [wait.category, wait.type]")
+
+	cfg = DefaultMetricsConfig().SqlserverOsWaitTasksCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -739,6 +873,18 @@ func TestSqlserverPlanExecutionRateMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.plan.execution.rate doesn't have an attribute invalid, valid attributes: [sqlserver.plan.guidance.result]")
 
 	cfg = DefaultMetricsConfig().SqlserverPlanExecutionRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverProcessCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverProcessCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverProcessCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.process.count doesn't have an attribute invalid, valid attributes: [process.status]")
+
+	cfg = DefaultMetricsConfig().SqlserverProcessCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics.go
@@ -162,6 +162,32 @@ var MapAttributeMemoryPool = map[string]AttributeMemoryPool{
 	"max_workspace":     AttributeMemoryPoolMaxWorkspace,
 }
 
+// AttributeMemoryState specifies the value memory.state attribute.
+type AttributeMemoryState int
+
+const (
+	_ AttributeMemoryState = iota
+	AttributeMemoryStateAvailable
+	AttributeMemoryStateTotal
+)
+
+// String returns the string representation of the AttributeMemoryState.
+func (av AttributeMemoryState) String() string {
+	switch av {
+	case AttributeMemoryStateAvailable:
+		return "available"
+	case AttributeMemoryStateTotal:
+		return "total"
+	}
+	return ""
+}
+
+// MapAttributeMemoryState is a helper map of string to AttributeMemoryState attribute value.
+var MapAttributeMemoryState = map[string]AttributeMemoryState{
+	"available": AttributeMemoryStateAvailable,
+	"total":     AttributeMemoryStateTotal,
+}
+
 // AttributePageOperations specifies the value page.operations attribute.
 type AttributePageOperations int
 
@@ -232,6 +258,82 @@ var MapAttributePagePool = map[string]AttributePagePool{
 	"stolen":   AttributePagePoolStolen,
 	"reserved": AttributePagePoolReserved,
 	"free":     AttributePagePoolFree,
+}
+
+// AttributePageFileState specifies the value page_file.state attribute.
+type AttributePageFileState int
+
+const (
+	_ AttributePageFileState = iota
+	AttributePageFileStateUsed
+	AttributePageFileStateFree
+	AttributePageFileStateTotal
+)
+
+// String returns the string representation of the AttributePageFileState.
+func (av AttributePageFileState) String() string {
+	switch av {
+	case AttributePageFileStateUsed:
+		return "used"
+	case AttributePageFileStateFree:
+		return "free"
+	case AttributePageFileStateTotal:
+		return "total"
+	}
+	return ""
+}
+
+// MapAttributePageFileState is a helper map of string to AttributePageFileState attribute value.
+var MapAttributePageFileState = map[string]AttributePageFileState{
+	"used":  AttributePageFileStateUsed,
+	"free":  AttributePageFileStateFree,
+	"total": AttributePageFileStateTotal,
+}
+
+// AttributeProcessStatus specifies the value process.status attribute.
+type AttributeProcessStatus int
+
+const (
+	_ AttributeProcessStatus = iota
+	AttributeProcessStatusBackground
+	AttributeProcessStatusDormant
+	AttributeProcessStatusPreconnect
+	AttributeProcessStatusRunnable
+	AttributeProcessStatusRunning
+	AttributeProcessStatusSleeping
+	AttributeProcessStatusSuspended
+)
+
+// String returns the string representation of the AttributeProcessStatus.
+func (av AttributeProcessStatus) String() string {
+	switch av {
+	case AttributeProcessStatusBackground:
+		return "background"
+	case AttributeProcessStatusDormant:
+		return "dormant"
+	case AttributeProcessStatusPreconnect:
+		return "preconnect"
+	case AttributeProcessStatusRunnable:
+		return "runnable"
+	case AttributeProcessStatusRunning:
+		return "running"
+	case AttributeProcessStatusSleeping:
+		return "sleeping"
+	case AttributeProcessStatusSuspended:
+		return "suspended"
+	}
+	return ""
+}
+
+// MapAttributeProcessStatus is a helper map of string to AttributeProcessStatus attribute value.
+var MapAttributeProcessStatus = map[string]AttributeProcessStatus{
+	"background": AttributeProcessStatusBackground,
+	"dormant":    AttributeProcessStatusDormant,
+	"preconnect": AttributeProcessStatusPreconnect,
+	"runnable":   AttributeProcessStatusRunnable,
+	"running":    AttributeProcessStatusRunning,
+	"sleeping":   AttributeProcessStatusSleeping,
+	"suspended":  AttributeProcessStatusSuspended,
 }
 
 // AttributeReplicaDirection specifies the value replica.direction attribute.
@@ -432,6 +534,12 @@ var MetricsInfo = metricsInfo{
 	SqlserverAttentionRate: metricInfo{
 		Name: "sqlserver.attention.rate",
 	},
+	SqlserverBatchCompilationUtilization: metricInfo{
+		Name: "sqlserver.batch.compilation.utilization",
+	},
+	SqlserverBatchPageSplitUtilization: metricInfo{
+		Name: "sqlserver.batch.page_split.utilization",
+	},
 	SqlserverBatchRequestRate: metricInfo{
 		Name: "sqlserver.batch.request.rate",
 	},
@@ -476,6 +584,10 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.database.operations",
 		Attributes: []string{"physical_filename", "logical_filename", "file_type", "direction"},
 	},
+	SqlserverDatabasePageFileSize: metricInfo{
+		Name:       "sqlserver.database.page_file.size",
+		Attributes: []string{"db.namespace", "page_file.state"},
+	},
 	SqlserverDatabaseSecurityRoleMembershipCount: metricInfo{
 		Name:       "sqlserver.database.security.role_membership.count",
 		Attributes: []string{"db.namespace", "role"},
@@ -487,11 +599,18 @@ var MetricsInfo = metricsInfo{
 	SqlserverDatabaseTempdbVersionStoreSize: metricInfo{
 		Name: "sqlserver.database.tempdb.version_store.size",
 	},
+	SqlserverDatabaseTransactionsActive: metricInfo{
+		Name:       "sqlserver.database.transactions.active",
+		Attributes: []string{"db.namespace"},
+	},
 	SqlserverDeadlockRate: metricInfo{
 		Name: "sqlserver.deadlock.rate",
 	},
 	SqlserverIndexSearchRate: metricInfo{
 		Name: "sqlserver.index.search.rate",
+	},
+	SqlserverKillConnectionErrorRate: metricInfo{
+		Name: "sqlserver.kill_connection.error.rate",
 	},
 	SqlserverLatchSuperlatchCount: metricInfo{
 		Name: "sqlserver.latch.superlatch.count",
@@ -548,8 +667,25 @@ var MetricsInfo = metricsInfo{
 	SqlserverMemoryUsage: metricInfo{
 		Name: "sqlserver.memory.usage",
 	},
+	SqlserverOsDiskSize: metricInfo{
+		Name: "sqlserver.os.disk.size",
+	},
+	SqlserverOsMemoryUsage: metricInfo{
+		Name:       "sqlserver.os.memory.usage",
+		Attributes: []string{"memory.state"},
+	},
+	SqlserverOsMemoryUtilization: metricInfo{
+		Name: "sqlserver.os.memory.utilization",
+	},
+	SqlserverOsSchedulerRunnableTasksCount: metricInfo{
+		Name: "sqlserver.os.scheduler.runnable_tasks.count",
+	},
 	SqlserverOsWaitDuration: metricInfo{
 		Name:       "sqlserver.os.wait.duration",
+		Attributes: []string{"wait.category", "wait.type"},
+	},
+	SqlserverOsWaitTasksCount: metricInfo{
+		Name:       "sqlserver.os.wait.tasks.count",
 		Attributes: []string{"wait.category", "wait.type"},
 	},
 	SqlserverPageBufferCacheFreeListStallsRate: metricInfo{
@@ -585,6 +721,10 @@ var MetricsInfo = metricsInfo{
 	SqlserverPlanExecutionRate: metricInfo{
 		Name:       "sqlserver.plan.execution.rate",
 		Attributes: []string{"sqlserver.plan.guidance.result"},
+	},
+	SqlserverProcessCount: metricInfo{
+		Name:       "sqlserver.process.count",
+		Attributes: []string{"process.status"},
 	},
 	SqlserverProcessesBlocked: metricInfo{
 		Name: "sqlserver.processes.blocked",
@@ -654,6 +794,8 @@ var MetricsInfo = metricsInfo{
 
 type metricsInfo struct {
 	SqlserverAttentionRate                       metricInfo
+	SqlserverBatchCompilationUtilization         metricInfo
+	SqlserverBatchPageSplitUtilization           metricInfo
 	SqlserverBatchRequestRate                    metricInfo
 	SqlserverBatchSQLCompilationRate             metricInfo
 	SqlserverBatchSQLRecompilationRate           metricInfo
@@ -667,11 +809,14 @@ type metricsInfo struct {
 	SqlserverDatabaseIo                          metricInfo
 	SqlserverDatabaseLatency                     metricInfo
 	SqlserverDatabaseOperations                  metricInfo
+	SqlserverDatabasePageFileSize                metricInfo
 	SqlserverDatabaseSecurityRoleMembershipCount metricInfo
 	SqlserverDatabaseTempdbSpace                 metricInfo
 	SqlserverDatabaseTempdbVersionStoreSize      metricInfo
+	SqlserverDatabaseTransactionsActive          metricInfo
 	SqlserverDeadlockRate                        metricInfo
 	SqlserverIndexSearchRate                     metricInfo
+	SqlserverKillConnectionErrorRate             metricInfo
 	SqlserverLatchSuperlatchCount                metricInfo
 	SqlserverLatchSuperlatchTransitionRate       metricInfo
 	SqlserverLatchWaitRate                       metricInfo
@@ -689,7 +834,12 @@ type metricsInfo struct {
 	SqlserverMemoryPageCount                     metricInfo
 	SqlserverMemoryTarget                        metricInfo
 	SqlserverMemoryUsage                         metricInfo
+	SqlserverOsDiskSize                          metricInfo
+	SqlserverOsMemoryUsage                       metricInfo
+	SqlserverOsMemoryUtilization                 metricInfo
+	SqlserverOsSchedulerRunnableTasksCount       metricInfo
 	SqlserverOsWaitDuration                      metricInfo
+	SqlserverOsWaitTasksCount                    metricInfo
 	SqlserverPageBufferCacheFreeListStallsRate   metricInfo
 	SqlserverPageBufferCacheHitRatio             metricInfo
 	SqlserverPageCheckpointFlushRate             metricInfo
@@ -700,6 +850,7 @@ type metricsInfo struct {
 	SqlserverPageSplitRate                       metricInfo
 	SqlserverParameterizationRate                metricInfo
 	SqlserverPlanExecutionRate                   metricInfo
+	SqlserverProcessCount                        metricInfo
 	SqlserverProcessesBlocked                    metricInfo
 	SqlserverRecompilationRatio                  metricInfo
 	SqlserverReplicaDataRate                     metricInfo
@@ -769,6 +920,106 @@ func (m *metricSqlserverAttentionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverAttentionRate(cfg SqlserverAttentionRateMetricConfig) metricSqlserverAttentionRate {
 	m := metricSqlserverAttentionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverBatchCompilationUtilization struct {
+	data     pmetric.Metric                                   // data buffer for generated metric.
+	config   SqlserverBatchCompilationUtilizationMetricConfig // metric config provided by user.
+	capacity int                                              // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.batch.compilation.utilization metric with initial data.
+func (m *metricSqlserverBatchCompilationUtilization) init() {
+	m.data.SetName("sqlserver.batch.compilation.utilization")
+	m.data.SetDescription("Number of SQL compilations per batch request.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverBatchCompilationUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverBatchCompilationUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverBatchCompilationUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverBatchCompilationUtilization(cfg SqlserverBatchCompilationUtilizationMetricConfig) metricSqlserverBatchCompilationUtilization {
+	m := metricSqlserverBatchCompilationUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverBatchPageSplitUtilization struct {
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   SqlserverBatchPageSplitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.batch.page_split.utilization metric with initial data.
+func (m *metricSqlserverBatchPageSplitUtilization) init() {
+	m.data.SetName("sqlserver.batch.page_split.utilization")
+	m.data.SetDescription("Number of page splits per batch request.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverBatchPageSplitUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverBatchPageSplitUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverBatchPageSplitUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverBatchPageSplitUtilization(cfg SqlserverBatchPageSplitUtilizationMetricConfig) metricSqlserverBatchPageSplitUtilization {
+	m := metricSqlserverBatchPageSplitUtilization{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -1658,6 +1909,98 @@ func newMetricSqlserverDatabaseOperations(cfg SqlserverDatabaseOperationsMetricC
 	return m
 }
 
+type metricSqlserverDatabasePageFileSize struct {
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        SqlserverDatabasePageFileSizeMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.page_file.size metric with initial data.
+func (m *metricSqlserverDatabasePageFileSize) init() {
+	m.data.SetName("sqlserver.database.page_file.size")
+	m.data.SetDescription("Reserved space allocated to the database, broken down by usage state.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePageFileSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, pageFileStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState) {
+		dp.Attributes().PutStr("page_file.state", pageFileStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePageFileSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePageFileSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePageFileSize(cfg SqlserverDatabasePageFileSizeMetricConfig) metricSqlserverDatabasePageFileSize {
+	m := metricSqlserverDatabasePageFileSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDatabaseSecurityRoleMembershipCount struct {
 	data          pmetric.Metric                                           // data buffer for generated metric.
 	config        SqlserverDatabaseSecurityRoleMembershipCountMetricConfig // metric config provided by user.
@@ -1891,6 +2234,95 @@ func newMetricSqlserverDatabaseTempdbVersionStoreSize(cfg SqlserverDatabaseTempd
 	return m
 }
 
+type metricSqlserverDatabaseTransactionsActive struct {
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        SqlserverDatabaseTransactionsActiveMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                                         // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.transactions.active metric with initial data.
+func (m *metricSqlserverDatabaseTransactionsActive) init() {
+	m.data.SetName("sqlserver.database.transactions.active")
+	m.data.SetDescription("Number of active transactions in the database.")
+	m.data.SetUnit("{transactions}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseTransactionsActive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseTransactionsActive) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseTransactionsActive) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseTransactionsActive(cfg SqlserverDatabaseTransactionsActiveMetricConfig) metricSqlserverDatabaseTransactionsActive {
+	m := metricSqlserverDatabaseTransactionsActive{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDeadlockRate struct {
 	data     pmetric.Metric                    // data buffer for generated metric.
 	config   SqlserverDeadlockRateMetricConfig // metric config provided by user.
@@ -1983,6 +2415,56 @@ func (m *metricSqlserverIndexSearchRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverIndexSearchRate(cfg SqlserverIndexSearchRateMetricConfig) metricSqlserverIndexSearchRate {
 	m := metricSqlserverIndexSearchRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverKillConnectionErrorRate struct {
+	data     pmetric.Metric                               // data buffer for generated metric.
+	config   SqlserverKillConnectionErrorRateMetricConfig // metric config provided by user.
+	capacity int                                          // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.kill_connection.error.rate metric with initial data.
+func (m *metricSqlserverKillConnectionErrorRate) init() {
+	m.data.SetName("sqlserver.kill_connection.error.rate")
+	m.data.SetDescription("Number of kill-connection errors per second.")
+	m.data.SetUnit("{errors}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverKillConnectionErrorRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverKillConnectionErrorRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverKillConnectionErrorRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverKillConnectionErrorRate(cfg SqlserverKillConnectionErrorRateMetricConfig) metricSqlserverKillConnectionErrorRate {
+	m := metricSqlserverKillConnectionErrorRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3005,6 +3487,245 @@ func newMetricSqlserverMemoryUsage(cfg SqlserverMemoryUsageMetricConfig) metricS
 	return m
 }
 
+type metricSqlserverOsDiskSize struct {
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   SqlserverOsDiskSizeMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.disk.size metric with initial data.
+func (m *metricSqlserverOsDiskSize) init() {
+	m.data.SetName("sqlserver.os.disk.size")
+	m.data.SetDescription("Total disk space across volumes hosting SQL Server database files.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsDiskSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsDiskSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsDiskSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsDiskSize(cfg SqlserverOsDiskSizeMetricConfig) metricSqlserverOsDiskSize {
+	m := metricSqlserverOsDiskSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsMemoryUsage struct {
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        SqlserverOsMemoryUsageMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.os.memory.usage metric with initial data.
+func (m *metricSqlserverOsMemoryUsage) init() {
+	m.data.SetName("sqlserver.os.memory.usage")
+	m.data.SetDescription("Amount of system physical memory observed by SQL Server.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverOsMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsMemoryUsageMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory.state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsMemoryUsage) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsMemoryUsage) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsMemoryUsage(cfg SqlserverOsMemoryUsageMetricConfig) metricSqlserverOsMemoryUsage {
+	m := metricSqlserverOsMemoryUsage{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsMemoryUtilization struct {
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   SqlserverOsMemoryUtilizationMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.memory.utilization metric with initial data.
+func (m *metricSqlserverOsMemoryUtilization) init() {
+	m.data.SetName("sqlserver.os.memory.utilization")
+	m.data.SetDescription("Fraction of system physical memory in use by the SQL Server process.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsMemoryUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsMemoryUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsMemoryUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsMemoryUtilization(cfg SqlserverOsMemoryUtilizationMetricConfig) metricSqlserverOsMemoryUtilization {
+	m := metricSqlserverOsMemoryUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsSchedulerRunnableTasksCount struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverOsSchedulerRunnableTasksCountMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.scheduler.runnable_tasks.count metric with initial data.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) init() {
+	m.data.SetName("sqlserver.os.scheduler.runnable_tasks.count")
+	m.data.SetDescription("Total number of runnable tasks across online schedulers.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsSchedulerRunnableTasksCount(cfg SqlserverOsSchedulerRunnableTasksCountMetricConfig) metricSqlserverOsSchedulerRunnableTasksCount {
+	m := metricSqlserverOsSchedulerRunnableTasksCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverOsWaitDuration struct {
 	data          pmetric.Metric                      // data buffer for generated metric.
 	config        SqlserverOsWaitDurationMetricConfig // metric config provided by user.
@@ -3091,6 +3812,100 @@ func (m *metricSqlserverOsWaitDuration) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverOsWaitDuration(cfg SqlserverOsWaitDurationMetricConfig) metricSqlserverOsWaitDuration {
 	m := metricSqlserverOsWaitDuration{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsWaitTasksCount struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        SqlserverOsWaitTasksCountMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.os.wait.tasks.count metric with initial data.
+func (m *metricSqlserverOsWaitTasksCount) init() {
+	m.data.SetName("sqlserver.os.wait.tasks.count")
+	m.data.SetDescription("Cumulative number of tasks that have waited on this wait type since SQL Server startup.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverOsWaitTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, waitCategoryAttributeValue string, waitTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory) {
+		dp.Attributes().PutStr("wait.category", waitCategoryAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType) {
+		dp.Attributes().PutStr("wait.type", waitTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsWaitTasksCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsWaitTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsWaitTasksCount(cfg SqlserverOsWaitTasksCountMetricConfig) metricSqlserverOsWaitTasksCount {
+	m := metricSqlserverOsWaitTasksCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3747,6 +4562,95 @@ func (m *metricSqlserverPlanExecutionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverPlanExecutionRate(cfg SqlserverPlanExecutionRateMetricConfig) metricSqlserverPlanExecutionRate {
 	m := metricSqlserverPlanExecutionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverProcessCount struct {
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        SqlserverProcessCountMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.process.count metric with initial data.
+func (m *metricSqlserverProcessCount) init() {
+	m.data.SetName("sqlserver.process.count")
+	m.data.SetDescription("Number of SQL Server processes (user sessions), broken down by status.")
+	m.data.SetUnit("{processes}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverProcessCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, processStatusAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverProcessCountMetricAttributeKeyProcessStatus) {
+		dp.Attributes().PutStr("process.status", processStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverProcessCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverProcessCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverProcessCount(cfg SqlserverProcessCountMetricConfig) metricSqlserverProcessCount {
+	m := metricSqlserverProcessCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4933,6 +5837,8 @@ type MetricsBuilder struct {
 	resourceAttributeIncludeFilter                     map[string]filter.Filter
 	resourceAttributeExcludeFilter                     map[string]filter.Filter
 	metricSqlserverAttentionRate                       metricSqlserverAttentionRate
+	metricSqlserverBatchCompilationUtilization         metricSqlserverBatchCompilationUtilization
+	metricSqlserverBatchPageSplitUtilization           metricSqlserverBatchPageSplitUtilization
 	metricSqlserverBatchRequestRate                    metricSqlserverBatchRequestRate
 	metricSqlserverBatchSQLCompilationRate             metricSqlserverBatchSQLCompilationRate
 	metricSqlserverBatchSQLRecompilationRate           metricSqlserverBatchSQLRecompilationRate
@@ -4946,11 +5852,14 @@ type MetricsBuilder struct {
 	metricSqlserverDatabaseIo                          metricSqlserverDatabaseIo
 	metricSqlserverDatabaseLatency                     metricSqlserverDatabaseLatency
 	metricSqlserverDatabaseOperations                  metricSqlserverDatabaseOperations
+	metricSqlserverDatabasePageFileSize                metricSqlserverDatabasePageFileSize
 	metricSqlserverDatabaseSecurityRoleMembershipCount metricSqlserverDatabaseSecurityRoleMembershipCount
 	metricSqlserverDatabaseTempdbSpace                 metricSqlserverDatabaseTempdbSpace
 	metricSqlserverDatabaseTempdbVersionStoreSize      metricSqlserverDatabaseTempdbVersionStoreSize
+	metricSqlserverDatabaseTransactionsActive          metricSqlserverDatabaseTransactionsActive
 	metricSqlserverDeadlockRate                        metricSqlserverDeadlockRate
 	metricSqlserverIndexSearchRate                     metricSqlserverIndexSearchRate
+	metricSqlserverKillConnectionErrorRate             metricSqlserverKillConnectionErrorRate
 	metricSqlserverLatchSuperlatchCount                metricSqlserverLatchSuperlatchCount
 	metricSqlserverLatchSuperlatchTransitionRate       metricSqlserverLatchSuperlatchTransitionRate
 	metricSqlserverLatchWaitRate                       metricSqlserverLatchWaitRate
@@ -4968,7 +5877,12 @@ type MetricsBuilder struct {
 	metricSqlserverMemoryPageCount                     metricSqlserverMemoryPageCount
 	metricSqlserverMemoryTarget                        metricSqlserverMemoryTarget
 	metricSqlserverMemoryUsage                         metricSqlserverMemoryUsage
+	metricSqlserverOsDiskSize                          metricSqlserverOsDiskSize
+	metricSqlserverOsMemoryUsage                       metricSqlserverOsMemoryUsage
+	metricSqlserverOsMemoryUtilization                 metricSqlserverOsMemoryUtilization
+	metricSqlserverOsSchedulerRunnableTasksCount       metricSqlserverOsSchedulerRunnableTasksCount
 	metricSqlserverOsWaitDuration                      metricSqlserverOsWaitDuration
+	metricSqlserverOsWaitTasksCount                    metricSqlserverOsWaitTasksCount
 	metricSqlserverPageBufferCacheFreeListStallsRate   metricSqlserverPageBufferCacheFreeListStallsRate
 	metricSqlserverPageBufferCacheHitRatio             metricSqlserverPageBufferCacheHitRatio
 	metricSqlserverPageCheckpointFlushRate             metricSqlserverPageCheckpointFlushRate
@@ -4979,6 +5893,7 @@ type MetricsBuilder struct {
 	metricSqlserverPageSplitRate                       metricSqlserverPageSplitRate
 	metricSqlserverParameterizationRate                metricSqlserverParameterizationRate
 	metricSqlserverPlanExecutionRate                   metricSqlserverPlanExecutionRate
+	metricSqlserverProcessCount                        metricSqlserverProcessCount
 	metricSqlserverProcessesBlocked                    metricSqlserverProcessesBlocked
 	metricSqlserverRecompilationRatio                  metricSqlserverRecompilationRatio
 	metricSqlserverReplicaDataRate                     metricSqlserverReplicaDataRate
@@ -5020,11 +5935,13 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                                             mbc,
-		startTime:                                          pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                                      pmetric.NewMetrics(),
-		buildInfo:                                          settings.BuildInfo,
-		metricSqlserverAttentionRate:                       newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
+		config:                       mbc,
+		startTime:                    pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                pmetric.NewMetrics(),
+		buildInfo:                    settings.BuildInfo,
+		metricSqlserverAttentionRate: newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
+		metricSqlserverBatchCompilationUtilization:         newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
+		metricSqlserverBatchPageSplitUtilization:           newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
 		metricSqlserverBatchRequestRate:                    newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
 		metricSqlserverBatchSQLCompilationRate:             newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
 		metricSqlserverBatchSQLRecompilationRate:           newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
@@ -5038,11 +5955,14 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverDatabaseIo:                          newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
 		metricSqlserverDatabaseLatency:                     newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
 		metricSqlserverDatabaseOperations:                  newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
+		metricSqlserverDatabasePageFileSize:                newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
 		metricSqlserverDatabaseSecurityRoleMembershipCount: newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
 		metricSqlserverDatabaseTempdbSpace:                 newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
 		metricSqlserverDatabaseTempdbVersionStoreSize:      newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
+		metricSqlserverDatabaseTransactionsActive:          newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
 		metricSqlserverDeadlockRate:                        newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
 		metricSqlserverIndexSearchRate:                     newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
+		metricSqlserverKillConnectionErrorRate:             newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
 		metricSqlserverLatchSuperlatchCount:                newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
 		metricSqlserverLatchSuperlatchTransitionRate:       newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
 		metricSqlserverLatchWaitRate:                       newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
@@ -5060,7 +5980,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverMemoryPageCount:                     newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
 		metricSqlserverMemoryTarget:                        newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
 		metricSqlserverMemoryUsage:                         newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
+		metricSqlserverOsDiskSize:                          newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
+		metricSqlserverOsMemoryUsage:                       newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
+		metricSqlserverOsMemoryUtilization:                 newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
+		metricSqlserverOsSchedulerRunnableTasksCount:       newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
 		metricSqlserverOsWaitDuration:                      newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
+		metricSqlserverOsWaitTasksCount:                    newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
 		metricSqlserverPageBufferCacheFreeListStallsRate:   newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
 		metricSqlserverPageBufferCacheHitRatio:             newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
 		metricSqlserverPageCheckpointFlushRate:             newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
@@ -5071,6 +5996,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverPageSplitRate:                       newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
 		metricSqlserverParameterizationRate:                newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
 		metricSqlserverPlanExecutionRate:                   newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
+		metricSqlserverProcessCount:                        newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
 		metricSqlserverProcessesBlocked:                    newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
 		metricSqlserverRecompilationRatio:                  newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
 		metricSqlserverReplicaDataRate:                     newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
@@ -5218,6 +6144,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSqlserverAttentionRate.emit(ils.Metrics())
+	mb.metricSqlserverBatchCompilationUtilization.emit(ils.Metrics())
+	mb.metricSqlserverBatchPageSplitUtilization.emit(ils.Metrics())
 	mb.metricSqlserverBatchRequestRate.emit(ils.Metrics())
 	mb.metricSqlserverBatchSQLCompilationRate.emit(ils.Metrics())
 	mb.metricSqlserverBatchSQLRecompilationRate.emit(ils.Metrics())
@@ -5231,11 +6159,14 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverDatabaseIo.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseLatency.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseOperations.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePageFileSize.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbSpace.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseTransactionsActive.emit(ils.Metrics())
 	mb.metricSqlserverDeadlockRate.emit(ils.Metrics())
 	mb.metricSqlserverIndexSearchRate.emit(ils.Metrics())
+	mb.metricSqlserverKillConnectionErrorRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchCount.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchTransitionRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitRate.emit(ils.Metrics())
@@ -5253,7 +6184,12 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverMemoryPageCount.emit(ils.Metrics())
 	mb.metricSqlserverMemoryTarget.emit(ils.Metrics())
 	mb.metricSqlserverMemoryUsage.emit(ils.Metrics())
+	mb.metricSqlserverOsDiskSize.emit(ils.Metrics())
+	mb.metricSqlserverOsMemoryUsage.emit(ils.Metrics())
+	mb.metricSqlserverOsMemoryUtilization.emit(ils.Metrics())
+	mb.metricSqlserverOsSchedulerRunnableTasksCount.emit(ils.Metrics())
 	mb.metricSqlserverOsWaitDuration.emit(ils.Metrics())
+	mb.metricSqlserverOsWaitTasksCount.emit(ils.Metrics())
 	mb.metricSqlserverPageBufferCacheFreeListStallsRate.emit(ils.Metrics())
 	mb.metricSqlserverPageBufferCacheHitRatio.emit(ils.Metrics())
 	mb.metricSqlserverPageCheckpointFlushRate.emit(ils.Metrics())
@@ -5264,6 +6200,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverPageSplitRate.emit(ils.Metrics())
 	mb.metricSqlserverParameterizationRate.emit(ils.Metrics())
 	mb.metricSqlserverPlanExecutionRate.emit(ils.Metrics())
+	mb.metricSqlserverProcessCount.emit(ils.Metrics())
 	mb.metricSqlserverProcessesBlocked.emit(ils.Metrics())
 	mb.metricSqlserverRecompilationRatio.emit(ils.Metrics())
 	mb.metricSqlserverReplicaDataRate.emit(ils.Metrics())
@@ -5318,6 +6255,16 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 // RecordSqlserverAttentionRateDataPoint adds a data point to sqlserver.attention.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverAttentionRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverAttentionRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverBatchCompilationUtilizationDataPoint adds a data point to sqlserver.batch.compilation.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverBatchCompilationUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverBatchCompilationUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverBatchPageSplitUtilizationDataPoint adds a data point to sqlserver.batch.page_split.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverBatchPageSplitUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverBatchPageSplitUtilization.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverBatchRequestRateDataPoint adds a data point to sqlserver.batch.request.rate metric.
@@ -5415,6 +6362,16 @@ func (mb *MetricsBuilder) RecordSqlserverDatabaseOperationsDataPoint(ts pcommon.
 	return nil
 }
 
+// RecordSqlserverDatabasePageFileSizeDataPoint adds a data point to sqlserver.database.page_file.size metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePageFileSizeDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, pageFileStateAttributeValue AttributePageFileState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePageFileSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePageFileSize.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, pageFileStateAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint adds a data point to sqlserver.database.security.role_membership.count metric.
 func (mb *MetricsBuilder) RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -5435,6 +6392,16 @@ func (mb *MetricsBuilder) RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverDatabaseTransactionsActiveDataPoint adds a data point to sqlserver.database.transactions.active metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseTransactionsActiveDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseTransactionsActive, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseTransactionsActive.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
 // RecordSqlserverDeadlockRateDataPoint adds a data point to sqlserver.deadlock.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverDeadlockRate.recordDataPoint(mb.startTime, ts, val)
@@ -5443,6 +6410,11 @@ func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timest
 // RecordSqlserverIndexSearchRateDataPoint adds a data point to sqlserver.index.search.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverIndexSearchRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverIndexSearchRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverKillConnectionErrorRateDataPoint adds a data point to sqlserver.kill_connection.error.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverKillConnectionErrorRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverKillConnectionErrorRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverLatchSuperlatchCountDataPoint adds a data point to sqlserver.latch.superlatch.count metric.
@@ -5535,9 +6507,54 @@ func (mb *MetricsBuilder) RecordSqlserverMemoryUsageDataPoint(ts pcommon.Timesta
 	mb.metricSqlserverMemoryUsage.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverOsDiskSizeDataPoint adds a data point to sqlserver.os.disk.size metric.
+func (mb *MetricsBuilder) RecordSqlserverOsDiskSizeDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsDiskSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsDiskSize.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverOsMemoryUsageDataPoint adds a data point to sqlserver.os.memory.usage metric.
+func (mb *MetricsBuilder) RecordSqlserverOsMemoryUsageDataPoint(ts pcommon.Timestamp, inputVal string, memoryStateAttributeValue AttributeMemoryState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsMemoryUsage, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsMemoryUsage.recordDataPoint(mb.startTime, ts, val, memoryStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverOsMemoryUtilizationDataPoint adds a data point to sqlserver.os.memory.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverOsMemoryUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverOsMemoryUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverOsSchedulerRunnableTasksCountDataPoint adds a data point to sqlserver.os.scheduler.runnable_tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsSchedulerRunnableTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsSchedulerRunnableTasksCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
 // RecordSqlserverOsWaitDurationDataPoint adds a data point to sqlserver.os.wait.duration metric.
 func (mb *MetricsBuilder) RecordSqlserverOsWaitDurationDataPoint(ts pcommon.Timestamp, val float64, waitCategoryAttributeValue string, waitTypeAttributeValue string) {
 	mb.metricSqlserverOsWaitDuration.recordDataPoint(mb.startTime, ts, val, waitCategoryAttributeValue, waitTypeAttributeValue)
+}
+
+// RecordSqlserverOsWaitTasksCountDataPoint adds a data point to sqlserver.os.wait.tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverOsWaitTasksCountDataPoint(ts pcommon.Timestamp, inputVal string, waitCategoryAttributeValue string, waitTypeAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsWaitTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsWaitTasksCount.recordDataPoint(mb.startTime, ts, val, waitCategoryAttributeValue, waitTypeAttributeValue)
+	return nil
 }
 
 // RecordSqlserverPageBufferCacheFreeListStallsRateDataPoint adds a data point to sqlserver.page.buffer_cache.free_list.stalls.rate metric.
@@ -5588,6 +6605,16 @@ func (mb *MetricsBuilder) RecordSqlserverParameterizationRateDataPoint(ts pcommo
 // RecordSqlserverPlanExecutionRateDataPoint adds a data point to sqlserver.plan.execution.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverPlanExecutionRateDataPoint(ts pcommon.Timestamp, val float64, sqlserverPlanGuidanceResultAttributeValue AttributeSqlserverPlanGuidanceResult) {
 	mb.metricSqlserverPlanExecutionRate.recordDataPoint(mb.startTime, ts, val, sqlserverPlanGuidanceResultAttributeValue.String())
+}
+
+// RecordSqlserverProcessCountDataPoint adds a data point to sqlserver.process.count metric.
+func (mb *MetricsBuilder) RecordSqlserverProcessCountDataPoint(ts pcommon.Timestamp, inputVal string, processStatusAttributeValue AttributeProcessStatus) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverProcessCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverProcessCount.recordDataPoint(mb.startTime, ts, val, processStatusAttributeValue.String())
+	return nil
 }
 
 // RecordSqlserverProcessesBlockedDataPoint adds a data point to sqlserver.processes.blocked metric.

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -72,17 +72,22 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.database.io"] = mb.metricSqlserverDatabaseIo.config.AggregationStrategy
 			aggMap["sqlserver.database.latency"] = mb.metricSqlserverDatabaseLatency.config.AggregationStrategy
 			aggMap["sqlserver.database.operations"] = mb.metricSqlserverDatabaseOperations.config.AggregationStrategy
+			aggMap["sqlserver.database.page_file.size"] = mb.metricSqlserverDatabasePageFileSize.config.AggregationStrategy
 			aggMap["sqlserver.database.security.role_membership.count"] = mb.metricSqlserverDatabaseSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.database.tempdb.space"] = mb.metricSqlserverDatabaseTempdbSpace.config.AggregationStrategy
+			aggMap["sqlserver.database.transactions.active"] = mb.metricSqlserverDatabaseTransactionsActive.config.AggregationStrategy
 			aggMap["sqlserver.latch.superlatch.transition.rate"] = mb.metricSqlserverLatchSuperlatchTransitionRate.config.AggregationStrategy
 			aggMap["sqlserver.memory.area"] = mb.metricSqlserverMemoryArea.config.AggregationStrategy
 			aggMap["sqlserver.memory.cache.object.count"] = mb.metricSqlserverMemoryCacheObjectCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.page.count"] = mb.metricSqlserverMemoryPageCount.config.AggregationStrategy
+			aggMap["sqlserver.os.memory.usage"] = mb.metricSqlserverOsMemoryUsage.config.AggregationStrategy
 			aggMap["sqlserver.os.wait.duration"] = mb.metricSqlserverOsWaitDuration.config.AggregationStrategy
+			aggMap["sqlserver.os.wait.tasks.count"] = mb.metricSqlserverOsWaitTasksCount.config.AggregationStrategy
 			aggMap["sqlserver.page.life_expectancy"] = mb.metricSqlserverPageLifeExpectancy.config.AggregationStrategy
 			aggMap["sqlserver.page.operation.rate"] = mb.metricSqlserverPageOperationRate.config.AggregationStrategy
 			aggMap["sqlserver.parameterization.rate"] = mb.metricSqlserverParameterizationRate.config.AggregationStrategy
 			aggMap["sqlserver.plan.execution.rate"] = mb.metricSqlserverPlanExecutionRate.config.AggregationStrategy
+			aggMap["sqlserver.process.count"] = mb.metricSqlserverProcessCount.config.AggregationStrategy
 			aggMap["sqlserver.replica.data.rate"] = mb.metricSqlserverReplicaDataRate.config.AggregationStrategy
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.server.security.role_membership.count"] = mb.metricSqlserverServerSecurityRoleMembershipCount.config.AggregationStrategy
@@ -98,6 +103,12 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordSqlserverAttentionRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverBatchCompilationUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverBatchPageSplitUtilizationDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverBatchRequestRateDataPoint(ts, 1)
@@ -154,6 +165,12 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabasePageFileSizeDataPoint(ts, "1", "db.namespace-val", AttributePageFileStateUsed)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePageFileSizeDataPoint(ts, "3", "db.namespace-val-2", AttributePageFileStateFree)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "1", "db.namespace-val", "role-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
@@ -169,10 +186,19 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDeadlockRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverIndexSearchRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverKillConnectionErrorRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverLatchSuperlatchCountDataPoint(ts, 1)
@@ -238,9 +264,30 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverMemoryUsageDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverOsDiskSizeDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverOsMemoryUsageDataPoint(ts, "1", AttributeMemoryStateAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverOsMemoryUsageDataPoint(ts, "3", AttributeMemoryStateTotal)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverOsMemoryUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(ts, "1")
+
+			allMetricsCount++
 			mb.RecordSqlserverOsWaitDurationDataPoint(ts, 1, "wait.category-val", "wait.type-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverOsWaitDurationDataPoint(ts, 3, "wait.category-val-2", "wait.type-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverOsWaitTasksCountDataPoint(ts, "1", "wait.category-val", "wait.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverOsWaitTasksCountDataPoint(ts, "3", "wait.category-val-2", "wait.type-val-2")
 			}
 
 			allMetricsCount++
@@ -283,6 +330,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverPlanExecutionRateDataPoint(ts, 1, AttributeSqlserverPlanGuidanceResultGuided)
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverPlanExecutionRateDataPoint(ts, 3, AttributeSqlserverPlanGuidanceResultMisguided)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverProcessCountDataPoint(ts, "1", AttributeProcessStatusBackground)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverProcessCountDataPoint(ts, "3", AttributeProcessStatusDormant)
 			}
 
 			allMetricsCount++
@@ -375,17 +428,22 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverDatabaseIo.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseLatency.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseOperations.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePageFileSize.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTempdbSpace.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseTransactionsActive.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverLatchSuperlatchTransitionRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryArea.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryCacheObjectCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryPageCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverOsMemoryUsage.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverOsWaitDuration.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverOsWaitTasksCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPageLifeExpectancy.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPageOperationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverParameterizationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPlanExecutionRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverProcessCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverReplicaDataRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverServerSecurityRoleMembershipCount.aggDataPoints)
@@ -424,6 +482,30 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 					assert.Equal(t, "Number of SQL attentions (client cancellation interrupts) received per second.", mi.Description())
 					assert.Equal(t, "{attentions}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.batch.compilation.utilization":
+					assert.False(t, validatedMetrics["sqlserver.batch.compilation.utilization"], "Found a duplicate in the metrics slice: sqlserver.batch.compilation.utilization")
+					validatedMetrics["sqlserver.batch.compilation.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of SQL compilations per batch request.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.batch.page_split.utilization":
+					assert.False(t, validatedMetrics["sqlserver.batch.page_split.utilization"], "Found a duplicate in the metrics slice: sqlserver.batch.page_split.utilization")
+					validatedMetrics["sqlserver.batch.page_split.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of page splits per batch request.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
@@ -787,6 +869,51 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("direction")
 						assert.False(t, ok)
 					}
+				case "sqlserver.database.page_file.size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.page_file.size"], "Found a duplicate in the metrics slice: sqlserver.database.page_file.size")
+						validatedMetrics["sqlserver.database.page_file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Reserved space allocated to the database, broken down by usage state.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						pageFileStateAttrVal, ok := dp.Attributes().Get("page_file.state")
+						assert.True(t, ok)
+						assert.Equal(t, "used", pageFileStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.page_file.size"], "Found a duplicate in the metrics slice: sqlserver.database.page_file.size")
+						validatedMetrics["sqlserver.database.page_file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Reserved space allocated to the database, broken down by usage state.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.page_file.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("page_file.state")
+						assert.False(t, ok)
+					}
 				case "sqlserver.database.security.role_membership.count":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.database.security.role_membership.count"], "Found a duplicate in the metrics slice: sqlserver.database.security.role_membership.count")
@@ -888,6 +1015,46 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.database.transactions.active":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.transactions.active"], "Found a duplicate in the metrics slice: sqlserver.database.transactions.active")
+						validatedMetrics["sqlserver.database.transactions.active"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of active transactions in the database.", mi.Description())
+						assert.Equal(t, "{transactions}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.transactions.active"], "Found a duplicate in the metrics slice: sqlserver.database.transactions.active")
+						validatedMetrics["sqlserver.database.transactions.active"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of active transactions in the database.", mi.Description())
+						assert.Equal(t, "{transactions}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.transactions.active"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
 				case "sqlserver.deadlock.rate":
 					assert.False(t, validatedMetrics["sqlserver.deadlock.rate"], "Found a duplicate in the metrics slice: sqlserver.deadlock.rate")
 					validatedMetrics["sqlserver.deadlock.rate"] = true
@@ -907,6 +1074,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 					assert.Equal(t, "Total number of index searches.", mi.Description())
 					assert.Equal(t, "{searches}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.kill_connection.error.rate":
+					assert.False(t, validatedMetrics["sqlserver.kill_connection.error.rate"], "Found a duplicate in the metrics slice: sqlserver.kill_connection.error.rate")
+					validatedMetrics["sqlserver.kill_connection.error.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of kill-connection errors per second.", mi.Description())
+					assert.Equal(t, "{errors}/s", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
@@ -1236,6 +1415,82 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.os.disk.size":
+					assert.False(t, validatedMetrics["sqlserver.os.disk.size"], "Found a duplicate in the metrics slice: sqlserver.os.disk.size")
+					validatedMetrics["sqlserver.os.disk.size"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Total disk space across volumes hosting SQL Server database files.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.os.memory.usage":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.os.memory.usage"], "Found a duplicate in the metrics slice: sqlserver.os.memory.usage")
+						validatedMetrics["sqlserver.os.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of system physical memory observed by SQL Server.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory.state")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.os.memory.usage"], "Found a duplicate in the metrics slice: sqlserver.os.memory.usage")
+						validatedMetrics["sqlserver.os.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of system physical memory observed by SQL Server.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.os.memory.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("memory.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.os.memory.utilization":
+					assert.False(t, validatedMetrics["sqlserver.os.memory.utilization"], "Found a duplicate in the metrics slice: sqlserver.os.memory.utilization")
+					validatedMetrics["sqlserver.os.memory.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Fraction of system physical memory in use by the SQL Server process.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.os.scheduler.runnable_tasks.count":
+					assert.False(t, validatedMetrics["sqlserver.os.scheduler.runnable_tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.scheduler.runnable_tasks.count")
+					validatedMetrics["sqlserver.os.scheduler.runnable_tasks.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Total number of runnable tasks across online schedulers.", mi.Description())
+					assert.Equal(t, "{tasks}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "sqlserver.os.wait.duration":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.os.wait.duration"], "Found a duplicate in the metrics slice: sqlserver.os.wait.duration")
@@ -1279,6 +1534,55 @@ func TestMetricsBuilder(t *testing.T) {
 							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 						case "max":
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("wait.category")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("wait.type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.os.wait.tasks.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.os.wait.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.wait.tasks.count")
+						validatedMetrics["sqlserver.os.wait.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative number of tasks that have waited on this wait type since SQL Server startup.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						waitCategoryAttrVal, ok := dp.Attributes().Get("wait.category")
+						assert.True(t, ok)
+						assert.Equal(t, "wait.category-val", waitCategoryAttrVal.Str())
+						waitTypeAttrVal, ok := dp.Attributes().Get("wait.type")
+						assert.True(t, ok)
+						assert.Equal(t, "wait.type-val", waitTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.os.wait.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.wait.tasks.count")
+						validatedMetrics["sqlserver.os.wait.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative number of tasks that have waited on this wait type since SQL Server startup.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.os.wait.tasks.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
 						}
 						_, ok := dp.Attributes().Get("wait.category")
 						assert.False(t, ok)
@@ -1515,6 +1819,46 @@ func TestMetricsBuilder(t *testing.T) {
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
 						}
 						_, ok := dp.Attributes().Get("sqlserver.plan.guidance.result")
+						assert.False(t, ok)
+					}
+				case "sqlserver.process.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.process.count"], "Found a duplicate in the metrics slice: sqlserver.process.count")
+						validatedMetrics["sqlserver.process.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server processes (user sessions), broken down by status.", mi.Description())
+						assert.Equal(t, "{processes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						processStatusAttrVal, ok := dp.Attributes().Get("process.status")
+						assert.True(t, ok)
+						assert.Equal(t, "background", processStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.process.count"], "Found a duplicate in the metrics slice: sqlserver.process.count")
+						validatedMetrics["sqlserver.process.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server processes (user sessions), broken down by status.", mi.Description())
+						assert.Equal(t, "{processes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.process.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("process.status")
 						assert.False(t, ok)
 					}
 				case "sqlserver.processes.blocked":

--- a/receiver/nrsqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nrsqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,10 @@ all_set:
   metrics:
     sqlserver.attention.rate:
       enabled: true
+    sqlserver.batch.compilation.utilization:
+      enabled: true
+    sqlserver.batch.page_split.utilization:
+      enabled: true
     sqlserver.batch.request.rate:
       enabled: true
     sqlserver.batch.sql_compilation.rate:
@@ -34,6 +38,9 @@ all_set:
     sqlserver.database.operations:
       enabled: true
       attributes: ["physical_filename","logical_filename","file_type","direction"]
+    sqlserver.database.page_file.size:
+      enabled: true
+      attributes: ["db.namespace","page_file.state"]
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: ["db.namespace","role"]
@@ -42,9 +49,14 @@ all_set:
       attributes: ["tempdb.state"]
     sqlserver.database.tempdb.version_store.size:
       enabled: true
+    sqlserver.database.transactions.active:
+      enabled: true
+      attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: true
     sqlserver.index.search.rate:
+      enabled: true
+    sqlserver.kill_connection.error.rate:
       enabled: true
     sqlserver.latch.superlatch.count:
       enabled: true
@@ -84,7 +96,19 @@ all_set:
       enabled: true
     sqlserver.memory.usage:
       enabled: true
+    sqlserver.os.disk.size:
+      enabled: true
+    sqlserver.os.memory.usage:
+      enabled: true
+      attributes: ["memory.state"]
+    sqlserver.os.memory.utilization:
+      enabled: true
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: true
     sqlserver.os.wait.duration:
+      enabled: true
+      attributes: ["wait.category","wait.type"]
+    sqlserver.os.wait.tasks.count:
       enabled: true
       attributes: ["wait.category","wait.type"]
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -111,6 +135,9 @@ all_set:
     sqlserver.plan.execution.rate:
       enabled: true
       attributes: ["sqlserver.plan.guidance.result"]
+    sqlserver.process.count:
+      enabled: true
+      attributes: ["process.status"]
     sqlserver.processes.blocked:
       enabled: true
     sqlserver.recompilation.ratio:
@@ -183,6 +210,10 @@ reaggregate_set:
   metrics:
     sqlserver.attention.rate:
       enabled: true
+    sqlserver.batch.compilation.utilization:
+      enabled: true
+    sqlserver.batch.page_split.utilization:
+      enabled: true
     sqlserver.batch.request.rate:
       enabled: true
     sqlserver.batch.sql_compilation.rate:
@@ -214,6 +245,9 @@ reaggregate_set:
     sqlserver.database.operations:
       enabled: true
       attributes: []
+    sqlserver.database.page_file.size:
+      enabled: true
+      attributes: []
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: []
@@ -222,9 +256,14 @@ reaggregate_set:
       attributes: []
     sqlserver.database.tempdb.version_store.size:
       enabled: true
+    sqlserver.database.transactions.active:
+      enabled: true
+      attributes: []
     sqlserver.deadlock.rate:
       enabled: true
     sqlserver.index.search.rate:
+      enabled: true
+    sqlserver.kill_connection.error.rate:
       enabled: true
     sqlserver.latch.superlatch.count:
       enabled: true
@@ -264,7 +303,19 @@ reaggregate_set:
       enabled: true
     sqlserver.memory.usage:
       enabled: true
+    sqlserver.os.disk.size:
+      enabled: true
+    sqlserver.os.memory.usage:
+      enabled: true
+      attributes: []
+    sqlserver.os.memory.utilization:
+      enabled: true
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: true
     sqlserver.os.wait.duration:
+      enabled: true
+      attributes: []
+    sqlserver.os.wait.tasks.count:
       enabled: true
       attributes: []
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -289,6 +340,9 @@ reaggregate_set:
       enabled: true
       attributes: []
     sqlserver.plan.execution.rate:
+      enabled: true
+      attributes: []
+    sqlserver.process.count:
       enabled: true
       attributes: []
     sqlserver.processes.blocked:
@@ -363,6 +417,10 @@ none_set:
   metrics:
     sqlserver.attention.rate:
       enabled: false
+    sqlserver.batch.compilation.utilization:
+      enabled: false
+    sqlserver.batch.page_split.utilization:
+      enabled: false
     sqlserver.batch.request.rate:
       enabled: false
     sqlserver.batch.sql_compilation.rate:
@@ -394,6 +452,9 @@ none_set:
     sqlserver.database.operations:
       enabled: false
       attributes: ["physical_filename","logical_filename","file_type","direction"]
+    sqlserver.database.page_file.size:
+      enabled: false
+      attributes: ["db.namespace","page_file.state"]
     sqlserver.database.security.role_membership.count:
       enabled: false
       attributes: ["db.namespace","role"]
@@ -402,9 +463,14 @@ none_set:
       attributes: ["tempdb.state"]
     sqlserver.database.tempdb.version_store.size:
       enabled: false
+    sqlserver.database.transactions.active:
+      enabled: false
+      attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: false
     sqlserver.index.search.rate:
+      enabled: false
+    sqlserver.kill_connection.error.rate:
       enabled: false
     sqlserver.latch.superlatch.count:
       enabled: false
@@ -444,7 +510,19 @@ none_set:
       enabled: false
     sqlserver.memory.usage:
       enabled: false
+    sqlserver.os.disk.size:
+      enabled: false
+    sqlserver.os.memory.usage:
+      enabled: false
+      attributes: ["memory.state"]
+    sqlserver.os.memory.utilization:
+      enabled: false
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: false
     sqlserver.os.wait.duration:
+      enabled: false
+      attributes: ["wait.category","wait.type"]
+    sqlserver.os.wait.tasks.count:
       enabled: false
       attributes: ["wait.category","wait.type"]
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -471,6 +549,9 @@ none_set:
     sqlserver.plan.execution.rate:
       enabled: false
       attributes: ["sqlserver.plan.guidance.result"]
+    sqlserver.process.count:
+      enabled: false
+      attributes: ["process.status"]
     sqlserver.processes.blocked:
       enabled: false
     sqlserver.recompilation.ratio:

--- a/receiver/nrsqlserverreceiver/metadata.yaml
+++ b/receiver/nrsqlserverreceiver/metadata.yaml
@@ -121,6 +121,11 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [target, total, sql_cache, optimizer, connection, granted_workspace, max_workspace]
+  memory.state:
+    description: The state of system memory observed by SQL Server.
+    type: string
+    requirement_level: recommended
+    enum: [available, total]
   network.peer.address:
     description: IP address of the peer client.
     type: string
@@ -140,6 +145,11 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [cache, total, target, database, stolen, reserved, free]
+  page_file.state:
+    description: The state of the database page file (reserved space) allocation.
+    type: string
+    requirement_level: recommended
+    enum: [used, free, total]
   performance_counter.object_name:
     description: Category to which this counter belongs
     type: string
@@ -148,6 +158,11 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  process.status:
+    description: The status of the SQL Server process/session.
+    type: string
+    requirement_level: recommended
+    enum: [background, dormant, preconnect, runnable, running, sleeping, suspended]
   replica.direction:
     description: The direction of flow of bytes for replica.
     type: string
@@ -476,6 +491,24 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.batch.compilation.utilization:
+    enabled: false
+    description: Number of SQL compilations per batch request.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.batch.page_split.utilization:
+    enabled: false
+    description: Number of page splits per batch request.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.batch.request.rate:
     enabled: true
     description: Number of batch requests received by SQL Server.
@@ -592,6 +625,16 @@ metrics:
       input_type: string
     attributes: [physical_filename, logical_filename, file_type, direction]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.page_file.size:
+    enabled: false
+    description: Reserved space allocated to the database, broken down by usage state.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, page_file.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -620,6 +663,16 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.database.transactions.active:
+    enabled: false
+    description: Number of active transactions in the database.
+    stability: development
+    unit: "{transactions}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.deadlock.rate:
     enabled: false
     description: Total number of deadlocks.
@@ -636,6 +689,15 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.kill_connection.error.rate:
+    enabled: false
+    description: Number of kill-connection errors per second.
+    stability: development
+    unit: "{errors}/s"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.latch.superlatch.count:
     enabled: false
     description: Number of superlatches currently active.
@@ -789,6 +851,45 @@ metrics:
       monotonic: false
       value_type: double
     attributes: []
+  sqlserver.os.disk.size:
+    enabled: false
+    description: Total disk space across volumes hosting SQL Server database files.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.memory.usage:
+    enabled: false
+    description: Amount of system physical memory observed by SQL Server.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [memory.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+  sqlserver.os.memory.utilization:
+    enabled: false
+    description: Fraction of system physical memory in use by the SQL Server process.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.scheduler.runnable_tasks.count:
+    enabled: false
+    description: Total number of runnable tasks across online schedulers.
+    stability: development
+    unit: "{tasks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.os.wait.duration:
     enabled: false
     description: Total wait time for this wait type
@@ -800,6 +901,18 @@ metrics:
       value_type: double
     attributes: [wait.category, wait.type]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.wait.tasks.count:
+    enabled: false
+    description: Cumulative number of tasks that have waited on this wait type since SQL Server startup.
+    stability: development
+    unit: "{tasks}"
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    attributes: [wait.category, wait.type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
   sqlserver.page.buffer_cache.free_list.stalls.rate:
     enabled: false
     description: Number of free list stalls.
@@ -880,6 +993,16 @@ metrics:
     gauge:
       value_type: double
     attributes: [sqlserver.plan.guidance.result]
+  sqlserver.process.count:
+    enabled: false
+    description: Number of SQL Server processes (user sessions), broken down by status.
+    stability: development
+    unit: "{processes}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [process.status]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
   sqlserver.processes.blocked:
     enabled: false
     description: The number of processes that are currently blocked

--- a/receiver/nrsqlserverreceiver/metadata.yaml
+++ b/receiver/nrsqlserverreceiver/metadata.yaml
@@ -634,7 +634,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [db.namespace, page_file.state]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -870,7 +870,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [memory.state]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.os.memory.utilization:
     enabled: false
     description: Fraction of system physical memory in use by the SQL Server process.
@@ -912,7 +912,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [wait.category, wait.type]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.page.buffer_cache.free_list.stalls.rate:
     enabled: false
     description: Number of free list stalls.
@@ -1002,7 +1002,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [process.status]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Use sqlserver.processes.blocked for blocked-session counts.
   sqlserver.processes.blocked:
     enabled: false
     description: The number of processes that are currently blocked

--- a/receiver/nrsqlserverreceiver/queries.go
+++ b/receiver/nrsqlserverreceiver/queries.go
@@ -1423,8 +1423,8 @@ func getSQLServerProcessCountQuery(instanceName string) string {
 // UNION ALL because the sqlquery client only reads the first result set.
 const sqlServerDatabasePageFileQuery = `
 SET DEADLOCK_PRIORITY -10;
-IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
-	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size.';
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size (Azure SQL Database does not allow cross-database 3-part naming).';
 	RAISERROR (@ErrorMessage,11,1)
 	RETURN
 END

--- a/receiver/nrsqlserverreceiver/queries.go
+++ b/receiver/nrsqlserverreceiver/queries.go
@@ -1274,3 +1274,199 @@ func getSQLServerDatabaseSecurityRoleMembersQuery(instanceName string) string {
 	r := strings.NewReplacer("{filter_instance_name}", "")
 	return r.Replace(sqlServerDatabaseSecurityRoleMembersQuery)
 }
+
+// sqlServerOSMemoryQuery returns physical memory statistics observed by the
+// SQL Server process. Requires sys.dm_os_sys_memory + sys.dm_os_process_memory,
+// which are unavailable on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSMemoryQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.dm_os_sys_memory; sqlserver.os.memory.* metrics require Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_memory' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(MAX(sys_mem.total_physical_memory_kb) * 1024 AS BIGINT) AS [total_physical_memory_bytes],
+	CAST(MAX(sys_mem.available_physical_memory_kb) * 1024 AS BIGINT) AS [available_physical_memory_bytes],
+	CAST(
+		CAST(MAX(proc_mem.physical_memory_in_use_kb) AS float)
+		/ NULLIF(CAST(MAX(sys_mem.total_physical_memory_kb) AS float), 0) AS float
+	) AS [memory_utilization]
+FROM sys.dm_os_process_memory proc_mem,
+     sys.dm_os_sys_memory sys_mem
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerOSMemoryQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSMemoryQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSMemoryQuery)
+}
+
+// sqlServerOSDiskQuery returns total disk space across volumes hosting SQL
+// Server database files. Requires sys.master_files + sys.dm_os_volume_stats,
+// which are unavailable on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSDiskQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.master_files / sys.dm_os_volume_stats; sqlserver.os.disk.size requires Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_disk' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(SUM(total_bytes) AS BIGINT) AS [total_disk_space_bytes]
+FROM (
+	SELECT DISTINCT
+		dovs.volume_mount_point,
+		dovs.total_bytes
+	FROM sys.master_files mf WITH (NOLOCK)
+	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+) drives
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerOSDiskQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSDiskQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSDiskQuery)
+}
+
+// sqlServerOSSchedulerRunnableTasksQuery returns the total number of runnable
+// tasks across visible online schedulers (sys.dm_os_schedulers). Unavailable
+// on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSSchedulerRunnableTasksQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.dm_os_schedulers; sqlserver.os.scheduler.runnable_tasks.count requires Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_scheduler' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(SUM(runnable_tasks_count) AS BIGINT) AS [runnable_tasks_count]
+FROM sys.dm_os_schedulers WITH (NOLOCK)
+WHERE scheduler_id < 255
+	AND status = 'VISIBLE ONLINE'
+{filter_instance_name};
+`
+
+func getSQLServerOSSchedulerRunnableTasksQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
+}
+
+// sqlServerProcessCountQuery returns user-session counts pivoted by status.
+// Derived from sys.dm_exec_sessions (joined with sys.dm_exec_requests so that
+// an active request's status overrides the session-level status). Returns one
+// row with seven count columns.
+const sqlServerProcessCountQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.process.count.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_process_count' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(MAX(CASE WHEN status = 'background' THEN counts ELSE 0 END) AS BIGINT) AS [background],
+	CAST(MAX(CASE WHEN status = 'dormant'    THEN counts ELSE 0 END) AS BIGINT) AS [dormant],
+	CAST(MAX(CASE WHEN status = 'preconnect' THEN counts ELSE 0 END) AS BIGINT) AS [preconnect],
+	CAST(MAX(CASE WHEN status = 'runnable'   THEN counts ELSE 0 END) AS BIGINT) AS [runnable],
+	CAST(MAX(CASE WHEN status = 'running'    THEN counts ELSE 0 END) AS BIGINT) AS [running],
+	CAST(MAX(CASE WHEN status = 'sleeping'   THEN counts ELSE 0 END) AS BIGINT) AS [sleeping],
+	CAST(MAX(CASE WHEN status = 'suspended'  THEN counts ELSE 0 END) AS BIGINT) AS [suspended]
+FROM (
+	SELECT status, COUNT(*) AS counts FROM (
+		SELECT COALESCE(req.status, sess.status) AS status
+		FROM sys.dm_exec_sessions sess WITH (NOLOCK)
+		LEFT JOIN sys.dm_exec_requests req WITH (NOLOCK)
+			ON sess.session_id = req.session_id
+		WHERE sess.session_id > 50
+	) statuses
+	GROUP BY status
+) sessions
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerProcessCountQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerProcessCountQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerProcessCountQuery)
+}
+
+// sqlServerDatabasePageFileQuery returns total reserved space and used space
+// per online user database. The receiver derives the "free" datapoint as
+// (total - used). Executes per-database via dynamic SQL on the server side
+// so a single round-trip covers all online user databases.
+const sqlServerDatabasePageFileQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	N'USE ' + QUOTENAME(name) + N';' +
+	N'SELECT ''sqlserver_database_page_file'' AS [measurement],
+		REPLACE(@@SERVERNAME, ''\'', '':'') AS [sql_instance],
+		DB_NAME() AS [database_name],
+		CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes],
+		CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes]
+	FROM sys.partitions p WITH (NOLOCK)
+	INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id;' + CHAR(13)
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4  -- Exclude system databases (master, tempdb, model, msdb)
+	AND state = 0  -- Online only
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabasePageFileQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabasePageFileQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabasePageFileQuery)
+}

--- a/receiver/nrsqlserverreceiver/queries.go
+++ b/receiver/nrsqlserverreceiver/queries.go
@@ -1275,9 +1275,7 @@ func getSQLServerDatabaseSecurityRoleMembersQuery(instanceName string) string {
 	return r.Replace(sqlServerDatabaseSecurityRoleMembersQuery)
 }
 
-// sqlServerOSMemoryQuery returns physical memory statistics observed by the
-// SQL Server process. Requires sys.dm_os_sys_memory + sys.dm_os_process_memory,
-// which are unavailable on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSMemoryQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1312,9 +1310,7 @@ func getSQLServerOSMemoryQuery(instanceName string) string {
 	return r.Replace(sqlServerOSMemoryQuery)
 }
 
-// sqlServerOSDiskQuery returns total disk space across volumes hosting SQL
-// Server database files. Requires sys.master_files + sys.dm_os_volume_stats,
-// which are unavailable on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSDiskQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1349,9 +1345,7 @@ func getSQLServerOSDiskQuery(instanceName string) string {
 	return r.Replace(sqlServerOSDiskQuery)
 }
 
-// sqlServerOSSchedulerRunnableTasksQuery returns the total number of runnable
-// tasks across visible online schedulers (sys.dm_os_schedulers). Unavailable
-// on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSSchedulerRunnableTasksQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1381,10 +1375,7 @@ func getSQLServerOSSchedulerRunnableTasksQuery(instanceName string) string {
 	return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
 }
 
-// sqlServerProcessCountQuery returns user-session counts pivoted by status.
-// Derived from sys.dm_exec_sessions (joined with sys.dm_exec_requests so that
-// an active request's status overrides the session-level status). Returns one
-// row with seven count columns.
+// Active request status (when present) overrides the session-level status.
 const sqlServerProcessCountQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
@@ -1428,10 +1419,8 @@ func getSQLServerProcessCountQuery(instanceName string) string {
 	return r.Replace(sqlServerProcessCountQuery)
 }
 
-// sqlServerDatabasePageFileQuery returns total reserved space and used space
-// per online user database. The receiver derives the "free" datapoint as
-// (total - used). Executes per-database via dynamic SQL on the server side
-// so a single round-trip covers all online user databases.
+// One row per online user database; receiver derives "used" as total - free.
+// UNION ALL because the sqlquery client only reads the first result set.
 const sqlServerDatabasePageFileQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
@@ -1443,21 +1432,19 @@ END
 DECLARE @SQL nvarchar(max) = N'';
 
 SELECT @SQL = @SQL +
-	N'USE ' + QUOTENAME(name) + N';' +
-	N'SELECT ''sqlserver_database_page_file'' AS [measurement],
-		REPLACE(@@SERVERNAME, ''\'', '':'') AS [sql_instance],
-		DB_NAME() AS [database_name],
-		CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes],
-		CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes]
-	FROM sys.partitions p WITH (NOLOCK)
-	INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id;' + CHAR(13)
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	N'CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes], ' +
+	N'CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.partitions p WITH (NOLOCK) ' +
+	N'INNER JOIN ' + QUOTENAME(name) + N'.sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id'
 FROM sys.databases WITH (NOLOCK)
 WHERE database_id > 4  -- Exclude system databases (master, tempdb, model, msdb)
 	AND state = 0  -- Online only
 	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
 {filter_instance_name};
 
-EXEC sp_executesql @SQL;
+IF @SQL <> N'' EXEC sp_executesql @SQL;
 `
 
 func getSQLServerDatabasePageFileQuery(instanceName string) string {

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -519,10 +519,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		recompRatioRow       sqlquery.StringMap
 	)
 
-	// Track batch-request, SQL-compilation and page-split rates so the derived
-	// sqlserver.batch.compilation.utilization and sqlserver.batch.page_split.utilization
-	// metrics can be emitted after the row loop. compRate / compSeen are reused
-	// from the recompilation block above.
+	// Source rates for the batch.*.utilization derived metrics; emitted after the loop.
 	var (
 		batchRate, pageSplitRate float64
 		batchSeen, pageSplitSeen bool
@@ -542,9 +539,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverTableCountDataPoint(now, val.(int64), metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
 			}
 		case activeTransactions:
-			// The Active Transactions counter from SQLServer:Databases is per-database;
-			// the SQL query selects all instances and "_Total". Skip the rollup; emit one
-			// datapoint per database with the database name in db.namespace.
+			// Per-database counter; skip the "_Total" rollup row.
 			dbName := row[instanceKey]
 			if dbName == "" || dbName == "Total" {
 				break
@@ -622,9 +617,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val.(int64))
 			}
 		case errorsPerSec:
-			// The SQLServer:SQL Errors / Errors/sec counter has multiple instances
-			// (User Errors, Kill Connection Errors, etc.). Only the Kill Connection
-			// Errors instance maps to a new metric.
+			// Errors/sec has multiple instances (User Errors, Kill Connection Errors, ...);
+			// only Kill Connection Errors maps to a metric.
 			if row[instanceKey] != killConnectionErrorsInstance {
 				break
 			}
@@ -748,9 +742,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val.(float64))
 			}
 		case pageSplitsPerSec:
-			// The Access Methods / Page Splits/sec counter is only emitted by the
-			// perf-counter query for instance_name = '_Total'. Capture for the
-			// sqlserver.batch.page_split.utilization derived metric.
+			// Captured here only to derive batch.page_split.utilization after the loop.
 			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, pageSplitsPerSec)
@@ -1076,9 +1068,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
-	// Emit derived sqlserver.batch.compilation.utilization and
-	// sqlserver.batch.page_split.utilization metrics once the source counters
-	// have been observed and the denominator (batch request rate) is nonzero.
+	// Emit derived batch.*.utilization once batch request rate is nonzero.
 	if batchSeen && batchRate > 0 {
 		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), utilizationRow)
 		emitted := false
@@ -1358,7 +1348,7 @@ func (s *sqlServerScraperHelper) recordProcessCountMetrics(ctx context.Context) 
 
 func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Context) error {
 	const (
-		databaseName              = "database_name"
+		databaseName              = "db_name"
 		reservedSpaceBytes        = "reserved_space_bytes"
 		reservedSpaceNotUsedBytes = "reserved_space_not_used_bytes"
 	)

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -135,6 +135,16 @@ func (s *sqlServerScraperHelper) ScrapeMetrics(ctx context.Context) (pmetric.Met
 		err = s.recordSecurityRoleMembersMetrics(ctx)
 	case getSQLServerDatabaseSecurityRoleMembersQuery(s.config.InstanceName):
 		err = s.recordDatabaseSecurityRoleMembersMetrics(ctx)
+	case getSQLServerOSMemoryQuery(s.config.InstanceName):
+		err = s.recordOSMemoryMetrics(ctx)
+	case getSQLServerOSDiskQuery(s.config.InstanceName):
+		err = s.recordOSDiskMetrics(ctx)
+	case getSQLServerOSSchedulerRunnableTasksQuery(s.config.InstanceName):
+		err = s.recordOSSchedulerMetrics(ctx)
+	case getSQLServerProcessCountQuery(s.config.InstanceName):
+		err = s.recordProcessCountMetrics(ctx)
+	case getSQLServerDatabasePageFileQuery(s.config.InstanceName):
+		err = s.recordDatabasePageFileMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -420,9 +430,11 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) er
 
 func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Context) error {
 	const counterKey = "counter"
+	const instanceKey = "instance"
 	const valueKey = "value"
 	// Constants are the columns for metrics from query
 	const activeTempTables = "Active Temp Tables"
+	const activeTransactions = "Active Transactions"
 	const autoParamAttemptsPerSec = "Auto-Param Attempts/sec"
 	const backupRestoreThroughputPerSec = "Backup/Restore Throughput/sec"
 	const batchRequestRate = "Batch Requests/sec"
@@ -433,6 +445,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const diskReadIOThrottled = "Disk Read IO Throttled/sec"
 	const diskWriteIOSec = "Disk Write IO/sec"
 	const diskWriteIOThrottled = "Disk Write IO Throttled/sec"
+	const errorsPerSec = "Errors/sec"
+	const killConnectionErrorsInstance = "Kill Connection Errors"
 	const executionErrors = "Execution Errors"
 	const failedAutoParamsPerSec = "Failed Auto-Params/sec"
 	const forcedParameterizationsPerSec = "Forced Parameterizations/sec"
@@ -452,6 +466,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const memoryGrantsPending = "Memory Grants Pending"
 	const pageLifeExpectancy = "Page life expectancy"
 	const pageLookupsPerSec = "Page lookups/sec"
+	const pageSplitsPerSec = "Page Splits/sec"
 	const processesBlocked = "Processes blocked"
 	const safeAutoParamsPerSec = "Safe Auto-Params/sec"
 	const sqlAttentionRate = "SQL Attention rate"
@@ -504,6 +519,16 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		recompRatioRow       sqlquery.StringMap
 	)
 
+	// Track batch-request, SQL-compilation and page-split rates so the derived
+	// sqlserver.batch.compilation.utilization and sqlserver.batch.page_split.utilization
+	// metrics can be emitted after the row loop. compRate / compSeen are reused
+	// from the recompilation block above.
+	var (
+		batchRate, pageSplitRate float64
+		batchSeen, pageSplitSeen bool
+		utilizationRow           sqlquery.StringMap
+	)
+
 	for i, row := range rows {
 		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
 
@@ -516,6 +541,15 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 			} else {
 				s.mb.RecordSqlserverTableCountDataPoint(now, val.(int64), metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
 			}
+		case activeTransactions:
+			// The Active Transactions counter from SQLServer:Databases is per-database;
+			// the SQL query selects all instances and "_Total". Skip the rollup; emit one
+			// datapoint per database with the database name in db.namespace.
+			dbName := row[instanceKey]
+			if dbName == "" || dbName == "Total" {
+				break
+			}
+			errs = append(errs, s.mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(now, row[valueKey], dbName))
 		case backupRestoreThroughputPerSec:
 			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
@@ -531,6 +565,9 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverBatchRequestRateDataPoint(now, val.(float64))
+				batchRate = val.(float64)
+				batchSeen = true
+				utilizationRow = row
 			}
 		case bufferCacheHitRatio:
 			val, err := retrieveFloat(row, valueKey)
@@ -583,6 +620,20 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val.(int64))
+			}
+		case errorsPerSec:
+			// The SQLServer:SQL Errors / Errors/sec counter has multiple instances
+			// (User Errors, Kill Connection Errors, etc.). Only the Kill Connection
+			// Errors instance maps to a new metric.
+			if row[instanceKey] != killConnectionErrorsInstance {
+				break
+			}
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s/%s", i, err, errorsPerSec, killConnectionErrorsInstance)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverKillConnectionErrorRateDataPoint(now, val.(float64))
 			}
 		case freeListStalls:
 			val, err := retrieveInt(row, valueKey)
@@ -696,6 +747,21 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 			} else {
 				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val.(float64))
 			}
+		case pageSplitsPerSec:
+			// The Access Methods / Page Splits/sec counter is only emitted by the
+			// perf-counter query for instance_name = '_Total'. Capture for the
+			// sqlserver.batch.page_split.utilization derived metric.
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, pageSplitsPerSec)
+				errs = append(errs, err)
+			} else {
+				pageSplitRate = val.(float64)
+				pageSplitSeen = true
+				if utilizationRow == nil {
+					utilizationRow = row
+				}
+			}
 		case processesBlocked:
 			errs = append(errs, s.mb.RecordSqlserverProcessesBlockedDataPoint(now, row[valueKey]))
 		case sqlCompilationRate:
@@ -708,6 +774,9 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				compRate = val.(float64)
 				compSeen = true
 				recompRatioRow = row
+				if utilizationRow == nil {
+					utilizationRow = row
+				}
 			}
 		case sqlReCompilationsRate:
 			val, err := retrieveFloat(row, valueKey)
@@ -1007,6 +1076,25 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
+	// Emit derived sqlserver.batch.compilation.utilization and
+	// sqlserver.batch.page_split.utilization metrics once the source counters
+	// have been observed and the denominator (batch request rate) is nonzero.
+	if batchSeen && batchRate > 0 {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), utilizationRow)
+		emitted := false
+		if compSeen {
+			s.mb.RecordSqlserverBatchCompilationUtilizationDataPoint(now, compRate/batchRate)
+			emitted = true
+		}
+		if pageSplitSeen {
+			s.mb.RecordSqlserverBatchPageSplitUtilizationDataPoint(now, pageSplitRate/batchRate)
+			emitted = true
+		}
+		if emitted {
+			s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -1055,9 +1143,10 @@ func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context
 func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) error {
 	// Constants are the columns for metrics from query
 	const (
-		waitCategory = "wait_category"
-		waitTimeMs   = "wait_time_ms"
-		waitType     = "wait_type"
+		waitCategory      = "wait_category"
+		waitTimeMs        = "wait_time_ms"
+		waitType          = "wait_type"
+		waitingTasksCount = "waiting_tasks_count"
 	)
 
 	rows, err := s.client.QueryRows(ctx)
@@ -1082,6 +1171,8 @@ func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) 
 			// The value is divided here because it's stored in SQL Server in ms, need to convert to s
 			s.mb.RecordSqlserverOsWaitDurationDataPoint(now, val.(float64)/1e3, row[waitCategory], row[waitType])
 		}
+
+		errs = append(errs, s.mb.RecordSqlserverOsWaitTasksCountDataPoint(now, row[waitingTasksCount], row[waitCategory], row[waitType]))
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
@@ -1138,6 +1229,172 @@ func (s *sqlServerScraperHelper) recordDatabaseSizeMetrics(ctx context.Context) 
 
 		if err := s.mb.RecordSqlserverDatabaseFileSizeDataPoint(now, row[sizeBytes], row[fileType], row[databaseName]); err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse database file size for row %d: %w", i, err))
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSMemoryMetrics(ctx context.Context) error {
+	const (
+		totalBytes     = "total_physical_memory_bytes"
+		availableBytes = "available_physical_memory_bytes"
+		utilization    = "memory_utilization"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverOsMemoryUsageDataPoint(now, row[totalBytes], metadata.AttributeMemoryStateTotal),
+			s.mb.RecordSqlserverOsMemoryUsageDataPoint(now, row[availableBytes], metadata.AttributeMemoryStateAvailable),
+		)
+
+		if utilStr := row[utilization]; utilStr != "" {
+			val, parseErr := retrieveFloat(row, utilization)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s: %w", utilization, parseErr))
+			} else {
+				s.mb.RecordSqlserverOsMemoryUtilizationDataPoint(now, val.(float64))
+			}
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSDiskMetrics(ctx context.Context) error {
+	const totalDiskBytes = "total_disk_space_bytes"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		errs = append(errs, s.mb.RecordSqlserverOsDiskSizeDataPoint(now, row[totalDiskBytes]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSSchedulerMetrics(ctx context.Context) error {
+	const runnableTasksCount = "runnable_tasks_count"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		errs = append(errs, s.mb.RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(now, row[runnableTasksCount]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordProcessCountMetrics(ctx context.Context) error {
+	statusColumns := []struct {
+		name  string
+		value metadata.AttributeProcessStatus
+	}{
+		{"background", metadata.AttributeProcessStatusBackground},
+		{"dormant", metadata.AttributeProcessStatusDormant},
+		{"preconnect", metadata.AttributeProcessStatusPreconnect},
+		{"runnable", metadata.AttributeProcessStatusRunnable},
+		{"running", metadata.AttributeProcessStatusRunning},
+		{"sleeping", metadata.AttributeProcessStatusSleeping},
+		{"suspended", metadata.AttributeProcessStatusSuspended},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		for _, col := range statusColumns {
+			errs = append(errs, s.mb.RecordSqlserverProcessCountDataPoint(now, row[col.name], col.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Context) error {
+	const (
+		databaseName              = "database_name"
+		reservedSpaceBytes        = "reserved_space_bytes"
+		reservedSpaceNotUsedBytes = "reserved_space_not_used_bytes"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+
+		totalVal, totalErr := retrieveInt(row, reservedSpaceBytes)
+		freeVal, freeErr := retrieveInt(row, reservedSpaceNotUsedBytes)
+		if totalErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", reservedSpaceBytes, i, totalErr))
+		}
+		if freeErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", reservedSpaceNotUsedBytes, i, freeErr))
+		}
+
+		if totalErr == nil {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, row[reservedSpaceBytes], row[databaseName], metadata.AttributePageFileStateTotal))
+		}
+		if freeErr == nil {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, row[reservedSpaceNotUsedBytes], row[databaseName], metadata.AttributePageFileStateFree))
+		}
+		if totalErr == nil && freeErr == nil {
+			usedBytes := max(totalVal.(int64)-freeVal.(int64), 0)
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, fmt.Sprintf("%d", usedBytes), row[databaseName], metadata.AttributePageFileStateUsed))
 		}
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -228,6 +228,26 @@ Number of SQL attentions (client cancellation interrupts) received per second.
 | ---- | ----------- | ---------- | --------- |
 | {attentions}/s | Gauge | Double | Development |
 
+### sqlserver.batch.compilation.utilization
+
+Number of SQL compilations per batch request.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
+### sqlserver.batch.page_split.utilization
+
+Number of page splits per batch request.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
 ### sqlserver.computer.uptime
 
 Computer uptime.
@@ -358,6 +378,23 @@ This metric is only available when the receiver is configured to directly connec
 | file_type | The type of file being monitored. | Any Str | Recommended | - |
 | direction | The direction of flow of bytes or operations. | Str: ``read``, ``write`` | Recommended | - |
 
+### sqlserver.database.page_file.size
+
+Reserved space allocated to the database, broken down by usage state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| page_file.state | The state of the database page file (reserved space) allocation. | Str: ``used``, ``free``, ``total`` | Recommended | - |
+
 ### sqlserver.database.security.role_membership.count
 
 Number of members in a database role.
@@ -397,6 +434,22 @@ TempDB version store size.
 | ---- | ----------- | ---------- | --------- |
 | KB | Gauge | Double | Development |
 
+### sqlserver.database.transactions.active
+
+Number of active transactions in the database.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
 ### sqlserver.deadlock.rate
 
 Total number of deadlocks.
@@ -412,6 +465,16 @@ Total number of index searches.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {searches}/s | Gauge | Double | Development |
+
+### sqlserver.kill_connection.error.rate
+
+Number of kill-connection errors per second.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {errors}/s | Gauge | Double | Development |
 
 ### sqlserver.latch.superlatch.count
 
@@ -577,6 +640,52 @@ Total memory in use.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | KB | Sum | Double | Cumulative | false | Development |
 
+### sqlserver.os.disk.size
+
+Total disk space across volumes hosting SQL Server database files.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+### sqlserver.os.memory.usage
+
+Amount of system physical memory observed by SQL Server.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| memory.state | The state of system memory observed by SQL Server. | Str: ``available``, ``total`` | Recommended | - |
+
+### sqlserver.os.memory.utilization
+
+Fraction of system physical memory in use by the SQL Server process.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
+### sqlserver.os.scheduler.runnable_tasks.count
+
+Total number of runnable tasks across online schedulers.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tasks} | Gauge | Int | Development |
+
 ### sqlserver.os.wait.duration
 
 Total wait time for this wait type
@@ -586,6 +695,23 @@ This metric is only available when the receiver is configured to directly connec
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| wait.category | Category of the reason for a wait. | Any Str | Recommended | - |
+| wait.type | Type of the wait, view [WaitTypes documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql?view=sql-server-ver16#WaitTypes) for more information. | Any Str | Recommended | - |
+
+### sqlserver.os.wait.tasks.count
+
+Cumulative number of tasks that have waited on this wait type since SQL Server startup.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {tasks} | Sum | Int | Cumulative | true | Development |
 
 #### Attributes
 
@@ -637,6 +763,22 @@ Rate of plan executions, classified by plan guide result.
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | sqlserver.plan.guidance.result | Whether a SQL plan execution successfully used a matching plan guide (guided) or did not (misguided). | Str: ``guided``, ``misguided`` | Recommended | - |
+
+### sqlserver.process.count
+
+Number of SQL Server processes (user sessions), broken down by status.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {processes} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| process.status | The status of the SQL Server process/session. | Str: ``background``, ``dormant``, ``preconnect``, ``runnable``, ``running``, ``sleeping``, ``suspended`` | Recommended | - |
 
 ### sqlserver.processes.blocked
 

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -382,7 +382,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Reserved space allocated to the database, broken down by usage state.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
@@ -654,7 +654,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Amount of system physical memory observed by SQL Server.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
@@ -707,7 +707,7 @@ This metric is only available when the receiver is configured to directly connec
 
 Cumulative number of tasks that have waited on this wait type since SQL Server startup.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+This metric is only available when the receiver is configured to directly connect to SQL Server.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
@@ -768,7 +768,7 @@ Rate of plan executions, classified by plan guide result.
 
 Number of SQL Server processes (user sessions), broken down by status.
 
-This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+This metric is only available when the receiver is configured to directly connect to SQL Server. Use sqlserver.processes.blocked for blocked-session counts.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -103,6 +103,26 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabaseSecurityRoleMembersQuery(cfg.InstanceName))
 	}
 
+	if cfg.Metrics.SqlserverOsMemoryUsage.Enabled || cfg.Metrics.SqlserverOsMemoryUtilization.Enabled {
+		queries = append(queries, getSQLServerOSMemoryQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverOsDiskSize.Enabled {
+		queries = append(queries, getSQLServerOSDiskQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverOsSchedulerRunnableTasksCount.Enabled {
+		queries = append(queries, getSQLServerOSSchedulerRunnableTasksQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverProcessCount.Enabled {
+		queries = append(queries, getSQLServerProcessCountQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverDatabasePageFileSize.Enabled {
+		queries = append(queries, getSQLServerDatabasePageFileQuery(cfg.InstanceName))
+	}
+
 	return queries
 }
 
@@ -281,12 +301,16 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	return metrics.SqlserverBatchRequestRate.Enabled ||
+	return metrics.SqlserverBatchCompilationUtilization.Enabled ||
+		metrics.SqlserverBatchPageSplitUtilization.Enabled ||
+		metrics.SqlserverBatchRequestRate.Enabled ||
 		metrics.SqlserverBatchSQLCompilationRate.Enabled ||
 		metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
 		metrics.SqlserverDatabaseBackupOrRestoreRate.Enabled ||
 		metrics.SqlserverDatabaseExecutionErrors.Enabled ||
 		metrics.SqlserverDatabaseFullScanRate.Enabled ||
+		metrics.SqlserverDatabaseTransactionsActive.Enabled ||
+		metrics.SqlserverKillConnectionErrorRate.Enabled ||
 		metrics.SqlserverDatabaseTempdbSpace.Enabled ||
 		metrics.SqlserverDatabaseTempdbVersionStoreSize.Enabled ||
 		metrics.SqlserverDeadlockRate.Enabled ||
@@ -329,5 +353,6 @@ func isWaitStatsQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	return metrics.SqlserverOsWaitDuration.Enabled
+	return metrics.SqlserverOsWaitDuration.Enabled ||
+		metrics.SqlserverOsWaitTasksCount.Enabled
 }

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -263,7 +263,7 @@ func TestSetupQueries(t *testing.T) {
 
 	metricsMetadata, ok := metadata["metrics"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, metricsMetadata, 67, "Every time metrics are added or removed, the function `setupQueries` must "+
+	require.Len(t, metricsMetadata, 78, "Every time metrics are added or removed, the function `setupQueries` must "+
 		"be modified to properly account for the change. Please update `setupQueries` and then, "+
 		"and only then, update the expected metric count here.")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config.go
@@ -30,6 +30,46 @@ func (ms *SqlserverAttentionRateMetricConfig) Unmarshal(parser *confmap.Conf) er
 	return nil
 }
 
+// SqlserverBatchCompilationUtilizationMetricConfig provides config for the sqlserver.batch.compilation.utilization metric.
+type SqlserverBatchCompilationUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverBatchCompilationUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverBatchPageSplitUtilizationMetricConfig provides config for the sqlserver.batch.page_split.utilization metric.
+type SqlserverBatchPageSplitUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverBatchPageSplitUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverBatchRequestRateMetricConfig provides config for the sqlserver.batch.request.rate metric.
 type SqlserverBatchRequestRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -440,6 +480,55 @@ func (ms *SqlserverDatabaseOperationsMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverDatabasePageFileSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.database.page_file.size metric.
+type SqlserverDatabasePageFileSizeMetricAttributeKey string
+
+const (
+	SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace   SqlserverDatabasePageFileSizeMetricAttributeKey = "db.namespace"
+	SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState SqlserverDatabasePageFileSizeMetricAttributeKey = "page_file.state"
+)
+
+// SqlserverDatabasePageFileSizeMetricConfig provides config for the sqlserver.database.page_file.size metric.
+type SqlserverDatabasePageFileSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePageFileSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePageFileSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePageFileSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState:
+		default:
+			return fmt.Errorf("metric sqlserver.database.page_file.size doesn't have an attribute %v, valid attributes: [db.namespace, page_file.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.security.role_membership.count metric.
 type SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey string
 
@@ -557,6 +646,54 @@ func (ms *SqlserverDatabaseTempdbVersionStoreSizeMetricConfig) Unmarshal(parser 
 	return nil
 }
 
+// SqlserverDatabaseTransactionsActiveMetricAttributeKey specifies the key of an attribute for the sqlserver.database.transactions.active metric.
+type SqlserverDatabaseTransactionsActiveMetricAttributeKey string
+
+const (
+	SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace SqlserverDatabaseTransactionsActiveMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabaseTransactionsActiveMetricConfig provides config for the sqlserver.database.transactions.active metric.
+type SqlserverDatabaseTransactionsActiveMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseTransactionsActiveMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseTransactionsActiveMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseTransactionsActiveMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.transactions.active doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDeadlockRateMetricConfig provides config for the sqlserver.deadlock.rate metric.
 type SqlserverDeadlockRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -584,6 +721,26 @@ type SqlserverIndexSearchRateMetricConfig struct {
 }
 
 func (ms *SqlserverIndexSearchRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverKillConnectionErrorRateMetricConfig provides config for the sqlserver.kill_connection.error.rate metric.
+type SqlserverKillConnectionErrorRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverKillConnectionErrorRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -1049,6 +1206,114 @@ func (ms *SqlserverMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) erro
 	return nil
 }
 
+// SqlserverOsDiskSizeMetricConfig provides config for the sqlserver.os.disk.size metric.
+type SqlserverOsDiskSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsDiskSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverOsMemoryUsageMetricAttributeKey specifies the key of an attribute for the sqlserver.os.memory.usage metric.
+type SqlserverOsMemoryUsageMetricAttributeKey string
+
+const (
+	SqlserverOsMemoryUsageMetricAttributeKeyMemoryState SqlserverOsMemoryUsageMetricAttributeKey = "memory.state"
+)
+
+// SqlserverOsMemoryUsageMetricConfig provides config for the sqlserver.os.memory.usage metric.
+type SqlserverOsMemoryUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverOsMemoryUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverOsMemoryUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverOsMemoryUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverOsMemoryUsageMetricAttributeKeyMemoryState:
+		default:
+			return fmt.Errorf("metric sqlserver.os.memory.usage doesn't have an attribute %v, valid attributes: [memory.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverOsMemoryUtilizationMetricConfig provides config for the sqlserver.os.memory.utilization metric.
+type SqlserverOsMemoryUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsMemoryUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverOsSchedulerRunnableTasksCountMetricConfig provides config for the sqlserver.os.scheduler.runnable_tasks.count metric.
+type SqlserverOsSchedulerRunnableTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverOsSchedulerRunnableTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverOsWaitDurationMetricAttributeKey specifies the key of an attribute for the sqlserver.os.wait.duration metric.
 type SqlserverOsWaitDurationMetricAttributeKey string
 
@@ -1086,6 +1351,55 @@ func (ms *SqlserverOsWaitDurationMetricConfig) Validate() error {
 		case SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType:
 		default:
 			return fmt.Errorf("metric sqlserver.os.wait.duration doesn't have an attribute %v, valid attributes: [wait.category, wait.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverOsWaitTasksCountMetricAttributeKey specifies the key of an attribute for the sqlserver.os.wait.tasks.count metric.
+type SqlserverOsWaitTasksCountMetricAttributeKey string
+
+const (
+	SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory SqlserverOsWaitTasksCountMetricAttributeKey = "wait.category"
+	SqlserverOsWaitTasksCountMetricAttributeKeyWaitType     SqlserverOsWaitTasksCountMetricAttributeKey = "wait.type"
+)
+
+// SqlserverOsWaitTasksCountMetricConfig provides config for the sqlserver.os.wait.tasks.count metric.
+type SqlserverOsWaitTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverOsWaitTasksCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverOsWaitTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverOsWaitTasksCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType:
+		default:
+			return fmt.Errorf("metric sqlserver.os.wait.tasks.count doesn't have an attribute %v, valid attributes: [wait.category, wait.type]", val)
 		}
 	}
 
@@ -1398,6 +1712,54 @@ func (ms *SqlserverPlanExecutionRateMetricConfig) Validate() error {
 		case SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult:
 		default:
 			return fmt.Errorf("metric sqlserver.plan.execution.rate doesn't have an attribute %v, valid attributes: [sqlserver.plan.guidance.result]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverProcessCountMetricAttributeKey specifies the key of an attribute for the sqlserver.process.count metric.
+type SqlserverProcessCountMetricAttributeKey string
+
+const (
+	SqlserverProcessCountMetricAttributeKeyProcessStatus SqlserverProcessCountMetricAttributeKey = "process.status"
+)
+
+// SqlserverProcessCountMetricConfig provides config for the sqlserver.process.count metric.
+type SqlserverProcessCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverProcessCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverProcessCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverProcessCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverProcessCountMetricAttributeKeyProcessStatus:
+		default:
+			return fmt.Errorf("metric sqlserver.process.count doesn't have an attribute %v, valid attributes: [process.status]", val)
 		}
 	}
 
@@ -1926,6 +2288,8 @@ func (ms *SqlserverUserConnectionCountMetricConfig) Unmarshal(parser *confmap.Co
 // MetricsConfig provides config for sqlserver metrics.
 type MetricsConfig struct {
 	SqlserverAttentionRate                       SqlserverAttentionRateMetricConfig                       `mapstructure:"sqlserver.attention.rate"`
+	SqlserverBatchCompilationUtilization         SqlserverBatchCompilationUtilizationMetricConfig         `mapstructure:"sqlserver.batch.compilation.utilization"`
+	SqlserverBatchPageSplitUtilization           SqlserverBatchPageSplitUtilizationMetricConfig           `mapstructure:"sqlserver.batch.page_split.utilization"`
 	SqlserverBatchRequestRate                    SqlserverBatchRequestRateMetricConfig                    `mapstructure:"sqlserver.batch.request.rate"`
 	SqlserverBatchSQLCompilationRate             SqlserverBatchSQLCompilationRateMetricConfig             `mapstructure:"sqlserver.batch.sql_compilation.rate"`
 	SqlserverBatchSQLRecompilationRate           SqlserverBatchSQLRecompilationRateMetricConfig           `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
@@ -1939,11 +2303,14 @@ type MetricsConfig struct {
 	SqlserverDatabaseIo                          SqlserverDatabaseIoMetricConfig                          `mapstructure:"sqlserver.database.io"`
 	SqlserverDatabaseLatency                     SqlserverDatabaseLatencyMetricConfig                     `mapstructure:"sqlserver.database.latency"`
 	SqlserverDatabaseOperations                  SqlserverDatabaseOperationsMetricConfig                  `mapstructure:"sqlserver.database.operations"`
+	SqlserverDatabasePageFileSize                SqlserverDatabasePageFileSizeMetricConfig                `mapstructure:"sqlserver.database.page_file.size"`
 	SqlserverDatabaseSecurityRoleMembershipCount SqlserverDatabaseSecurityRoleMembershipCountMetricConfig `mapstructure:"sqlserver.database.security.role_membership.count"`
 	SqlserverDatabaseTempdbSpace                 SqlserverDatabaseTempdbSpaceMetricConfig                 `mapstructure:"sqlserver.database.tempdb.space"`
 	SqlserverDatabaseTempdbVersionStoreSize      SqlserverDatabaseTempdbVersionStoreSizeMetricConfig      `mapstructure:"sqlserver.database.tempdb.version_store.size"`
+	SqlserverDatabaseTransactionsActive          SqlserverDatabaseTransactionsActiveMetricConfig          `mapstructure:"sqlserver.database.transactions.active"`
 	SqlserverDeadlockRate                        SqlserverDeadlockRateMetricConfig                        `mapstructure:"sqlserver.deadlock.rate"`
 	SqlserverIndexSearchRate                     SqlserverIndexSearchRateMetricConfig                     `mapstructure:"sqlserver.index.search.rate"`
+	SqlserverKillConnectionErrorRate             SqlserverKillConnectionErrorRateMetricConfig             `mapstructure:"sqlserver.kill_connection.error.rate"`
 	SqlserverLatchSuperlatchCount                SqlserverLatchSuperlatchCountMetricConfig                `mapstructure:"sqlserver.latch.superlatch.count"`
 	SqlserverLatchSuperlatchTransitionRate       SqlserverLatchSuperlatchTransitionRateMetricConfig       `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
 	SqlserverLatchWaitRate                       SqlserverLatchWaitRateMetricConfig                       `mapstructure:"sqlserver.latch.wait.rate"`
@@ -1961,7 +2328,12 @@ type MetricsConfig struct {
 	SqlserverMemoryPageCount                     SqlserverMemoryPageCountMetricConfig                     `mapstructure:"sqlserver.memory.page.count"`
 	SqlserverMemoryTarget                        SqlserverMemoryTargetMetricConfig                        `mapstructure:"sqlserver.memory.target"`
 	SqlserverMemoryUsage                         SqlserverMemoryUsageMetricConfig                         `mapstructure:"sqlserver.memory.usage"`
+	SqlserverOsDiskSize                          SqlserverOsDiskSizeMetricConfig                          `mapstructure:"sqlserver.os.disk.size"`
+	SqlserverOsMemoryUsage                       SqlserverOsMemoryUsageMetricConfig                       `mapstructure:"sqlserver.os.memory.usage"`
+	SqlserverOsMemoryUtilization                 SqlserverOsMemoryUtilizationMetricConfig                 `mapstructure:"sqlserver.os.memory.utilization"`
+	SqlserverOsSchedulerRunnableTasksCount       SqlserverOsSchedulerRunnableTasksCountMetricConfig       `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
 	SqlserverOsWaitDuration                      SqlserverOsWaitDurationMetricConfig                      `mapstructure:"sqlserver.os.wait.duration"`
+	SqlserverOsWaitTasksCount                    SqlserverOsWaitTasksCountMetricConfig                    `mapstructure:"sqlserver.os.wait.tasks.count"`
 	SqlserverPageBufferCacheFreeListStallsRate   SqlserverPageBufferCacheFreeListStallsRateMetricConfig   `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
 	SqlserverPageBufferCacheHitRatio             SqlserverPageBufferCacheHitRatioMetricConfig             `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
 	SqlserverPageCheckpointFlushRate             SqlserverPageCheckpointFlushRateMetricConfig             `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
@@ -1972,6 +2344,7 @@ type MetricsConfig struct {
 	SqlserverPageSplitRate                       SqlserverPageSplitRateMetricConfig                       `mapstructure:"sqlserver.page.split.rate"`
 	SqlserverParameterizationRate                SqlserverParameterizationRateMetricConfig                `mapstructure:"sqlserver.parameterization.rate"`
 	SqlserverPlanExecutionRate                   SqlserverPlanExecutionRateMetricConfig                   `mapstructure:"sqlserver.plan.execution.rate"`
+	SqlserverProcessCount                        SqlserverProcessCountMetricConfig                        `mapstructure:"sqlserver.process.count"`
 	SqlserverProcessesBlocked                    SqlserverProcessesBlockedMetricConfig                    `mapstructure:"sqlserver.processes.blocked"`
 	SqlserverRecompilationRatio                  SqlserverRecompilationRatioMetricConfig                  `mapstructure:"sqlserver.recompilation.ratio"`
 	SqlserverReplicaDataRate                     SqlserverReplicaDataRateMetricConfig                     `mapstructure:"sqlserver.replica.data.rate"`
@@ -1997,6 +2370,12 @@ type MetricsConfig struct {
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+			Enabled: false,
+		},
+		SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
 			Enabled: false,
 		},
 		SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
@@ -2048,6 +2427,11 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 		},
+		SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+		},
 		SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
@@ -2061,10 +2445,18 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 			Enabled: false,
 		},
+		SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+		},
 		SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 			Enabled: false,
 		},
 		SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 			Enabled: false,
 		},
 		SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -2126,10 +2518,29 @@ func DefaultMetricsConfig() MetricsConfig {
 		SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 			Enabled: false,
 		},
+		SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+			Enabled: false,
+		},
+		SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+		},
+		SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+			Enabled: false,
+		},
+		SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+			Enabled: false,
+		},
 		SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+		},
+		SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 		},
 		SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 			Enabled: false,
@@ -2168,6 +2579,11 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+		},
+		SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 		},
 		SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 			Enabled: false,

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
@@ -30,6 +30,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
 						Enabled: true,
 					},
+					SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+						Enabled: true,
+					},
+					SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
+						Enabled: true,
+					},
 					SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
 						Enabled: true,
 					},
@@ -79,6 +85,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 					},
+					SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -92,10 +103,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 						Enabled: true,
 					},
+					SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -157,10 +176,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 						Enabled: true,
 					},
+					SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+						Enabled: true,
+					},
+					SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+					},
+					SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+						Enabled: true,
+					},
+					SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+						Enabled: true,
+					},
 					SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+					},
+					SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 					},
 					SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 						Enabled: true,
@@ -199,6 +237,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+					},
+					SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 					},
 					SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 						Enabled: true,
@@ -289,6 +332,12 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverAttentionRate: SqlserverAttentionRateMetricConfig{
 						Enabled: false,
 					},
+					SqlserverBatchCompilationUtilization: SqlserverBatchCompilationUtilizationMetricConfig{
+						Enabled: false,
+					},
+					SqlserverBatchPageSplitUtilization: SqlserverBatchPageSplitUtilizationMetricConfig{
+						Enabled: false,
+					},
 					SqlserverBatchRequestRate: SqlserverBatchRequestRateMetricConfig{
 						Enabled: false,
 					},
@@ -338,6 +387,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverDatabaseOperationsMetricAttributeKey{SqlserverDatabaseOperationsMetricAttributeKeyPhysicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyLogicalFilename, SqlserverDatabaseOperationsMetricAttributeKeyFileType, SqlserverDatabaseOperationsMetricAttributeKeyDirection},
 					},
+					SqlserverDatabasePageFileSize: SqlserverDatabasePageFileSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -351,10 +405,18 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverDatabaseTempdbVersionStoreSize: SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{
 						Enabled: false,
 					},
+					SqlserverDatabaseTransactionsActive: SqlserverDatabaseTransactionsActiveMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseTransactionsActiveMetricAttributeKey{SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace},
+					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverKillConnectionErrorRate: SqlserverKillConnectionErrorRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverLatchSuperlatchCount: SqlserverLatchSuperlatchCountMetricConfig{
@@ -416,10 +478,29 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					SqlserverMemoryUsage: SqlserverMemoryUsageMetricConfig{
 						Enabled: false,
 					},
+					SqlserverOsDiskSize: SqlserverOsDiskSizeMetricConfig{
+						Enabled: false,
+					},
+					SqlserverOsMemoryUsage: SqlserverOsMemoryUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverOsMemoryUsageMetricAttributeKey{SqlserverOsMemoryUsageMetricAttributeKeyMemoryState},
+					},
+					SqlserverOsMemoryUtilization: SqlserverOsMemoryUtilizationMetricConfig{
+						Enabled: false,
+					},
+					SqlserverOsSchedulerRunnableTasksCount: SqlserverOsSchedulerRunnableTasksCountMetricConfig{
+						Enabled: false,
+					},
 					SqlserverOsWaitDuration: SqlserverOsWaitDurationMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverOsWaitDurationMetricAttributeKey{SqlserverOsWaitDurationMetricAttributeKeyWaitCategory, SqlserverOsWaitDurationMetricAttributeKeyWaitType},
+					},
+					SqlserverOsWaitTasksCount: SqlserverOsWaitTasksCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverOsWaitTasksCountMetricAttributeKey{SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType},
 					},
 					SqlserverPageBufferCacheFreeListStallsRate: SqlserverPageBufferCacheFreeListStallsRateMetricConfig{
 						Enabled: false,
@@ -458,6 +539,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverPlanExecutionRateMetricAttributeKey{SqlserverPlanExecutionRateMetricAttributeKeySqlserverPlanGuidanceResult},
+					},
+					SqlserverProcessCount: SqlserverProcessCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverProcessCountMetricAttributeKey{SqlserverProcessCountMetricAttributeKeyProcessStatus},
 					},
 					SqlserverProcessesBlocked: SqlserverProcessesBlockedMetricConfig{
 						Enabled: false,
@@ -545,7 +631,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -611,6 +697,18 @@ func TestSqlserverDatabaseOperationsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverDatabasePageFileSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePageFileSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePageFileSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.page_file.size doesn't have an attribute invalid, valid attributes: [db.namespace, page_file.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePageFileSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverDatabaseSecurityRoleMembershipCountMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverDatabaseSecurityRoleMembershipCount
 	require.NoError(t, cfg.Validate())
@@ -631,6 +729,18 @@ func TestSqlserverDatabaseTempdbSpaceMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.tempdb.space doesn't have an attribute invalid, valid attributes: [tempdb.state]")
 
 	cfg = DefaultMetricsConfig().SqlserverDatabaseTempdbSpace
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseTransactionsActiveMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseTransactionsActive
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseTransactionsActiveMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.transactions.active doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseTransactionsActive
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -683,6 +793,18 @@ func TestSqlserverMemoryPageCountMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverOsMemoryUsageMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverOsMemoryUsage
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverOsMemoryUsageMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.memory.usage doesn't have an attribute invalid, valid attributes: [memory.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverOsMemoryUsage
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverOsWaitDurationMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverOsWaitDuration
 	require.NoError(t, cfg.Validate())
@@ -691,6 +813,18 @@ func TestSqlserverOsWaitDurationMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.wait.duration doesn't have an attribute invalid, valid attributes: [wait.category, wait.type]")
 
 	cfg = DefaultMetricsConfig().SqlserverOsWaitDuration
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverOsWaitTasksCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverOsWaitTasksCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverOsWaitTasksCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.os.wait.tasks.count doesn't have an attribute invalid, valid attributes: [wait.category, wait.type]")
+
+	cfg = DefaultMetricsConfig().SqlserverOsWaitTasksCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -739,6 +873,18 @@ func TestSqlserverPlanExecutionRateMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.plan.execution.rate doesn't have an attribute invalid, valid attributes: [sqlserver.plan.guidance.result]")
 
 	cfg = DefaultMetricsConfig().SqlserverPlanExecutionRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverProcessCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverProcessCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverProcessCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.process.count doesn't have an attribute invalid, valid attributes: [process.status]")
+
+	cfg = DefaultMetricsConfig().SqlserverProcessCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -162,6 +162,32 @@ var MapAttributeMemoryPool = map[string]AttributeMemoryPool{
 	"max_workspace":     AttributeMemoryPoolMaxWorkspace,
 }
 
+// AttributeMemoryState specifies the value memory.state attribute.
+type AttributeMemoryState int
+
+const (
+	_ AttributeMemoryState = iota
+	AttributeMemoryStateAvailable
+	AttributeMemoryStateTotal
+)
+
+// String returns the string representation of the AttributeMemoryState.
+func (av AttributeMemoryState) String() string {
+	switch av {
+	case AttributeMemoryStateAvailable:
+		return "available"
+	case AttributeMemoryStateTotal:
+		return "total"
+	}
+	return ""
+}
+
+// MapAttributeMemoryState is a helper map of string to AttributeMemoryState attribute value.
+var MapAttributeMemoryState = map[string]AttributeMemoryState{
+	"available": AttributeMemoryStateAvailable,
+	"total":     AttributeMemoryStateTotal,
+}
+
 // AttributePageOperations specifies the value page.operations attribute.
 type AttributePageOperations int
 
@@ -232,6 +258,82 @@ var MapAttributePagePool = map[string]AttributePagePool{
 	"stolen":   AttributePagePoolStolen,
 	"reserved": AttributePagePoolReserved,
 	"free":     AttributePagePoolFree,
+}
+
+// AttributePageFileState specifies the value page_file.state attribute.
+type AttributePageFileState int
+
+const (
+	_ AttributePageFileState = iota
+	AttributePageFileStateUsed
+	AttributePageFileStateFree
+	AttributePageFileStateTotal
+)
+
+// String returns the string representation of the AttributePageFileState.
+func (av AttributePageFileState) String() string {
+	switch av {
+	case AttributePageFileStateUsed:
+		return "used"
+	case AttributePageFileStateFree:
+		return "free"
+	case AttributePageFileStateTotal:
+		return "total"
+	}
+	return ""
+}
+
+// MapAttributePageFileState is a helper map of string to AttributePageFileState attribute value.
+var MapAttributePageFileState = map[string]AttributePageFileState{
+	"used":  AttributePageFileStateUsed,
+	"free":  AttributePageFileStateFree,
+	"total": AttributePageFileStateTotal,
+}
+
+// AttributeProcessStatus specifies the value process.status attribute.
+type AttributeProcessStatus int
+
+const (
+	_ AttributeProcessStatus = iota
+	AttributeProcessStatusBackground
+	AttributeProcessStatusDormant
+	AttributeProcessStatusPreconnect
+	AttributeProcessStatusRunnable
+	AttributeProcessStatusRunning
+	AttributeProcessStatusSleeping
+	AttributeProcessStatusSuspended
+)
+
+// String returns the string representation of the AttributeProcessStatus.
+func (av AttributeProcessStatus) String() string {
+	switch av {
+	case AttributeProcessStatusBackground:
+		return "background"
+	case AttributeProcessStatusDormant:
+		return "dormant"
+	case AttributeProcessStatusPreconnect:
+		return "preconnect"
+	case AttributeProcessStatusRunnable:
+		return "runnable"
+	case AttributeProcessStatusRunning:
+		return "running"
+	case AttributeProcessStatusSleeping:
+		return "sleeping"
+	case AttributeProcessStatusSuspended:
+		return "suspended"
+	}
+	return ""
+}
+
+// MapAttributeProcessStatus is a helper map of string to AttributeProcessStatus attribute value.
+var MapAttributeProcessStatus = map[string]AttributeProcessStatus{
+	"background": AttributeProcessStatusBackground,
+	"dormant":    AttributeProcessStatusDormant,
+	"preconnect": AttributeProcessStatusPreconnect,
+	"runnable":   AttributeProcessStatusRunnable,
+	"running":    AttributeProcessStatusRunning,
+	"sleeping":   AttributeProcessStatusSleeping,
+	"suspended":  AttributeProcessStatusSuspended,
 }
 
 // AttributeReplicaDirection specifies the value replica.direction attribute.
@@ -432,6 +534,12 @@ var MetricsInfo = metricsInfo{
 	SqlserverAttentionRate: metricInfo{
 		Name: "sqlserver.attention.rate",
 	},
+	SqlserverBatchCompilationUtilization: metricInfo{
+		Name: "sqlserver.batch.compilation.utilization",
+	},
+	SqlserverBatchPageSplitUtilization: metricInfo{
+		Name: "sqlserver.batch.page_split.utilization",
+	},
 	SqlserverBatchRequestRate: metricInfo{
 		Name: "sqlserver.batch.request.rate",
 	},
@@ -476,6 +584,10 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.database.operations",
 		Attributes: []string{"physical_filename", "logical_filename", "file_type", "direction"},
 	},
+	SqlserverDatabasePageFileSize: metricInfo{
+		Name:       "sqlserver.database.page_file.size",
+		Attributes: []string{"db.namespace", "page_file.state"},
+	},
 	SqlserverDatabaseSecurityRoleMembershipCount: metricInfo{
 		Name:       "sqlserver.database.security.role_membership.count",
 		Attributes: []string{"db.namespace", "role"},
@@ -487,11 +599,18 @@ var MetricsInfo = metricsInfo{
 	SqlserverDatabaseTempdbVersionStoreSize: metricInfo{
 		Name: "sqlserver.database.tempdb.version_store.size",
 	},
+	SqlserverDatabaseTransactionsActive: metricInfo{
+		Name:       "sqlserver.database.transactions.active",
+		Attributes: []string{"db.namespace"},
+	},
 	SqlserverDeadlockRate: metricInfo{
 		Name: "sqlserver.deadlock.rate",
 	},
 	SqlserverIndexSearchRate: metricInfo{
 		Name: "sqlserver.index.search.rate",
+	},
+	SqlserverKillConnectionErrorRate: metricInfo{
+		Name: "sqlserver.kill_connection.error.rate",
 	},
 	SqlserverLatchSuperlatchCount: metricInfo{
 		Name: "sqlserver.latch.superlatch.count",
@@ -548,8 +667,25 @@ var MetricsInfo = metricsInfo{
 	SqlserverMemoryUsage: metricInfo{
 		Name: "sqlserver.memory.usage",
 	},
+	SqlserverOsDiskSize: metricInfo{
+		Name: "sqlserver.os.disk.size",
+	},
+	SqlserverOsMemoryUsage: metricInfo{
+		Name:       "sqlserver.os.memory.usage",
+		Attributes: []string{"memory.state"},
+	},
+	SqlserverOsMemoryUtilization: metricInfo{
+		Name: "sqlserver.os.memory.utilization",
+	},
+	SqlserverOsSchedulerRunnableTasksCount: metricInfo{
+		Name: "sqlserver.os.scheduler.runnable_tasks.count",
+	},
 	SqlserverOsWaitDuration: metricInfo{
 		Name:       "sqlserver.os.wait.duration",
+		Attributes: []string{"wait.category", "wait.type"},
+	},
+	SqlserverOsWaitTasksCount: metricInfo{
+		Name:       "sqlserver.os.wait.tasks.count",
 		Attributes: []string{"wait.category", "wait.type"},
 	},
 	SqlserverPageBufferCacheFreeListStallsRate: metricInfo{
@@ -585,6 +721,10 @@ var MetricsInfo = metricsInfo{
 	SqlserverPlanExecutionRate: metricInfo{
 		Name:       "sqlserver.plan.execution.rate",
 		Attributes: []string{"sqlserver.plan.guidance.result"},
+	},
+	SqlserverProcessCount: metricInfo{
+		Name:       "sqlserver.process.count",
+		Attributes: []string{"process.status"},
 	},
 	SqlserverProcessesBlocked: metricInfo{
 		Name: "sqlserver.processes.blocked",
@@ -654,6 +794,8 @@ var MetricsInfo = metricsInfo{
 
 type metricsInfo struct {
 	SqlserverAttentionRate                       metricInfo
+	SqlserverBatchCompilationUtilization         metricInfo
+	SqlserverBatchPageSplitUtilization           metricInfo
 	SqlserverBatchRequestRate                    metricInfo
 	SqlserverBatchSQLCompilationRate             metricInfo
 	SqlserverBatchSQLRecompilationRate           metricInfo
@@ -667,11 +809,14 @@ type metricsInfo struct {
 	SqlserverDatabaseIo                          metricInfo
 	SqlserverDatabaseLatency                     metricInfo
 	SqlserverDatabaseOperations                  metricInfo
+	SqlserverDatabasePageFileSize                metricInfo
 	SqlserverDatabaseSecurityRoleMembershipCount metricInfo
 	SqlserverDatabaseTempdbSpace                 metricInfo
 	SqlserverDatabaseTempdbVersionStoreSize      metricInfo
+	SqlserverDatabaseTransactionsActive          metricInfo
 	SqlserverDeadlockRate                        metricInfo
 	SqlserverIndexSearchRate                     metricInfo
+	SqlserverKillConnectionErrorRate             metricInfo
 	SqlserverLatchSuperlatchCount                metricInfo
 	SqlserverLatchSuperlatchTransitionRate       metricInfo
 	SqlserverLatchWaitRate                       metricInfo
@@ -689,7 +834,12 @@ type metricsInfo struct {
 	SqlserverMemoryPageCount                     metricInfo
 	SqlserverMemoryTarget                        metricInfo
 	SqlserverMemoryUsage                         metricInfo
+	SqlserverOsDiskSize                          metricInfo
+	SqlserverOsMemoryUsage                       metricInfo
+	SqlserverOsMemoryUtilization                 metricInfo
+	SqlserverOsSchedulerRunnableTasksCount       metricInfo
 	SqlserverOsWaitDuration                      metricInfo
+	SqlserverOsWaitTasksCount                    metricInfo
 	SqlserverPageBufferCacheFreeListStallsRate   metricInfo
 	SqlserverPageBufferCacheHitRatio             metricInfo
 	SqlserverPageCheckpointFlushRate             metricInfo
@@ -700,6 +850,7 @@ type metricsInfo struct {
 	SqlserverPageSplitRate                       metricInfo
 	SqlserverParameterizationRate                metricInfo
 	SqlserverPlanExecutionRate                   metricInfo
+	SqlserverProcessCount                        metricInfo
 	SqlserverProcessesBlocked                    metricInfo
 	SqlserverRecompilationRatio                  metricInfo
 	SqlserverReplicaDataRate                     metricInfo
@@ -769,6 +920,106 @@ func (m *metricSqlserverAttentionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverAttentionRate(cfg SqlserverAttentionRateMetricConfig) metricSqlserverAttentionRate {
 	m := metricSqlserverAttentionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverBatchCompilationUtilization struct {
+	data     pmetric.Metric                                   // data buffer for generated metric.
+	config   SqlserverBatchCompilationUtilizationMetricConfig // metric config provided by user.
+	capacity int                                              // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.batch.compilation.utilization metric with initial data.
+func (m *metricSqlserverBatchCompilationUtilization) init() {
+	m.data.SetName("sqlserver.batch.compilation.utilization")
+	m.data.SetDescription("Number of SQL compilations per batch request.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverBatchCompilationUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverBatchCompilationUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverBatchCompilationUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverBatchCompilationUtilization(cfg SqlserverBatchCompilationUtilizationMetricConfig) metricSqlserverBatchCompilationUtilization {
+	m := metricSqlserverBatchCompilationUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverBatchPageSplitUtilization struct {
+	data     pmetric.Metric                                 // data buffer for generated metric.
+	config   SqlserverBatchPageSplitUtilizationMetricConfig // metric config provided by user.
+	capacity int                                            // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.batch.page_split.utilization metric with initial data.
+func (m *metricSqlserverBatchPageSplitUtilization) init() {
+	m.data.SetName("sqlserver.batch.page_split.utilization")
+	m.data.SetDescription("Number of page splits per batch request.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverBatchPageSplitUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverBatchPageSplitUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverBatchPageSplitUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverBatchPageSplitUtilization(cfg SqlserverBatchPageSplitUtilizationMetricConfig) metricSqlserverBatchPageSplitUtilization {
+	m := metricSqlserverBatchPageSplitUtilization{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -1658,6 +1909,98 @@ func newMetricSqlserverDatabaseOperations(cfg SqlserverDatabaseOperationsMetricC
 	return m
 }
 
+type metricSqlserverDatabasePageFileSize struct {
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        SqlserverDatabasePageFileSizeMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.page_file.size metric with initial data.
+func (m *metricSqlserverDatabasePageFileSize) init() {
+	m.data.SetName("sqlserver.database.page_file.size")
+	m.data.SetDescription("Reserved space allocated to the database, broken down by usage state.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePageFileSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, pageFileStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState) {
+		dp.Attributes().PutStr("page_file.state", pageFileStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePageFileSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePageFileSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePageFileSize(cfg SqlserverDatabasePageFileSizeMetricConfig) metricSqlserverDatabasePageFileSize {
+	m := metricSqlserverDatabasePageFileSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDatabaseSecurityRoleMembershipCount struct {
 	data          pmetric.Metric                                           // data buffer for generated metric.
 	config        SqlserverDatabaseSecurityRoleMembershipCountMetricConfig // metric config provided by user.
@@ -1891,6 +2234,95 @@ func newMetricSqlserverDatabaseTempdbVersionStoreSize(cfg SqlserverDatabaseTempd
 	return m
 }
 
+type metricSqlserverDatabaseTransactionsActive struct {
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        SqlserverDatabaseTransactionsActiveMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                                         // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.transactions.active metric with initial data.
+func (m *metricSqlserverDatabaseTransactionsActive) init() {
+	m.data.SetName("sqlserver.database.transactions.active")
+	m.data.SetDescription("Number of active transactions in the database.")
+	m.data.SetUnit("{transactions}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseTransactionsActive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseTransactionsActiveMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseTransactionsActive) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseTransactionsActive) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseTransactionsActive(cfg SqlserverDatabaseTransactionsActiveMetricConfig) metricSqlserverDatabaseTransactionsActive {
+	m := metricSqlserverDatabaseTransactionsActive{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDeadlockRate struct {
 	data     pmetric.Metric                    // data buffer for generated metric.
 	config   SqlserverDeadlockRateMetricConfig // metric config provided by user.
@@ -1983,6 +2415,56 @@ func (m *metricSqlserverIndexSearchRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverIndexSearchRate(cfg SqlserverIndexSearchRateMetricConfig) metricSqlserverIndexSearchRate {
 	m := metricSqlserverIndexSearchRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverKillConnectionErrorRate struct {
+	data     pmetric.Metric                               // data buffer for generated metric.
+	config   SqlserverKillConnectionErrorRateMetricConfig // metric config provided by user.
+	capacity int                                          // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.kill_connection.error.rate metric with initial data.
+func (m *metricSqlserverKillConnectionErrorRate) init() {
+	m.data.SetName("sqlserver.kill_connection.error.rate")
+	m.data.SetDescription("Number of kill-connection errors per second.")
+	m.data.SetUnit("{errors}/s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverKillConnectionErrorRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverKillConnectionErrorRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverKillConnectionErrorRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverKillConnectionErrorRate(cfg SqlserverKillConnectionErrorRateMetricConfig) metricSqlserverKillConnectionErrorRate {
+	m := metricSqlserverKillConnectionErrorRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3005,6 +3487,245 @@ func newMetricSqlserverMemoryUsage(cfg SqlserverMemoryUsageMetricConfig) metricS
 	return m
 }
 
+type metricSqlserverOsDiskSize struct {
+	data     pmetric.Metric                  // data buffer for generated metric.
+	config   SqlserverOsDiskSizeMetricConfig // metric config provided by user.
+	capacity int                             // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.disk.size metric with initial data.
+func (m *metricSqlserverOsDiskSize) init() {
+	m.data.SetName("sqlserver.os.disk.size")
+	m.data.SetDescription("Total disk space across volumes hosting SQL Server database files.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsDiskSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsDiskSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsDiskSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsDiskSize(cfg SqlserverOsDiskSizeMetricConfig) metricSqlserverOsDiskSize {
+	m := metricSqlserverOsDiskSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsMemoryUsage struct {
+	data          pmetric.Metric                     // data buffer for generated metric.
+	config        SqlserverOsMemoryUsageMetricConfig // metric config provided by user.
+	capacity      int                                // max observed number of data points added to the metric.
+	aggDataPoints []int64                            // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.os.memory.usage metric with initial data.
+func (m *metricSqlserverOsMemoryUsage) init() {
+	m.data.SetName("sqlserver.os.memory.usage")
+	m.data.SetDescription("Amount of system physical memory observed by SQL Server.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverOsMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsMemoryUsageMetricAttributeKeyMemoryState) {
+		dp.Attributes().PutStr("memory.state", memoryStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsMemoryUsage) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsMemoryUsage) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsMemoryUsage(cfg SqlserverOsMemoryUsageMetricConfig) metricSqlserverOsMemoryUsage {
+	m := metricSqlserverOsMemoryUsage{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsMemoryUtilization struct {
+	data     pmetric.Metric                           // data buffer for generated metric.
+	config   SqlserverOsMemoryUtilizationMetricConfig // metric config provided by user.
+	capacity int                                      // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.memory.utilization metric with initial data.
+func (m *metricSqlserverOsMemoryUtilization) init() {
+	m.data.SetName("sqlserver.os.memory.utilization")
+	m.data.SetDescription("Fraction of system physical memory in use by the SQL Server process.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsMemoryUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsMemoryUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsMemoryUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsMemoryUtilization(cfg SqlserverOsMemoryUtilizationMetricConfig) metricSqlserverOsMemoryUtilization {
+	m := metricSqlserverOsMemoryUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsSchedulerRunnableTasksCount struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverOsSchedulerRunnableTasksCountMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.os.scheduler.runnable_tasks.count metric with initial data.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) init() {
+	m.data.SetName("sqlserver.os.scheduler.runnable_tasks.count")
+	m.data.SetDescription("Total number of runnable tasks across online schedulers.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsSchedulerRunnableTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsSchedulerRunnableTasksCount(cfg SqlserverOsSchedulerRunnableTasksCountMetricConfig) metricSqlserverOsSchedulerRunnableTasksCount {
+	m := metricSqlserverOsSchedulerRunnableTasksCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverOsWaitDuration struct {
 	data          pmetric.Metric                      // data buffer for generated metric.
 	config        SqlserverOsWaitDurationMetricConfig // metric config provided by user.
@@ -3091,6 +3812,100 @@ func (m *metricSqlserverOsWaitDuration) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverOsWaitDuration(cfg SqlserverOsWaitDurationMetricConfig) metricSqlserverOsWaitDuration {
 	m := metricSqlserverOsWaitDuration{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverOsWaitTasksCount struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        SqlserverOsWaitTasksCountMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.os.wait.tasks.count metric with initial data.
+func (m *metricSqlserverOsWaitTasksCount) init() {
+	m.data.SetName("sqlserver.os.wait.tasks.count")
+	m.data.SetDescription("Cumulative number of tasks that have waited on this wait type since SQL Server startup.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverOsWaitTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, waitCategoryAttributeValue string, waitTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsWaitTasksCountMetricAttributeKeyWaitCategory) {
+		dp.Attributes().PutStr("wait.category", waitCategoryAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverOsWaitTasksCountMetricAttributeKeyWaitType) {
+		dp.Attributes().PutStr("wait.type", waitTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverOsWaitTasksCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverOsWaitTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverOsWaitTasksCount(cfg SqlserverOsWaitTasksCountMetricConfig) metricSqlserverOsWaitTasksCount {
+	m := metricSqlserverOsWaitTasksCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -3747,6 +4562,95 @@ func (m *metricSqlserverPlanExecutionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverPlanExecutionRate(cfg SqlserverPlanExecutionRateMetricConfig) metricSqlserverPlanExecutionRate {
 	m := metricSqlserverPlanExecutionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverProcessCount struct {
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        SqlserverProcessCountMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.process.count metric with initial data.
+func (m *metricSqlserverProcessCount) init() {
+	m.data.SetName("sqlserver.process.count")
+	m.data.SetDescription("Number of SQL Server processes (user sessions), broken down by status.")
+	m.data.SetUnit("{processes}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverProcessCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, processStatusAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverProcessCountMetricAttributeKeyProcessStatus) {
+		dp.Attributes().PutStr("process.status", processStatusAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverProcessCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverProcessCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverProcessCount(cfg SqlserverProcessCountMetricConfig) metricSqlserverProcessCount {
+	m := metricSqlserverProcessCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4933,6 +5837,8 @@ type MetricsBuilder struct {
 	resourceAttributeIncludeFilter                     map[string]filter.Filter
 	resourceAttributeExcludeFilter                     map[string]filter.Filter
 	metricSqlserverAttentionRate                       metricSqlserverAttentionRate
+	metricSqlserverBatchCompilationUtilization         metricSqlserverBatchCompilationUtilization
+	metricSqlserverBatchPageSplitUtilization           metricSqlserverBatchPageSplitUtilization
 	metricSqlserverBatchRequestRate                    metricSqlserverBatchRequestRate
 	metricSqlserverBatchSQLCompilationRate             metricSqlserverBatchSQLCompilationRate
 	metricSqlserverBatchSQLRecompilationRate           metricSqlserverBatchSQLRecompilationRate
@@ -4946,11 +5852,14 @@ type MetricsBuilder struct {
 	metricSqlserverDatabaseIo                          metricSqlserverDatabaseIo
 	metricSqlserverDatabaseLatency                     metricSqlserverDatabaseLatency
 	metricSqlserverDatabaseOperations                  metricSqlserverDatabaseOperations
+	metricSqlserverDatabasePageFileSize                metricSqlserverDatabasePageFileSize
 	metricSqlserverDatabaseSecurityRoleMembershipCount metricSqlserverDatabaseSecurityRoleMembershipCount
 	metricSqlserverDatabaseTempdbSpace                 metricSqlserverDatabaseTempdbSpace
 	metricSqlserverDatabaseTempdbVersionStoreSize      metricSqlserverDatabaseTempdbVersionStoreSize
+	metricSqlserverDatabaseTransactionsActive          metricSqlserverDatabaseTransactionsActive
 	metricSqlserverDeadlockRate                        metricSqlserverDeadlockRate
 	metricSqlserverIndexSearchRate                     metricSqlserverIndexSearchRate
+	metricSqlserverKillConnectionErrorRate             metricSqlserverKillConnectionErrorRate
 	metricSqlserverLatchSuperlatchCount                metricSqlserverLatchSuperlatchCount
 	metricSqlserverLatchSuperlatchTransitionRate       metricSqlserverLatchSuperlatchTransitionRate
 	metricSqlserverLatchWaitRate                       metricSqlserverLatchWaitRate
@@ -4968,7 +5877,12 @@ type MetricsBuilder struct {
 	metricSqlserverMemoryPageCount                     metricSqlserverMemoryPageCount
 	metricSqlserverMemoryTarget                        metricSqlserverMemoryTarget
 	metricSqlserverMemoryUsage                         metricSqlserverMemoryUsage
+	metricSqlserverOsDiskSize                          metricSqlserverOsDiskSize
+	metricSqlserverOsMemoryUsage                       metricSqlserverOsMemoryUsage
+	metricSqlserverOsMemoryUtilization                 metricSqlserverOsMemoryUtilization
+	metricSqlserverOsSchedulerRunnableTasksCount       metricSqlserverOsSchedulerRunnableTasksCount
 	metricSqlserverOsWaitDuration                      metricSqlserverOsWaitDuration
+	metricSqlserverOsWaitTasksCount                    metricSqlserverOsWaitTasksCount
 	metricSqlserverPageBufferCacheFreeListStallsRate   metricSqlserverPageBufferCacheFreeListStallsRate
 	metricSqlserverPageBufferCacheHitRatio             metricSqlserverPageBufferCacheHitRatio
 	metricSqlserverPageCheckpointFlushRate             metricSqlserverPageCheckpointFlushRate
@@ -4979,6 +5893,7 @@ type MetricsBuilder struct {
 	metricSqlserverPageSplitRate                       metricSqlserverPageSplitRate
 	metricSqlserverParameterizationRate                metricSqlserverParameterizationRate
 	metricSqlserverPlanExecutionRate                   metricSqlserverPlanExecutionRate
+	metricSqlserverProcessCount                        metricSqlserverProcessCount
 	metricSqlserverProcessesBlocked                    metricSqlserverProcessesBlocked
 	metricSqlserverRecompilationRatio                  metricSqlserverRecompilationRatio
 	metricSqlserverReplicaDataRate                     metricSqlserverReplicaDataRate
@@ -5020,11 +5935,13 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                                             mbc,
-		startTime:                                          pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                                      pmetric.NewMetrics(),
-		buildInfo:                                          settings.BuildInfo,
-		metricSqlserverAttentionRate:                       newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
+		config:                       mbc,
+		startTime:                    pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                pmetric.NewMetrics(),
+		buildInfo:                    settings.BuildInfo,
+		metricSqlserverAttentionRate: newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
+		metricSqlserverBatchCompilationUtilization:         newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
+		metricSqlserverBatchPageSplitUtilization:           newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
 		metricSqlserverBatchRequestRate:                    newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
 		metricSqlserverBatchSQLCompilationRate:             newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
 		metricSqlserverBatchSQLRecompilationRate:           newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
@@ -5038,11 +5955,14 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverDatabaseIo:                          newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
 		metricSqlserverDatabaseLatency:                     newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
 		metricSqlserverDatabaseOperations:                  newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
+		metricSqlserverDatabasePageFileSize:                newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
 		metricSqlserverDatabaseSecurityRoleMembershipCount: newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
 		metricSqlserverDatabaseTempdbSpace:                 newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
 		metricSqlserverDatabaseTempdbVersionStoreSize:      newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
+		metricSqlserverDatabaseTransactionsActive:          newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
 		metricSqlserverDeadlockRate:                        newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
 		metricSqlserverIndexSearchRate:                     newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
+		metricSqlserverKillConnectionErrorRate:             newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
 		metricSqlserverLatchSuperlatchCount:                newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
 		metricSqlserverLatchSuperlatchTransitionRate:       newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
 		metricSqlserverLatchWaitRate:                       newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
@@ -5060,7 +5980,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverMemoryPageCount:                     newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
 		metricSqlserverMemoryTarget:                        newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
 		metricSqlserverMemoryUsage:                         newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
+		metricSqlserverOsDiskSize:                          newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
+		metricSqlserverOsMemoryUsage:                       newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
+		metricSqlserverOsMemoryUtilization:                 newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
+		metricSqlserverOsSchedulerRunnableTasksCount:       newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
 		metricSqlserverOsWaitDuration:                      newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
+		metricSqlserverOsWaitTasksCount:                    newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
 		metricSqlserverPageBufferCacheFreeListStallsRate:   newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
 		metricSqlserverPageBufferCacheHitRatio:             newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
 		metricSqlserverPageCheckpointFlushRate:             newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
@@ -5071,6 +5996,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricSqlserverPageSplitRate:                       newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
 		metricSqlserverParameterizationRate:                newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
 		metricSqlserverPlanExecutionRate:                   newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
+		metricSqlserverProcessCount:                        newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
 		metricSqlserverProcessesBlocked:                    newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
 		metricSqlserverRecompilationRatio:                  newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
 		metricSqlserverReplicaDataRate:                     newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
@@ -5218,6 +6144,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSqlserverAttentionRate.emit(ils.Metrics())
+	mb.metricSqlserverBatchCompilationUtilization.emit(ils.Metrics())
+	mb.metricSqlserverBatchPageSplitUtilization.emit(ils.Metrics())
 	mb.metricSqlserverBatchRequestRate.emit(ils.Metrics())
 	mb.metricSqlserverBatchSQLCompilationRate.emit(ils.Metrics())
 	mb.metricSqlserverBatchSQLRecompilationRate.emit(ils.Metrics())
@@ -5231,11 +6159,14 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverDatabaseIo.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseLatency.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseOperations.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePageFileSize.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbSpace.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseTransactionsActive.emit(ils.Metrics())
 	mb.metricSqlserverDeadlockRate.emit(ils.Metrics())
 	mb.metricSqlserverIndexSearchRate.emit(ils.Metrics())
+	mb.metricSqlserverKillConnectionErrorRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchCount.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchTransitionRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitRate.emit(ils.Metrics())
@@ -5253,7 +6184,12 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverMemoryPageCount.emit(ils.Metrics())
 	mb.metricSqlserverMemoryTarget.emit(ils.Metrics())
 	mb.metricSqlserverMemoryUsage.emit(ils.Metrics())
+	mb.metricSqlserverOsDiskSize.emit(ils.Metrics())
+	mb.metricSqlserverOsMemoryUsage.emit(ils.Metrics())
+	mb.metricSqlserverOsMemoryUtilization.emit(ils.Metrics())
+	mb.metricSqlserverOsSchedulerRunnableTasksCount.emit(ils.Metrics())
 	mb.metricSqlserverOsWaitDuration.emit(ils.Metrics())
+	mb.metricSqlserverOsWaitTasksCount.emit(ils.Metrics())
 	mb.metricSqlserverPageBufferCacheFreeListStallsRate.emit(ils.Metrics())
 	mb.metricSqlserverPageBufferCacheHitRatio.emit(ils.Metrics())
 	mb.metricSqlserverPageCheckpointFlushRate.emit(ils.Metrics())
@@ -5264,6 +6200,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverPageSplitRate.emit(ils.Metrics())
 	mb.metricSqlserverParameterizationRate.emit(ils.Metrics())
 	mb.metricSqlserverPlanExecutionRate.emit(ils.Metrics())
+	mb.metricSqlserverProcessCount.emit(ils.Metrics())
 	mb.metricSqlserverProcessesBlocked.emit(ils.Metrics())
 	mb.metricSqlserverRecompilationRatio.emit(ils.Metrics())
 	mb.metricSqlserverReplicaDataRate.emit(ils.Metrics())
@@ -5318,6 +6255,16 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 // RecordSqlserverAttentionRateDataPoint adds a data point to sqlserver.attention.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverAttentionRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverAttentionRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverBatchCompilationUtilizationDataPoint adds a data point to sqlserver.batch.compilation.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverBatchCompilationUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverBatchCompilationUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverBatchPageSplitUtilizationDataPoint adds a data point to sqlserver.batch.page_split.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverBatchPageSplitUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverBatchPageSplitUtilization.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverBatchRequestRateDataPoint adds a data point to sqlserver.batch.request.rate metric.
@@ -5415,6 +6362,16 @@ func (mb *MetricsBuilder) RecordSqlserverDatabaseOperationsDataPoint(ts pcommon.
 	return nil
 }
 
+// RecordSqlserverDatabasePageFileSizeDataPoint adds a data point to sqlserver.database.page_file.size metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePageFileSizeDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, pageFileStateAttributeValue AttributePageFileState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePageFileSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePageFileSize.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, pageFileStateAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint adds a data point to sqlserver.database.security.role_membership.count metric.
 func (mb *MetricsBuilder) RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -5435,6 +6392,16 @@ func (mb *MetricsBuilder) RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverDatabaseTransactionsActiveDataPoint adds a data point to sqlserver.database.transactions.active metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseTransactionsActiveDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseTransactionsActive, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseTransactionsActive.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
 // RecordSqlserverDeadlockRateDataPoint adds a data point to sqlserver.deadlock.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverDeadlockRate.recordDataPoint(mb.startTime, ts, val)
@@ -5443,6 +6410,11 @@ func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timest
 // RecordSqlserverIndexSearchRateDataPoint adds a data point to sqlserver.index.search.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverIndexSearchRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverIndexSearchRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverKillConnectionErrorRateDataPoint adds a data point to sqlserver.kill_connection.error.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverKillConnectionErrorRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverKillConnectionErrorRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverLatchSuperlatchCountDataPoint adds a data point to sqlserver.latch.superlatch.count metric.
@@ -5535,9 +6507,54 @@ func (mb *MetricsBuilder) RecordSqlserverMemoryUsageDataPoint(ts pcommon.Timesta
 	mb.metricSqlserverMemoryUsage.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverOsDiskSizeDataPoint adds a data point to sqlserver.os.disk.size metric.
+func (mb *MetricsBuilder) RecordSqlserverOsDiskSizeDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsDiskSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsDiskSize.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverOsMemoryUsageDataPoint adds a data point to sqlserver.os.memory.usage metric.
+func (mb *MetricsBuilder) RecordSqlserverOsMemoryUsageDataPoint(ts pcommon.Timestamp, inputVal string, memoryStateAttributeValue AttributeMemoryState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsMemoryUsage, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsMemoryUsage.recordDataPoint(mb.startTime, ts, val, memoryStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverOsMemoryUtilizationDataPoint adds a data point to sqlserver.os.memory.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverOsMemoryUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverOsMemoryUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverOsSchedulerRunnableTasksCountDataPoint adds a data point to sqlserver.os.scheduler.runnable_tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsSchedulerRunnableTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsSchedulerRunnableTasksCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
 // RecordSqlserverOsWaitDurationDataPoint adds a data point to sqlserver.os.wait.duration metric.
 func (mb *MetricsBuilder) RecordSqlserverOsWaitDurationDataPoint(ts pcommon.Timestamp, val float64, waitCategoryAttributeValue string, waitTypeAttributeValue string) {
 	mb.metricSqlserverOsWaitDuration.recordDataPoint(mb.startTime, ts, val, waitCategoryAttributeValue, waitTypeAttributeValue)
+}
+
+// RecordSqlserverOsWaitTasksCountDataPoint adds a data point to sqlserver.os.wait.tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverOsWaitTasksCountDataPoint(ts pcommon.Timestamp, inputVal string, waitCategoryAttributeValue string, waitTypeAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverOsWaitTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverOsWaitTasksCount.recordDataPoint(mb.startTime, ts, val, waitCategoryAttributeValue, waitTypeAttributeValue)
+	return nil
 }
 
 // RecordSqlserverPageBufferCacheFreeListStallsRateDataPoint adds a data point to sqlserver.page.buffer_cache.free_list.stalls.rate metric.
@@ -5588,6 +6605,16 @@ func (mb *MetricsBuilder) RecordSqlserverParameterizationRateDataPoint(ts pcommo
 // RecordSqlserverPlanExecutionRateDataPoint adds a data point to sqlserver.plan.execution.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverPlanExecutionRateDataPoint(ts pcommon.Timestamp, val float64, sqlserverPlanGuidanceResultAttributeValue AttributeSqlserverPlanGuidanceResult) {
 	mb.metricSqlserverPlanExecutionRate.recordDataPoint(mb.startTime, ts, val, sqlserverPlanGuidanceResultAttributeValue.String())
+}
+
+// RecordSqlserverProcessCountDataPoint adds a data point to sqlserver.process.count metric.
+func (mb *MetricsBuilder) RecordSqlserverProcessCountDataPoint(ts pcommon.Timestamp, inputVal string, processStatusAttributeValue AttributeProcessStatus) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverProcessCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverProcessCount.recordDataPoint(mb.startTime, ts, val, processStatusAttributeValue.String())
+	return nil
 }
 
 // RecordSqlserverProcessesBlockedDataPoint adds a data point to sqlserver.processes.blocked metric.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -72,17 +72,22 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.database.io"] = mb.metricSqlserverDatabaseIo.config.AggregationStrategy
 			aggMap["sqlserver.database.latency"] = mb.metricSqlserverDatabaseLatency.config.AggregationStrategy
 			aggMap["sqlserver.database.operations"] = mb.metricSqlserverDatabaseOperations.config.AggregationStrategy
+			aggMap["sqlserver.database.page_file.size"] = mb.metricSqlserverDatabasePageFileSize.config.AggregationStrategy
 			aggMap["sqlserver.database.security.role_membership.count"] = mb.metricSqlserverDatabaseSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.database.tempdb.space"] = mb.metricSqlserverDatabaseTempdbSpace.config.AggregationStrategy
+			aggMap["sqlserver.database.transactions.active"] = mb.metricSqlserverDatabaseTransactionsActive.config.AggregationStrategy
 			aggMap["sqlserver.latch.superlatch.transition.rate"] = mb.metricSqlserverLatchSuperlatchTransitionRate.config.AggregationStrategy
 			aggMap["sqlserver.memory.area"] = mb.metricSqlserverMemoryArea.config.AggregationStrategy
 			aggMap["sqlserver.memory.cache.object.count"] = mb.metricSqlserverMemoryCacheObjectCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.page.count"] = mb.metricSqlserverMemoryPageCount.config.AggregationStrategy
+			aggMap["sqlserver.os.memory.usage"] = mb.metricSqlserverOsMemoryUsage.config.AggregationStrategy
 			aggMap["sqlserver.os.wait.duration"] = mb.metricSqlserverOsWaitDuration.config.AggregationStrategy
+			aggMap["sqlserver.os.wait.tasks.count"] = mb.metricSqlserverOsWaitTasksCount.config.AggregationStrategy
 			aggMap["sqlserver.page.life_expectancy"] = mb.metricSqlserverPageLifeExpectancy.config.AggregationStrategy
 			aggMap["sqlserver.page.operation.rate"] = mb.metricSqlserverPageOperationRate.config.AggregationStrategy
 			aggMap["sqlserver.parameterization.rate"] = mb.metricSqlserverParameterizationRate.config.AggregationStrategy
 			aggMap["sqlserver.plan.execution.rate"] = mb.metricSqlserverPlanExecutionRate.config.AggregationStrategy
+			aggMap["sqlserver.process.count"] = mb.metricSqlserverProcessCount.config.AggregationStrategy
 			aggMap["sqlserver.replica.data.rate"] = mb.metricSqlserverReplicaDataRate.config.AggregationStrategy
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.server.security.role_membership.count"] = mb.metricSqlserverServerSecurityRoleMembershipCount.config.AggregationStrategy
@@ -98,6 +103,12 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordSqlserverAttentionRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverBatchCompilationUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverBatchPageSplitUtilizationDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverBatchRequestRateDataPoint(ts, 1)
@@ -154,6 +165,12 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabasePageFileSizeDataPoint(ts, "1", "db.namespace-val", AttributePageFileStateUsed)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePageFileSizeDataPoint(ts, "3", "db.namespace-val-2", AttributePageFileStateFree)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "1", "db.namespace-val", "role-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
@@ -169,10 +186,19 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDeadlockRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverIndexSearchRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverKillConnectionErrorRateDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverLatchSuperlatchCountDataPoint(ts, 1)
@@ -238,9 +264,30 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverMemoryUsageDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverOsDiskSizeDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverOsMemoryUsageDataPoint(ts, "1", AttributeMemoryStateAvailable)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverOsMemoryUsageDataPoint(ts, "3", AttributeMemoryStateTotal)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverOsMemoryUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(ts, "1")
+
+			allMetricsCount++
 			mb.RecordSqlserverOsWaitDurationDataPoint(ts, 1, "wait.category-val", "wait.type-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverOsWaitDurationDataPoint(ts, 3, "wait.category-val-2", "wait.type-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverOsWaitTasksCountDataPoint(ts, "1", "wait.category-val", "wait.type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverOsWaitTasksCountDataPoint(ts, "3", "wait.category-val-2", "wait.type-val-2")
 			}
 
 			allMetricsCount++
@@ -283,6 +330,12 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverPlanExecutionRateDataPoint(ts, 1, AttributeSqlserverPlanGuidanceResultGuided)
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverPlanExecutionRateDataPoint(ts, 3, AttributeSqlserverPlanGuidanceResultMisguided)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverProcessCountDataPoint(ts, "1", AttributeProcessStatusBackground)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverProcessCountDataPoint(ts, "3", AttributeProcessStatusDormant)
 			}
 
 			allMetricsCount++
@@ -375,17 +428,22 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverDatabaseIo.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseLatency.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseOperations.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePageFileSize.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTempdbSpace.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseTransactionsActive.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverLatchSuperlatchTransitionRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryArea.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryCacheObjectCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryPageCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverOsMemoryUsage.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverOsWaitDuration.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverOsWaitTasksCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPageLifeExpectancy.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPageOperationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverParameterizationRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverPlanExecutionRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverProcessCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverReplicaDataRate.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverServerSecurityRoleMembershipCount.aggDataPoints)
@@ -424,6 +482,30 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 					assert.Equal(t, "Number of SQL attentions (client cancellation interrupts) received per second.", mi.Description())
 					assert.Equal(t, "{attentions}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.batch.compilation.utilization":
+					assert.False(t, validatedMetrics["sqlserver.batch.compilation.utilization"], "Found a duplicate in the metrics slice: sqlserver.batch.compilation.utilization")
+					validatedMetrics["sqlserver.batch.compilation.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of SQL compilations per batch request.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.batch.page_split.utilization":
+					assert.False(t, validatedMetrics["sqlserver.batch.page_split.utilization"], "Found a duplicate in the metrics slice: sqlserver.batch.page_split.utilization")
+					validatedMetrics["sqlserver.batch.page_split.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of page splits per batch request.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
@@ -787,6 +869,51 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("direction")
 						assert.False(t, ok)
 					}
+				case "sqlserver.database.page_file.size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.page_file.size"], "Found a duplicate in the metrics slice: sqlserver.database.page_file.size")
+						validatedMetrics["sqlserver.database.page_file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Reserved space allocated to the database, broken down by usage state.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						pageFileStateAttrVal, ok := dp.Attributes().Get("page_file.state")
+						assert.True(t, ok)
+						assert.Equal(t, "used", pageFileStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.page_file.size"], "Found a duplicate in the metrics slice: sqlserver.database.page_file.size")
+						validatedMetrics["sqlserver.database.page_file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Reserved space allocated to the database, broken down by usage state.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.page_file.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("page_file.state")
+						assert.False(t, ok)
+					}
 				case "sqlserver.database.security.role_membership.count":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.database.security.role_membership.count"], "Found a duplicate in the metrics slice: sqlserver.database.security.role_membership.count")
@@ -888,6 +1015,46 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.database.transactions.active":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.transactions.active"], "Found a duplicate in the metrics slice: sqlserver.database.transactions.active")
+						validatedMetrics["sqlserver.database.transactions.active"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of active transactions in the database.", mi.Description())
+						assert.Equal(t, "{transactions}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.transactions.active"], "Found a duplicate in the metrics slice: sqlserver.database.transactions.active")
+						validatedMetrics["sqlserver.database.transactions.active"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of active transactions in the database.", mi.Description())
+						assert.Equal(t, "{transactions}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.transactions.active"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
 				case "sqlserver.deadlock.rate":
 					assert.False(t, validatedMetrics["sqlserver.deadlock.rate"], "Found a duplicate in the metrics slice: sqlserver.deadlock.rate")
 					validatedMetrics["sqlserver.deadlock.rate"] = true
@@ -907,6 +1074,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 					assert.Equal(t, "Total number of index searches.", mi.Description())
 					assert.Equal(t, "{searches}/s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.kill_connection.error.rate":
+					assert.False(t, validatedMetrics["sqlserver.kill_connection.error.rate"], "Found a duplicate in the metrics slice: sqlserver.kill_connection.error.rate")
+					validatedMetrics["sqlserver.kill_connection.error.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of kill-connection errors per second.", mi.Description())
+					assert.Equal(t, "{errors}/s", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
@@ -1236,6 +1415,82 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.os.disk.size":
+					assert.False(t, validatedMetrics["sqlserver.os.disk.size"], "Found a duplicate in the metrics slice: sqlserver.os.disk.size")
+					validatedMetrics["sqlserver.os.disk.size"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Total disk space across volumes hosting SQL Server database files.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.os.memory.usage":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.os.memory.usage"], "Found a duplicate in the metrics slice: sqlserver.os.memory.usage")
+						validatedMetrics["sqlserver.os.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of system physical memory observed by SQL Server.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						memoryStateAttrVal, ok := dp.Attributes().Get("memory.state")
+						assert.True(t, ok)
+						assert.Equal(t, "available", memoryStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.os.memory.usage"], "Found a duplicate in the metrics slice: sqlserver.os.memory.usage")
+						validatedMetrics["sqlserver.os.memory.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Amount of system physical memory observed by SQL Server.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.os.memory.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("memory.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.os.memory.utilization":
+					assert.False(t, validatedMetrics["sqlserver.os.memory.utilization"], "Found a duplicate in the metrics slice: sqlserver.os.memory.utilization")
+					validatedMetrics["sqlserver.os.memory.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Fraction of system physical memory in use by the SQL Server process.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.os.scheduler.runnable_tasks.count":
+					assert.False(t, validatedMetrics["sqlserver.os.scheduler.runnable_tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.scheduler.runnable_tasks.count")
+					validatedMetrics["sqlserver.os.scheduler.runnable_tasks.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Total number of runnable tasks across online schedulers.", mi.Description())
+					assert.Equal(t, "{tasks}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "sqlserver.os.wait.duration":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.os.wait.duration"], "Found a duplicate in the metrics slice: sqlserver.os.wait.duration")
@@ -1279,6 +1534,55 @@ func TestMetricsBuilder(t *testing.T) {
 							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 						case "max":
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("wait.category")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("wait.type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.os.wait.tasks.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.os.wait.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.wait.tasks.count")
+						validatedMetrics["sqlserver.os.wait.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative number of tasks that have waited on this wait type since SQL Server startup.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						waitCategoryAttrVal, ok := dp.Attributes().Get("wait.category")
+						assert.True(t, ok)
+						assert.Equal(t, "wait.category-val", waitCategoryAttrVal.Str())
+						waitTypeAttrVal, ok := dp.Attributes().Get("wait.type")
+						assert.True(t, ok)
+						assert.Equal(t, "wait.type-val", waitTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.os.wait.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.os.wait.tasks.count")
+						validatedMetrics["sqlserver.os.wait.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative number of tasks that have waited on this wait type since SQL Server startup.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.os.wait.tasks.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
 						}
 						_, ok := dp.Attributes().Get("wait.category")
 						assert.False(t, ok)
@@ -1515,6 +1819,46 @@ func TestMetricsBuilder(t *testing.T) {
 							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
 						}
 						_, ok := dp.Attributes().Get("sqlserver.plan.guidance.result")
+						assert.False(t, ok)
+					}
+				case "sqlserver.process.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.process.count"], "Found a duplicate in the metrics slice: sqlserver.process.count")
+						validatedMetrics["sqlserver.process.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server processes (user sessions), broken down by status.", mi.Description())
+						assert.Equal(t, "{processes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						processStatusAttrVal, ok := dp.Attributes().Get("process.status")
+						assert.True(t, ok)
+						assert.Equal(t, "background", processStatusAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.process.count"], "Found a duplicate in the metrics slice: sqlserver.process.count")
+						validatedMetrics["sqlserver.process.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server processes (user sessions), broken down by status.", mi.Description())
+						assert.Equal(t, "{processes}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.process.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("process.status")
 						assert.False(t, ok)
 					}
 				case "sqlserver.processes.blocked":

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,10 @@ all_set:
   metrics:
     sqlserver.attention.rate:
       enabled: true
+    sqlserver.batch.compilation.utilization:
+      enabled: true
+    sqlserver.batch.page_split.utilization:
+      enabled: true
     sqlserver.batch.request.rate:
       enabled: true
     sqlserver.batch.sql_compilation.rate:
@@ -34,6 +38,9 @@ all_set:
     sqlserver.database.operations:
       enabled: true
       attributes: ["physical_filename","logical_filename","file_type","direction"]
+    sqlserver.database.page_file.size:
+      enabled: true
+      attributes: ["db.namespace","page_file.state"]
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: ["db.namespace","role"]
@@ -42,9 +49,14 @@ all_set:
       attributes: ["tempdb.state"]
     sqlserver.database.tempdb.version_store.size:
       enabled: true
+    sqlserver.database.transactions.active:
+      enabled: true
+      attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: true
     sqlserver.index.search.rate:
+      enabled: true
+    sqlserver.kill_connection.error.rate:
       enabled: true
     sqlserver.latch.superlatch.count:
       enabled: true
@@ -84,7 +96,19 @@ all_set:
       enabled: true
     sqlserver.memory.usage:
       enabled: true
+    sqlserver.os.disk.size:
+      enabled: true
+    sqlserver.os.memory.usage:
+      enabled: true
+      attributes: ["memory.state"]
+    sqlserver.os.memory.utilization:
+      enabled: true
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: true
     sqlserver.os.wait.duration:
+      enabled: true
+      attributes: ["wait.category","wait.type"]
+    sqlserver.os.wait.tasks.count:
       enabled: true
       attributes: ["wait.category","wait.type"]
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -111,6 +135,9 @@ all_set:
     sqlserver.plan.execution.rate:
       enabled: true
       attributes: ["sqlserver.plan.guidance.result"]
+    sqlserver.process.count:
+      enabled: true
+      attributes: ["process.status"]
     sqlserver.processes.blocked:
       enabled: true
     sqlserver.recompilation.ratio:
@@ -183,6 +210,10 @@ reaggregate_set:
   metrics:
     sqlserver.attention.rate:
       enabled: true
+    sqlserver.batch.compilation.utilization:
+      enabled: true
+    sqlserver.batch.page_split.utilization:
+      enabled: true
     sqlserver.batch.request.rate:
       enabled: true
     sqlserver.batch.sql_compilation.rate:
@@ -214,6 +245,9 @@ reaggregate_set:
     sqlserver.database.operations:
       enabled: true
       attributes: []
+    sqlserver.database.page_file.size:
+      enabled: true
+      attributes: []
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: []
@@ -222,9 +256,14 @@ reaggregate_set:
       attributes: []
     sqlserver.database.tempdb.version_store.size:
       enabled: true
+    sqlserver.database.transactions.active:
+      enabled: true
+      attributes: []
     sqlserver.deadlock.rate:
       enabled: true
     sqlserver.index.search.rate:
+      enabled: true
+    sqlserver.kill_connection.error.rate:
       enabled: true
     sqlserver.latch.superlatch.count:
       enabled: true
@@ -264,7 +303,19 @@ reaggregate_set:
       enabled: true
     sqlserver.memory.usage:
       enabled: true
+    sqlserver.os.disk.size:
+      enabled: true
+    sqlserver.os.memory.usage:
+      enabled: true
+      attributes: []
+    sqlserver.os.memory.utilization:
+      enabled: true
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: true
     sqlserver.os.wait.duration:
+      enabled: true
+      attributes: []
+    sqlserver.os.wait.tasks.count:
       enabled: true
       attributes: []
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -289,6 +340,9 @@ reaggregate_set:
       enabled: true
       attributes: []
     sqlserver.plan.execution.rate:
+      enabled: true
+      attributes: []
+    sqlserver.process.count:
       enabled: true
       attributes: []
     sqlserver.processes.blocked:
@@ -363,6 +417,10 @@ none_set:
   metrics:
     sqlserver.attention.rate:
       enabled: false
+    sqlserver.batch.compilation.utilization:
+      enabled: false
+    sqlserver.batch.page_split.utilization:
+      enabled: false
     sqlserver.batch.request.rate:
       enabled: false
     sqlserver.batch.sql_compilation.rate:
@@ -394,6 +452,9 @@ none_set:
     sqlserver.database.operations:
       enabled: false
       attributes: ["physical_filename","logical_filename","file_type","direction"]
+    sqlserver.database.page_file.size:
+      enabled: false
+      attributes: ["db.namespace","page_file.state"]
     sqlserver.database.security.role_membership.count:
       enabled: false
       attributes: ["db.namespace","role"]
@@ -402,9 +463,14 @@ none_set:
       attributes: ["tempdb.state"]
     sqlserver.database.tempdb.version_store.size:
       enabled: false
+    sqlserver.database.transactions.active:
+      enabled: false
+      attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: false
     sqlserver.index.search.rate:
+      enabled: false
+    sqlserver.kill_connection.error.rate:
       enabled: false
     sqlserver.latch.superlatch.count:
       enabled: false
@@ -444,7 +510,19 @@ none_set:
       enabled: false
     sqlserver.memory.usage:
       enabled: false
+    sqlserver.os.disk.size:
+      enabled: false
+    sqlserver.os.memory.usage:
+      enabled: false
+      attributes: ["memory.state"]
+    sqlserver.os.memory.utilization:
+      enabled: false
+    sqlserver.os.scheduler.runnable_tasks.count:
+      enabled: false
     sqlserver.os.wait.duration:
+      enabled: false
+      attributes: ["wait.category","wait.type"]
+    sqlserver.os.wait.tasks.count:
       enabled: false
       attributes: ["wait.category","wait.type"]
     sqlserver.page.buffer_cache.free_list.stalls.rate:
@@ -471,6 +549,9 @@ none_set:
     sqlserver.plan.execution.rate:
       enabled: false
       attributes: ["sqlserver.plan.guidance.result"]
+    sqlserver.process.count:
+      enabled: false
+      attributes: ["process.status"]
     sqlserver.processes.blocked:
       enabled: false
     sqlserver.recompilation.ratio:

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -121,6 +121,11 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [target, total, sql_cache, optimizer, connection, granted_workspace, max_workspace]
+  memory.state:
+    description: The state of system memory observed by SQL Server.
+    type: string
+    requirement_level: recommended
+    enum: [available, total]
   network.peer.address:
     description: IP address of the peer client.
     type: string
@@ -140,6 +145,11 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [cache, total, target, database, stolen, reserved, free]
+  page_file.state:
+    description: The state of the database page file (reserved space) allocation.
+    type: string
+    requirement_level: recommended
+    enum: [used, free, total]
   performance_counter.object_name:
     description: Category to which this counter belongs
     type: string
@@ -148,6 +158,11 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  process.status:
+    description: The status of the SQL Server process/session.
+    type: string
+    requirement_level: recommended
+    enum: [background, dormant, preconnect, runnable, running, sleeping, suspended]
   replica.direction:
     description: The direction of flow of bytes for replica.
     type: string
@@ -476,6 +491,24 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.batch.compilation.utilization:
+    enabled: false
+    description: Number of SQL compilations per batch request.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.batch.page_split.utilization:
+    enabled: false
+    description: Number of page splits per batch request.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.batch.request.rate:
     enabled: true
     description: Number of batch requests received by SQL Server.
@@ -592,6 +625,16 @@ metrics:
       input_type: string
     attributes: [physical_filename, logical_filename, file_type, direction]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.page_file.size:
+    enabled: false
+    description: Reserved space allocated to the database, broken down by usage state.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, page_file.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -620,6 +663,16 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.database.transactions.active:
+    enabled: false
+    description: Number of active transactions in the database.
+    stability: development
+    unit: "{transactions}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.deadlock.rate:
     enabled: false
     description: Total number of deadlocks.
@@ -636,6 +689,15 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.kill_connection.error.rate:
+    enabled: false
+    description: Number of kill-connection errors per second.
+    stability: development
+    unit: "{errors}/s"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.latch.superlatch.count:
     enabled: false
     description: Number of superlatches currently active.
@@ -789,6 +851,45 @@ metrics:
       monotonic: false
       value_type: double
     attributes: []
+  sqlserver.os.disk.size:
+    enabled: false
+    description: Total disk space across volumes hosting SQL Server database files.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.memory.usage:
+    enabled: false
+    description: Amount of system physical memory observed by SQL Server.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [memory.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+  sqlserver.os.memory.utilization:
+    enabled: false
+    description: Fraction of system physical memory in use by the SQL Server process.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.scheduler.runnable_tasks.count:
+    enabled: false
+    description: Total number of runnable tasks across online schedulers.
+    stability: development
+    unit: "{tasks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.os.wait.duration:
     enabled: false
     description: Total wait time for this wait type
@@ -800,6 +901,18 @@ metrics:
       value_type: double
     attributes: [wait.category, wait.type]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.os.wait.tasks.count:
+    enabled: false
+    description: Cumulative number of tasks that have waited on this wait type since SQL Server startup.
+    stability: development
+    unit: "{tasks}"
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    attributes: [wait.category, wait.type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
   sqlserver.page.buffer_cache.free_list.stalls.rate:
     enabled: false
     description: Number of free list stalls.
@@ -880,6 +993,16 @@ metrics:
     gauge:
       value_type: double
     attributes: [sqlserver.plan.guidance.result]
+  sqlserver.process.count:
+    enabled: false
+    description: Number of SQL Server processes (user sessions), broken down by status.
+    stability: development
+    unit: "{processes}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [process.status]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
   sqlserver.processes.blocked:
     enabled: false
     description: The number of processes that are currently blocked

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -634,7 +634,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [db.namespace, page_file.state]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The page_file.state attribute breaks the value down by usage state (used, free, total).
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -870,7 +870,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [memory.state]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The memory.state attribute distinguishes total physical memory from currently available memory.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.os.memory.utilization:
     enabled: false
     description: Fraction of system physical memory in use by the SQL Server process.
@@ -912,7 +912,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [wait.category, wait.type]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Counterpart to sqlserver.os.wait.duration.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.page.buffer_cache.free_list.stalls.rate:
     enabled: false
     description: Number of free list stalls.
@@ -1002,7 +1002,7 @@ metrics:
       value_type: int
       input_type: string
     attributes: [process.status]
-    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. The process.status attribute reports background, dormant, preconnect, runnable, running, sleeping, or suspended. Use the existing sqlserver.processes.blocked metric for blocked-session counts.
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server. Use sqlserver.processes.blocked for blocked-session counts.
   sqlserver.processes.blocked:
     enabled: false
     description: The number of processes that are currently blocked

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -1423,8 +1423,8 @@ func getSQLServerProcessCountQuery(instanceName string) string {
 // UNION ALL because the sqlquery client only reads the first result set.
 const sqlServerDatabasePageFileQuery = `
 SET DEADLOCK_PRIORITY -10;
-IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
-	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size.';
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size (Azure SQL Database does not allow cross-database 3-part naming).';
 	RAISERROR (@ErrorMessage,11,1)
 	RETURN
 END

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -1274,3 +1274,199 @@ func getSQLServerDatabaseSecurityRoleMembersQuery(instanceName string) string {
 	r := strings.NewReplacer("{filter_instance_name}", "")
 	return r.Replace(sqlServerDatabaseSecurityRoleMembersQuery)
 }
+
+// sqlServerOSMemoryQuery returns physical memory statistics observed by the
+// SQL Server process. Requires sys.dm_os_sys_memory + sys.dm_os_process_memory,
+// which are unavailable on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSMemoryQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.dm_os_sys_memory; sqlserver.os.memory.* metrics require Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_memory' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(MAX(sys_mem.total_physical_memory_kb) * 1024 AS BIGINT) AS [total_physical_memory_bytes],
+	CAST(MAX(sys_mem.available_physical_memory_kb) * 1024 AS BIGINT) AS [available_physical_memory_bytes],
+	CAST(
+		CAST(MAX(proc_mem.physical_memory_in_use_kb) AS float)
+		/ NULLIF(CAST(MAX(sys_mem.total_physical_memory_kb) AS float), 0) AS float
+	) AS [memory_utilization]
+FROM sys.dm_os_process_memory proc_mem,
+     sys.dm_os_sys_memory sys_mem
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerOSMemoryQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSMemoryQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSMemoryQuery)
+}
+
+// sqlServerOSDiskQuery returns total disk space across volumes hosting SQL
+// Server database files. Requires sys.master_files + sys.dm_os_volume_stats,
+// which are unavailable on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSDiskQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.master_files / sys.dm_os_volume_stats; sqlserver.os.disk.size requires Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_disk' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(SUM(total_bytes) AS BIGINT) AS [total_disk_space_bytes]
+FROM (
+	SELECT DISTINCT
+		dovs.volume_mount_point,
+		dovs.total_bytes
+	FROM sys.master_files mf WITH (NOLOCK)
+	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+) drives
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerOSDiskQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSDiskQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSDiskQuery)
+}
+
+// sqlServerOSSchedulerRunnableTasksQuery returns the total number of runnable
+// tasks across visible online schedulers (sys.dm_os_schedulers). Unavailable
+// on Azure SQL Database (EngineEdition = 5).
+const sqlServerOSSchedulerRunnableTasksQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' does not support sys.dm_os_schedulers; sqlserver.os.scheduler.runnable_tasks.count requires Standard, Enterprise, Express, or Managed Instance.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_os_scheduler' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(SUM(runnable_tasks_count) AS BIGINT) AS [runnable_tasks_count]
+FROM sys.dm_os_schedulers WITH (NOLOCK)
+WHERE scheduler_id < 255
+	AND status = 'VISIBLE ONLINE'
+{filter_instance_name};
+`
+
+func getSQLServerOSSchedulerRunnableTasksQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
+}
+
+// sqlServerProcessCountQuery returns user-session counts pivoted by status.
+// Derived from sys.dm_exec_sessions (joined with sys.dm_exec_requests so that
+// an active request's status overrides the session-level status). Returns one
+// row with seven count columns.
+const sqlServerProcessCountQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.process.count.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_process_count' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(MAX(CASE WHEN status = 'background' THEN counts ELSE 0 END) AS BIGINT) AS [background],
+	CAST(MAX(CASE WHEN status = 'dormant'    THEN counts ELSE 0 END) AS BIGINT) AS [dormant],
+	CAST(MAX(CASE WHEN status = 'preconnect' THEN counts ELSE 0 END) AS BIGINT) AS [preconnect],
+	CAST(MAX(CASE WHEN status = 'runnable'   THEN counts ELSE 0 END) AS BIGINT) AS [runnable],
+	CAST(MAX(CASE WHEN status = 'running'    THEN counts ELSE 0 END) AS BIGINT) AS [running],
+	CAST(MAX(CASE WHEN status = 'sleeping'   THEN counts ELSE 0 END) AS BIGINT) AS [sleeping],
+	CAST(MAX(CASE WHEN status = 'suspended'  THEN counts ELSE 0 END) AS BIGINT) AS [suspended]
+FROM (
+	SELECT status, COUNT(*) AS counts FROM (
+		SELECT COALESCE(req.status, sess.status) AS status
+		FROM sys.dm_exec_sessions sess WITH (NOLOCK)
+		LEFT JOIN sys.dm_exec_requests req WITH (NOLOCK)
+			ON sess.session_id = req.session_id
+		WHERE sess.session_id > 50
+	) statuses
+	GROUP BY status
+) sessions
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerProcessCountQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerProcessCountQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerProcessCountQuery)
+}
+
+// sqlServerDatabasePageFileQuery returns total reserved space and used space
+// per online user database. The receiver derives the "free" datapoint as
+// (total - used). Executes per-database via dynamic SQL on the server side
+// so a single round-trip covers all online user databases.
+const sqlServerDatabasePageFileQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.page_file.size.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	N'USE ' + QUOTENAME(name) + N';' +
+	N'SELECT ''sqlserver_database_page_file'' AS [measurement],
+		REPLACE(@@SERVERNAME, ''\'', '':'') AS [sql_instance],
+		DB_NAME() AS [database_name],
+		CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes],
+		CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes]
+	FROM sys.partitions p WITH (NOLOCK)
+	INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id;' + CHAR(13)
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4  -- Exclude system databases (master, tempdb, model, msdb)
+	AND state = 0  -- Online only
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabasePageFileQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabasePageFileQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabasePageFileQuery)
+}

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -1275,9 +1275,7 @@ func getSQLServerDatabaseSecurityRoleMembersQuery(instanceName string) string {
 	return r.Replace(sqlServerDatabaseSecurityRoleMembersQuery)
 }
 
-// sqlServerOSMemoryQuery returns physical memory statistics observed by the
-// SQL Server process. Requires sys.dm_os_sys_memory + sys.dm_os_process_memory,
-// which are unavailable on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSMemoryQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1312,9 +1310,7 @@ func getSQLServerOSMemoryQuery(instanceName string) string {
 	return r.Replace(sqlServerOSMemoryQuery)
 }
 
-// sqlServerOSDiskQuery returns total disk space across volumes hosting SQL
-// Server database files. Requires sys.master_files + sys.dm_os_volume_stats,
-// which are unavailable on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSDiskQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1349,9 +1345,7 @@ func getSQLServerOSDiskQuery(instanceName string) string {
 	return r.Replace(sqlServerOSDiskQuery)
 }
 
-// sqlServerOSSchedulerRunnableTasksQuery returns the total number of runnable
-// tasks across visible online schedulers (sys.dm_os_schedulers). Unavailable
-// on Azure SQL Database (EngineEdition = 5).
+// Unavailable on Azure SQL Database (EngineEdition = 5).
 const sqlServerOSSchedulerRunnableTasksQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
@@ -1381,10 +1375,7 @@ func getSQLServerOSSchedulerRunnableTasksQuery(instanceName string) string {
 	return r.Replace(sqlServerOSSchedulerRunnableTasksQuery)
 }
 
-// sqlServerProcessCountQuery returns user-session counts pivoted by status.
-// Derived from sys.dm_exec_sessions (joined with sys.dm_exec_requests so that
-// an active request's status overrides the session-level status). Returns one
-// row with seven count columns.
+// Active request status (when present) overrides the session-level status.
 const sqlServerProcessCountQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
@@ -1428,10 +1419,8 @@ func getSQLServerProcessCountQuery(instanceName string) string {
 	return r.Replace(sqlServerProcessCountQuery)
 }
 
-// sqlServerDatabasePageFileQuery returns total reserved space and used space
-// per online user database. The receiver derives the "free" datapoint as
-// (total - used). Executes per-database via dynamic SQL on the server side
-// so a single round-trip covers all online user databases.
+// One row per online user database; receiver derives "used" as total - free.
+// UNION ALL because the sqlquery client only reads the first result set.
 const sqlServerDatabasePageFileQuery = `
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
@@ -1443,21 +1432,19 @@ END
 DECLARE @SQL nvarchar(max) = N'';
 
 SELECT @SQL = @SQL +
-	N'USE ' + QUOTENAME(name) + N';' +
-	N'SELECT ''sqlserver_database_page_file'' AS [measurement],
-		REPLACE(@@SERVERNAME, ''\'', '':'') AS [sql_instance],
-		DB_NAME() AS [database_name],
-		CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes],
-		CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes]
-	FROM sys.partitions p WITH (NOLOCK)
-	INNER JOIN sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id;' + CHAR(13)
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	N'CAST(SUM(a.total_pages) * 8 * 1024 AS BIGINT) AS [reserved_space_bytes], ' +
+	N'CAST((SUM(a.total_pages) - SUM(a.used_pages)) * 8 * 1024 AS BIGINT) AS [reserved_space_not_used_bytes] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.partitions p WITH (NOLOCK) ' +
+	N'INNER JOIN ' + QUOTENAME(name) + N'.sys.allocation_units a WITH (NOLOCK) ON p.partition_id = a.container_id'
 FROM sys.databases WITH (NOLOCK)
 WHERE database_id > 4  -- Exclude system databases (master, tempdb, model, msdb)
 	AND state = 0  -- Online only
 	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
 {filter_instance_name};
 
-EXEC sp_executesql @SQL;
+IF @SQL <> N'' EXEC sp_executesql @SQL;
 `
 
 func getSQLServerDatabasePageFileQuery(instanceName string) string {

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -136,6 +136,16 @@ func (s *sqlServerScraperHelper) ScrapeMetrics(ctx context.Context) (pmetric.Met
 		err = s.recordSecurityRoleMembersMetrics(ctx)
 	case getSQLServerDatabaseSecurityRoleMembersQuery(s.config.InstanceName):
 		err = s.recordDatabaseSecurityRoleMembersMetrics(ctx)
+	case getSQLServerOSMemoryQuery(s.config.InstanceName):
+		err = s.recordOSMemoryMetrics(ctx)
+	case getSQLServerOSDiskQuery(s.config.InstanceName):
+		err = s.recordOSDiskMetrics(ctx)
+	case getSQLServerOSSchedulerRunnableTasksQuery(s.config.InstanceName):
+		err = s.recordOSSchedulerMetrics(ctx)
+	case getSQLServerProcessCountQuery(s.config.InstanceName):
+		err = s.recordProcessCountMetrics(ctx)
+	case getSQLServerDatabasePageFileQuery(s.config.InstanceName):
+		err = s.recordDatabasePageFileMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -421,9 +431,11 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) er
 
 func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Context) error {
 	const counterKey = "counter"
+	const instanceKey = "instance"
 	const valueKey = "value"
 	// Constants are the columns for metrics from query
 	const activeTempTables = "Active Temp Tables"
+	const activeTransactions = "Active Transactions"
 	const autoParamAttemptsPerSec = "Auto-Param Attempts/sec"
 	const backupRestoreThroughputPerSec = "Backup/Restore Throughput/sec"
 	const batchRequestRate = "Batch Requests/sec"
@@ -434,6 +446,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const diskReadIOThrottled = "Disk Read IO Throttled/sec"
 	const diskWriteIOSec = "Disk Write IO/sec"
 	const diskWriteIOThrottled = "Disk Write IO Throttled/sec"
+	const errorsPerSec = "Errors/sec"
+	const killConnectionErrorsInstance = "Kill Connection Errors"
 	const executionErrors = "Execution Errors"
 	const failedAutoParamsPerSec = "Failed Auto-Params/sec"
 	const forcedParameterizationsPerSec = "Forced Parameterizations/sec"
@@ -453,6 +467,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const memoryGrantsPending = "Memory Grants Pending"
 	const pageLifeExpectancy = "Page life expectancy"
 	const pageLookupsPerSec = "Page lookups/sec"
+	const pageSplitsPerSec = "Page Splits/sec"
 	const processesBlocked = "Processes blocked"
 	const safeAutoParamsPerSec = "Safe Auto-Params/sec"
 	const sqlAttentionRate = "SQL Attention rate"
@@ -505,6 +520,16 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		recompRatioRow       sqlquery.StringMap
 	)
 
+	// Track batch-request, SQL-compilation and page-split rates so the derived
+	// sqlserver.batch.compilation.utilization and sqlserver.batch.page_split.utilization
+	// metrics can be emitted after the row loop. compRate / compSeen are reused
+	// from the recompilation block above.
+	var (
+		batchRate, pageSplitRate float64
+		batchSeen, pageSplitSeen bool
+		utilizationRow           sqlquery.StringMap
+	)
+
 	for i, row := range rows {
 		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
 
@@ -517,6 +542,15 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 			} else {
 				s.mb.RecordSqlserverTableCountDataPoint(now, val.(int64), metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
 			}
+		case activeTransactions:
+			// The Active Transactions counter from SQLServer:Databases is per-database;
+			// the SQL query selects all instances and "_Total". Skip the rollup; emit one
+			// datapoint per database with the database name in db.namespace.
+			dbName := row[instanceKey]
+			if dbName == "" || dbName == "Total" {
+				break
+			}
+			errs = append(errs, s.mb.RecordSqlserverDatabaseTransactionsActiveDataPoint(now, row[valueKey], dbName))
 		case backupRestoreThroughputPerSec:
 			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
@@ -532,6 +566,9 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverBatchRequestRateDataPoint(now, val.(float64))
+				batchRate = val.(float64)
+				batchSeen = true
+				utilizationRow = row
 			}
 		case bufferCacheHitRatio:
 			val, err := retrieveFloat(row, valueKey)
@@ -584,6 +621,20 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val.(int64))
+			}
+		case errorsPerSec:
+			// The SQLServer:SQL Errors / Errors/sec counter has multiple instances
+			// (User Errors, Kill Connection Errors, etc.). Only the Kill Connection
+			// Errors instance maps to a new metric.
+			if row[instanceKey] != killConnectionErrorsInstance {
+				break
+			}
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s/%s", i, err, errorsPerSec, killConnectionErrorsInstance)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverKillConnectionErrorRateDataPoint(now, val.(float64))
 			}
 		case freeListStalls:
 			val, err := retrieveInt(row, valueKey)
@@ -697,6 +748,21 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 			} else {
 				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val.(float64))
 			}
+		case pageSplitsPerSec:
+			// The Access Methods / Page Splits/sec counter is only emitted by the
+			// perf-counter query for instance_name = '_Total'. Capture for the
+			// sqlserver.batch.page_split.utilization derived metric.
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, pageSplitsPerSec)
+				errs = append(errs, err)
+			} else {
+				pageSplitRate = val.(float64)
+				pageSplitSeen = true
+				if utilizationRow == nil {
+					utilizationRow = row
+				}
+			}
 		case processesBlocked:
 			errs = append(errs, s.mb.RecordSqlserverProcessesBlockedDataPoint(now, row[valueKey]))
 		case sqlCompilationRate:
@@ -709,6 +775,9 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				compRate = val.(float64)
 				compSeen = true
 				recompRatioRow = row
+				if utilizationRow == nil {
+					utilizationRow = row
+				}
 			}
 		case sqlReCompilationsRate:
 			val, err := retrieveFloat(row, valueKey)
@@ -1008,6 +1077,25 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
+	// Emit derived sqlserver.batch.compilation.utilization and
+	// sqlserver.batch.page_split.utilization metrics once the source counters
+	// have been observed and the denominator (batch request rate) is nonzero.
+	if batchSeen && batchRate > 0 {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), utilizationRow)
+		emitted := false
+		if compSeen {
+			s.mb.RecordSqlserverBatchCompilationUtilizationDataPoint(now, compRate/batchRate)
+			emitted = true
+		}
+		if pageSplitSeen {
+			s.mb.RecordSqlserverBatchPageSplitUtilizationDataPoint(now, pageSplitRate/batchRate)
+			emitted = true
+		}
+		if emitted {
+			s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -1056,9 +1144,10 @@ func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context
 func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) error {
 	// Constants are the columns for metrics from query
 	const (
-		waitCategory = "wait_category"
-		waitTimeMs   = "wait_time_ms"
-		waitType     = "wait_type"
+		waitCategory      = "wait_category"
+		waitTimeMs        = "wait_time_ms"
+		waitType          = "wait_type"
+		waitingTasksCount = "waiting_tasks_count"
 	)
 
 	rows, err := s.client.QueryRows(ctx)
@@ -1083,6 +1172,8 @@ func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) 
 			// The value is divided here because it's stored in SQL Server in ms, need to convert to s
 			s.mb.RecordSqlserverOsWaitDurationDataPoint(now, val.(float64)/1e3, row[waitCategory], row[waitType])
 		}
+
+		errs = append(errs, s.mb.RecordSqlserverOsWaitTasksCountDataPoint(now, row[waitingTasksCount], row[waitCategory], row[waitType]))
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
@@ -1139,6 +1230,172 @@ func (s *sqlServerScraperHelper) recordDatabaseSizeMetrics(ctx context.Context) 
 
 		if err := s.mb.RecordSqlserverDatabaseFileSizeDataPoint(now, row[sizeBytes], row[fileType], row[databaseName]); err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse database file size for row %d: %w", i, err))
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSMemoryMetrics(ctx context.Context) error {
+	const (
+		totalBytes     = "total_physical_memory_bytes"
+		availableBytes = "available_physical_memory_bytes"
+		utilization    = "memory_utilization"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverOsMemoryUsageDataPoint(now, row[totalBytes], metadata.AttributeMemoryStateTotal),
+			s.mb.RecordSqlserverOsMemoryUsageDataPoint(now, row[availableBytes], metadata.AttributeMemoryStateAvailable),
+		)
+
+		if utilStr := row[utilization]; utilStr != "" {
+			val, parseErr := retrieveFloat(row, utilization)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s: %w", utilization, parseErr))
+			} else {
+				s.mb.RecordSqlserverOsMemoryUtilizationDataPoint(now, val.(float64))
+			}
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSDiskMetrics(ctx context.Context) error {
+	const totalDiskBytes = "total_disk_space_bytes"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		errs = append(errs, s.mb.RecordSqlserverOsDiskSizeDataPoint(now, row[totalDiskBytes]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordOSSchedulerMetrics(ctx context.Context) error {
+	const runnableTasksCount = "runnable_tasks_count"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		errs = append(errs, s.mb.RecordSqlserverOsSchedulerRunnableTasksCountDataPoint(now, row[runnableTasksCount]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordProcessCountMetrics(ctx context.Context) error {
+	statusColumns := []struct {
+		name  string
+		value metadata.AttributeProcessStatus
+	}{
+		{"background", metadata.AttributeProcessStatusBackground},
+		{"dormant", metadata.AttributeProcessStatusDormant},
+		{"preconnect", metadata.AttributeProcessStatusPreconnect},
+		{"runnable", metadata.AttributeProcessStatusRunnable},
+		{"running", metadata.AttributeProcessStatusRunning},
+		{"sleeping", metadata.AttributeProcessStatusSleeping},
+		{"suspended", metadata.AttributeProcessStatusSuspended},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		for _, col := range statusColumns {
+			errs = append(errs, s.mb.RecordSqlserverProcessCountDataPoint(now, row[col.name], col.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Context) error {
+	const (
+		databaseName              = "database_name"
+		reservedSpaceBytes        = "reserved_space_bytes"
+		reservedSpaceNotUsedBytes = "reserved_space_not_used_bytes"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+
+		totalVal, totalErr := retrieveInt(row, reservedSpaceBytes)
+		freeVal, freeErr := retrieveInt(row, reservedSpaceNotUsedBytes)
+		if totalErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", reservedSpaceBytes, i, totalErr))
+		}
+		if freeErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", reservedSpaceNotUsedBytes, i, freeErr))
+		}
+
+		if totalErr == nil {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, row[reservedSpaceBytes], row[databaseName], metadata.AttributePageFileStateTotal))
+		}
+		if freeErr == nil {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, row[reservedSpaceNotUsedBytes], row[databaseName], metadata.AttributePageFileStateFree))
+		}
+		if totalErr == nil && freeErr == nil {
+			usedBytes := max(totalVal.(int64)-freeVal.(int64), 0)
+			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, fmt.Sprintf("%d", usedBytes), row[databaseName], metadata.AttributePageFileStateUsed))
 		}
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -520,10 +520,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		recompRatioRow       sqlquery.StringMap
 	)
 
-	// Track batch-request, SQL-compilation and page-split rates so the derived
-	// sqlserver.batch.compilation.utilization and sqlserver.batch.page_split.utilization
-	// metrics can be emitted after the row loop. compRate / compSeen are reused
-	// from the recompilation block above.
+	// Source rates for the batch.*.utilization derived metrics; emitted after the loop.
 	var (
 		batchRate, pageSplitRate float64
 		batchSeen, pageSplitSeen bool
@@ -543,9 +540,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverTableCountDataPoint(now, val.(int64), metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
 			}
 		case activeTransactions:
-			// The Active Transactions counter from SQLServer:Databases is per-database;
-			// the SQL query selects all instances and "_Total". Skip the rollup; emit one
-			// datapoint per database with the database name in db.namespace.
+			// Per-database counter; skip the "_Total" rollup row.
 			dbName := row[instanceKey]
 			if dbName == "" || dbName == "Total" {
 				break
@@ -623,9 +618,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val.(int64))
 			}
 		case errorsPerSec:
-			// The SQLServer:SQL Errors / Errors/sec counter has multiple instances
-			// (User Errors, Kill Connection Errors, etc.). Only the Kill Connection
-			// Errors instance maps to a new metric.
+			// Errors/sec has multiple instances (User Errors, Kill Connection Errors, ...);
+			// only Kill Connection Errors maps to a metric.
 			if row[instanceKey] != killConnectionErrorsInstance {
 				break
 			}
@@ -749,9 +743,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val.(float64))
 			}
 		case pageSplitsPerSec:
-			// The Access Methods / Page Splits/sec counter is only emitted by the
-			// perf-counter query for instance_name = '_Total'. Capture for the
-			// sqlserver.batch.page_split.utilization derived metric.
+			// Captured here only to derive batch.page_split.utilization after the loop.
 			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, pageSplitsPerSec)
@@ -1077,9 +1069,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
-	// Emit derived sqlserver.batch.compilation.utilization and
-	// sqlserver.batch.page_split.utilization metrics once the source counters
-	// have been observed and the denominator (batch request rate) is nonzero.
+	// Emit derived batch.*.utilization once batch request rate is nonzero.
 	if batchSeen && batchRate > 0 {
 		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), utilizationRow)
 		emitted := false
@@ -1359,7 +1349,7 @@ func (s *sqlServerScraperHelper) recordProcessCountMetrics(ctx context.Context) 
 
 func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Context) error {
 	const (
-		databaseName              = "database_name"
+		databaseName              = "db_name"
 		reservedSpaceBytes        = "reserved_space_bytes"
 		reservedSpaceNotUsedBytes = "reserved_space_not_used_bytes"
 	)


### PR DESCRIPTION
Covers the PP/NRDOT enable_instance_metrics (15 entries), enable_database_metrics (3 entries), and enable_wait_time_metrics (1 entry) "Not Available" gaps from the Core Metrics audit. All new metrics disabled by default, stability=development, and require direct- DB connection. Same set added to receiver/sqlserver and receiver/nrsqlserver.

Reuses sqlServerPerformanceCountersQuery for active transactions, kill- connection errors, and the two utilization ratios; reuses sqlServerWaitStatsQuery for wait task counts; adds 5 small DMV queries for OS memory, OS disk, OS schedulers, process counts, and per-DB page-file space.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
<img width="1909" height="901" alt="Screenshot 2026-06-23 at 8 26 28 AM" src="https://github.com/user-attachments/assets/c5978a9b-ff5d-4357-8f9e-1c088156edda" />
<img width="1920" height="1080" alt="Screenshot 2026-06-23 at 8 26 36 AM (2)" src="https://github.com/user-attachments/assets/07f3de7e-00d1-4a61-9358-bf04689e92e4"  />
<img width="1889" height="700" alt="Screenshot 2026-06-23 at 8 28 45 AM" src="https://github.com/user-attachments/assets/83708a61-1c76-4d89-ae96-e5f9addbd655" />
<img width="1893" height="670" alt="Screenshot 2026-06-23 at 8 29 03 AM" src="https://github.com/user-attachments/assets/f8475cd2-79da-411e-9034-14d1cbc99622" />
<img width="1885" height="620" alt="Screenshot 2026-06-23 at 8 30 02 AM" src="https://github.com/user-attachments/assets/033eb137-aa9f-4bc8-b206-5577b1621c5b" />
<img width="1894" height="752" alt="Screenshot 2026-06-23 at 8 30 35 AM" src="https://github.com/user-attachments/assets/23fddcb9-a0be-41c4-b8d5-bc8a7be7c23f" />
<img width="1875" height="617" alt="Screenshot 2026-06-23 at 8 30 55 AM" src="https://github.com/user-attachments/assets/9af36656-640e-4cfd-9acc-bfd40a9a0f31" />
<img width="1903" height="780" alt="Screenshot 2026-06-23 at 8 31 20 AM" src="https://github.com/user-attachments/assets/a1127c81-39af-4256-adac-13a0a9f0098b" />
<img width="1917" height="848" alt="Screenshot 2026-06-23 at 8 32 26 AM" src="https://github.com/user-attachments/assets/7e47491f-0c1e-4c72-a378-6c4e5d2b1534" />
<img width="1861" height="681" alt="Screenshot 2026-06-23 at 8 34 36 AM" src="https://github.com/user-attachments/assets/2200bdc7-47a9-4656-b1d6-2b77d6f0a479" />
<img width="1876" height="636" alt="Screenshot 2026-06-23 at 8 48 46 AM" src="https://github.com/user-attachments/assets/1c4fd658-b0a4-4c62-b9cd-64bde163ec1e" />
<img width="1074" height="774" alt="Screenshot 2026-06-23 at 2 07 54 PM" src="https://github.com/user-attachments/assets/b4377429-5a0b-42b0-9738-0cdb5574addc" />
<img width="1076" height="774" alt="Screenshot 2026-06-23 at 2 01 56 PM" src="https://github.com/user-attachments/assets/9c4c9c9e-439b-4a0d-a4e9-55c7435e7c9b" />
<img width="1077" height="775" alt="Screenshot 2026-06-23 at 1 59 19 PM" src="https://github.com/user-attachments/assets/1c6d6452-a5dc-4cec-b466-83d66a63b671" />
<img width="1071" height="776" alt="Screenshot 2026-06-23 at 1 58 54 PM" src="https://github.com/user-attachments/assets/2b6536ab-693d-464c-a006-0358a809afc1" />
<img width="1073" height="783" alt="Screenshot 2026-06-23 at 1 58 18 PM" src="https://github.com/user-attachments/assets/87ce6cd2-2f14-454d-bd59-dc022080f6ec" />
