### PR TITLE
feat(sqlserver): add 31 opt-in metrics across lock, thread-pool, tempdb, failover-cluster, principals, role-membership, and transaction categories

### DIFF
--- a/.chloggen/sqlserver-security-and-perf-metrics.yaml
+++ b/.chloggen/sqlserver-security-and-perf-metrics.yaml
@@ -1,0 +1,53 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add 28 opt-in metrics across lock, thread-pool, tempdb, failover-cluster, database-principals, and database-role-membership categories.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48643]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext: |
+  New metrics (all disabled by default, `stability: development`, direct-DB connection mode only):
+    Lock:
+    - `sqlserver.lock.by_mode.count` (attr: `db.namespace`, `lock.mode`)
+    - `sqlserver.lock.by_resource.count` (attr: `db.namespace`, `lock.resource`)
+    Thread pool:
+    - `sqlserver.thread_pool.workers.count` (attr: `worker.state`)
+    - `sqlserver.thread_pool.workers.max`
+    - `sqlserver.thread_pool.workers.utilization`
+    - `sqlserver.thread_pool.tasks.count` (attr: `task.state`)
+    TempDB:
+    - `sqlserver.tempdb.allocation.wait_time.total` (attr: `allocation.page_type`)
+    - `sqlserver.tempdb.contention.waiters.count`
+    - `sqlserver.tempdb.data_files.count`
+    - `sqlserver.tempdb.file.size` (attr: `file_type`, `tempdb.file.id`)
+    - `sqlserver.tempdb.space.usage` (attr: `tempdb.space_kind`)
+    Failover cluster:
+    - `sqlserver.failover_cluster.ag.cluster_type` (attr: `ag.name`, `ag.cluster_type`)
+    - `sqlserver.failover_cluster.ag.failure_condition_level` (attr: `ag.name`)
+    - `sqlserver.failover_cluster.ag.health_check_timeout` (attr: `ag.name`)
+    - `sqlserver.failover_cluster.ag.required_sync_secondaries` (attr: `ag.name`)
+    - `sqlserver.failover_cluster.replica.role` (attr: `ag.name`, `replica.server_name`, `replica.role`)
+    - `sqlserver.failover_cluster.replica.synchronization_health` (attr: `ag.name`, `replica.server_name`, `replica.sync_health`)
+    - `sqlserver.failover_cluster.replica.flow_control_time`
+    - `sqlserver.failover_cluster.replica.database.queue_size` (attr: `ag.name`, `replica.server_name`, `db.namespace`, `replica.queue_kind`)
+    - `sqlserver.failover_cluster.replica.database.redo.rate` (attr: `ag.name`, `replica.server_name`, `db.namespace`)
+    Database principals:
+    - `sqlserver.database.principals.count` (attr: `db.namespace`, `principal.type`)
+    - `sqlserver.database.principals.recently_created` (attr: `db.namespace`)
+    - `sqlserver.database.principals.old` (attr: `db.namespace`)
+    - `sqlserver.database.principals.orphaned_users` (attr: `db.namespace`)
+    Database role membership:
+    - `sqlserver.database.role.members.count` (attr: `db.namespace`, `member.kind`)
+    - `sqlserver.database.role.memberships.count` (attr: `db.namespace`, `membership.kind`)
+    - `sqlserver.database.role.roles.count` (attr: `db.namespace`, `role.state`)
+    - `sqlserver.database.role.permission.risk_level` (attr: `db.namespace`, `role`)
+
+change_logs: [user]

--- a/docs/superpowers/specs/2026-06-23-sqlserver-lock-threadpool-tempdb-design.md
+++ b/docs/superpowers/specs/2026-06-23-sqlserver-lock-threadpool-tempdb-design.md
@@ -1,0 +1,276 @@
+# SQL Server: lock, thread pool, and tempdb metrics
+
+**Date:** 2026-06-23
+**Branch:** `lock-threadpool-tempdb-metrics` (cut from `sqlserver-core-metrics`)
+**Receivers touched:** `receiver/sqlserverreceiver` and `receiver/nrsqlserverreceiver`. Identical changes applied to both.
+**Prior work:** [2026-06-22-sqlserver-instance-database-metrics-design.md](2026-06-22-sqlserver-instance-database-metrics-design.md) — same conventions reused.
+
+## Background
+
+Confluence audit page 5734137875 catalogs metrics missing from the OTel `sqlserverreceiver` vs the existing New Relic SQL Server integration. PR #222 closed 19 entries across the instance, database, and wait-stats categories. This branch closes 30 more entries across `enable_lock_metrics` (20), `enable_thread_pool_metrics` (7), and `enable_tempdb_metrics` (3).
+
+## Goals
+
+- Cover all 30 missing entries across the 3 categories.
+- For TempDB, go beyond a basic 5-field snapshot — add the deeper signals a DBA needs to diagnose contention (object-type breakdown, per-file size, allocation-page wait split).
+- All new metrics disabled by default, `stability: development`, direct-DB connection only.
+- Names follow OTel semconv (lowercase dot-separated).
+- Same set mirrored to upstream `sqlserverreceiver` and the NR `nrsqlserverreceiver` fork.
+
+## Non-goals
+
+- Azure SQL Database edition-specific fallbacks. Queries that fail on Engine Edition 5 will fail-fast with a clear error.
+- PDH/perf-counter collection mode.
+- Backfilling entries the audit already classified as "Matching" (e.g. `latch.*`).
+
+## Metric catalog — 11 new metrics
+
+### Lock (2 metrics, covers 20 audit entries)
+
+| Metric | Type / unit | Attributes |
+|---|---|---|
+| `sqlserver.lock.by_mode.count` | gauge / `{locks}` | `db.namespace`, `lock.mode ∈ {shared, exclusive, update, intent, schema, bulk_update, shared_intent_exclusive}` |
+| `sqlserver.lock.by_resource.count` | gauge / `{locks}` | `db.namespace`, `lock.resource ∈ {key, page, row, table, extent, file, hobt, metadata, application, allocation_unit, database_level}` |
+
+The audit's `total` entries become NRQL aggregations (`SUM(...)`) over the attribute, so no separate `total` metric is needed.
+
+### Thread pool (4 metrics, covers 7 audit entries)
+
+| Metric | Type / unit | Attributes |
+|---|---|---|
+| `sqlserver.thread_pool.workers.count` | gauge / `{workers}` | `worker.state ∈ {running, suspended_or_sleeping}` |
+| `sqlserver.thread_pool.workers.max` | gauge / `{workers}` | — |
+| `sqlserver.thread_pool.workers.utilization` | gauge / `1` | — |
+| `sqlserver.thread_pool.tasks.count` | gauge / `{tasks}` | `task.state ∈ {current, queued, waiting_for_threadpool}` |
+
+`runnable_tasks` from the audit is already covered by `sqlserver.os.scheduler.runnable_tasks.count` (added in PR #222).
+
+### TempDB (5 metrics, covers 3 audit entries + 7 enrichment dims)
+
+| Metric | Type / unit | Attributes |
+|---|---|---|
+| `sqlserver.tempdb.allocation.wait_time.total` | sum (cumulative, monotonic) / `s` | `allocation.page_type ∈ {gam, sgam, pfs, other}` |
+| `sqlserver.tempdb.contention.waiters.count` | gauge / `{waiters}` | — |
+| `sqlserver.tempdb.data_files.count` | gauge / `{files}` | — |
+| `sqlserver.tempdb.file.size` | gauge / `By` | `file_type ∈ {data, log}`, `tempdb.file.id` |
+| `sqlserver.tempdb.space.usage` | gauge / `By` | `tempdb.space_kind ∈ {user_objects, internal_objects, version_store, free}` |
+
+`allocation.page_type` splits the allocation-waits bucket into the three pages that actually cause contention (GAM, SGAM, PFS) plus an `other` catch-all — different fixes apply to different ones. `tempdb.space_kind` from `sys.dm_db_file_space_usage` tells the operator whether tempdb is full of user temp tables, internal spills, version-store rows, or genuinely free — different fixes apply to each.
+
+### New enum attributes added to metadata.yaml
+
+```yaml
+allocation.page_type:
+  description: TempDB allocation-page wait type.
+  type: string
+  enum: [gam, sgam, pfs, other]
+lock.mode:
+  description: SQL Server lock request mode.
+  type: string
+  enum: [shared, exclusive, update, intent, schema, bulk_update, shared_intent_exclusive]
+lock.resource:
+  description: SQL Server lock resource type.
+  type: string
+  enum: [key, page, row, table, extent, file, hobt, metadata, application, allocation_unit, database_level]
+task.state:
+  description: SQL Server task state for thread-pool diagnostics.
+  type: string
+  enum: [current, queued, waiting_for_threadpool]
+tempdb.file.id:
+  description: Numeric file_id within tempdb (master_files.file_id).
+  type: int
+tempdb.space_kind:
+  description: TempDB space usage category.
+  type: string
+  enum: [user_objects, internal_objects, version_store, free]
+worker.state:
+  description: SQL Server worker state.
+  type: string
+  enum: [running, suspended_or_sleeping]
+```
+
+## Query strategy
+
+### Reuse: none
+
+None of the existing queries return the data we need at the granularity we need.
+
+### New (3 queries)
+
+#### `sqlServerLockQuery` (per-DB, both by_mode and by_resource in one rowset)
+
+```sql
+SELECT
+    DB_NAME(tl.resource_database_id) AS db_name,
+    -- by mode
+    SUM(CASE WHEN tl.request_mode IN ('S', 'IS')              THEN 1 ELSE 0 END) AS [shared],
+    SUM(CASE WHEN tl.request_mode IN ('X', 'IX')              THEN 1 ELSE 0 END) AS [exclusive],
+    SUM(CASE WHEN tl.request_mode IN ('U', 'IU', 'SIU', 'UIX') THEN 1 ELSE 0 END) AS [update_mode],
+    SUM(CASE WHEN tl.request_mode IN ('IS','IX','IU','SIU','SIX','UIX') THEN 1 ELSE 0 END) AS [intent],
+    SUM(CASE WHEN tl.request_mode IN ('Sch-S', 'Sch-M')        THEN 1 ELSE 0 END) AS [schema_mode],
+    SUM(CASE WHEN tl.request_mode = 'BU'                       THEN 1 ELSE 0 END) AS [bulk_update],
+    SUM(CASE WHEN tl.request_mode = 'SIX'                      THEN 1 ELSE 0 END) AS [shared_intent_exclusive],
+    -- by resource
+    SUM(CASE WHEN tl.resource_type = 'KEY'              THEN 1 ELSE 0 END) AS [res_key],
+    SUM(CASE WHEN tl.resource_type = 'PAGE'             THEN 1 ELSE 0 END) AS [res_page],
+    SUM(CASE WHEN tl.resource_type = 'RID'              THEN 1 ELSE 0 END) AS [res_row],
+    SUM(CASE WHEN tl.resource_type = 'OBJECT'           THEN 1 ELSE 0 END) AS [res_table],
+    SUM(CASE WHEN tl.resource_type = 'EXTENT'           THEN 1 ELSE 0 END) AS [res_extent],
+    SUM(CASE WHEN tl.resource_type = 'FILE'             THEN 1 ELSE 0 END) AS [res_file],
+    SUM(CASE WHEN tl.resource_type = 'HOBT'             THEN 1 ELSE 0 END) AS [res_hobt],
+    SUM(CASE WHEN tl.resource_type = 'METADATA'         THEN 1 ELSE 0 END) AS [res_metadata],
+    SUM(CASE WHEN tl.resource_type = 'APPLICATION'      THEN 1 ELSE 0 END) AS [res_application],
+    SUM(CASE WHEN tl.resource_type = 'ALLOCATION_UNIT'  THEN 1 ELSE 0 END) AS [res_allocation_unit],
+    SUM(CASE WHEN tl.resource_type = 'DATABASE'         THEN 1 ELSE 0 END) AS [res_database_level]
+FROM sys.dm_tran_locks tl WITH (NOLOCK)
+WHERE tl.resource_database_id > 0
+GROUP BY tl.resource_database_id
+HAVING COUNT(*) > 0;
+```
+
+One row per DB with active locks. Scraper emits both metrics from each row.
+
+#### `sqlServerThreadPoolQuery` (single row, all worker/task/scheduler stats)
+
+```sql
+WITH waits AS (
+    SELECT COUNT(*) AS waiting_for_threadpool
+    FROM sys.dm_os_waiting_tasks WITH (NOLOCK)
+    WHERE wait_type = 'THREADPOOL'
+),
+sched AS (
+    SELECT SUM(work_queue_count) AS work_queue, SUM(current_tasks_count) AS current_tasks
+    FROM sys.dm_os_schedulers WITH (NOLOCK)
+    WHERE scheduler_id < 255 AND status = 'VISIBLE ONLINE'
+),
+workers AS (
+    SELECT
+        SUM(CASE WHEN state = 'RUNNING' THEN 1 ELSE 0 END) AS running,
+        SUM(CASE WHEN state NOT IN ('RUNNING','RUNNABLE') THEN 1 ELSE 0 END) AS suspended_or_sleeping
+    FROM sys.dm_os_workers WITH (NOLOCK)
+),
+cfg AS (
+    SELECT max_workers_count AS max_workers FROM sys.dm_os_sys_info
+)
+SELECT
+    workers.running,
+    workers.suspended_or_sleeping,
+    cfg.max_workers,
+    CAST(workers.running AS float) / NULLIF(CAST(cfg.max_workers AS float), 0) AS utilization,
+    sched.current_tasks,
+    sched.work_queue,
+    waits.waiting_for_threadpool
+FROM waits, sched, workers, cfg;
+```
+
+#### `sqlServerTempDBQuery` (single rowset, multiple sections via CROSS JOIN)
+
+```sql
+WITH
+file_space AS (
+    SELECT
+        SUM(user_object_reserved_page_count)     * 8 * 1024 AS bytes_user_objects,
+        SUM(internal_object_reserved_page_count) * 8 * 1024 AS bytes_internal_objects,
+        SUM(version_store_reserved_page_count)   * 8 * 1024 AS bytes_version_store,
+        SUM(unallocated_extent_page_count)       * 8 * 1024 AS bytes_free
+    FROM tempdb.sys.dm_db_file_space_usage WITH (NOLOCK)
+),
+data_files AS (
+    SELECT COUNT(*) AS data_file_count
+    FROM sys.master_files WITH (NOLOCK)
+    WHERE database_id = 2 AND type = 0
+),
+waits AS (
+    SELECT
+        (SELECT COUNT(*) FROM sys.dm_os_wait_stats
+         WHERE wait_type IN ('PAGELATCH_IO','PAGELATCH_SH','PAGELATCH_EX','PAGELATCH_UP')
+           AND waiting_tasks_count > 0) AS pagelatch_waiters,
+        ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type LIKE '%GAM%'  AND wait_type NOT LIKE '%SGAM%'), 0) AS gam_ms,
+        ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type LIKE '%SGAM%'), 0) AS sgam_ms,
+        ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WHERE wait_type LIKE '%PFS%'),  0) AS pfs_ms,
+        ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats
+                WHERE wait_type LIKE '%ALLOCATION%' AND wait_type NOT LIKE '%GAM%' AND wait_type NOT LIKE '%SGAM%' AND wait_type NOT LIKE '%PFS%'), 0) AS other_ms
+)
+SELECT
+    file_space.bytes_user_objects,
+    file_space.bytes_internal_objects,
+    file_space.bytes_version_store,
+    file_space.bytes_free,
+    data_files.data_file_count,
+    waits.pagelatch_waiters,
+    waits.gam_ms, waits.sgam_ms, waits.pfs_ms, waits.other_ms
+FROM file_space, data_files, waits;
+```
+
+A separate query (`sqlServerTempDBFileQuery`) returns per-file sizes:
+
+```sql
+SELECT
+    file_id,
+    CASE type WHEN 0 THEN 'data' WHEN 1 THEN 'log' ELSE 'other' END AS file_type,
+    CAST(size AS BIGINT) * 8 * 1024 AS size_bytes
+FROM sys.master_files WITH (NOLOCK)
+WHERE database_id = 2 AND type IN (0, 1);
+```
+
+### Engine support
+
+All queries use DMVs available on Standard/Enterprise/Express (EngineEdition 2,3,4) and Managed Instance (8). Azure SQL Database (5) is excluded — `tempdb.sys.dm_db_file_space_usage` and `sys.master_files` can't be reached the same way from a user database on Azure SQL DB.
+
+## Scraper changes
+
+5 new scraper functions, one per query plus one per metric-emission family:
+
+| Function | Query | Metrics emitted |
+|---|---|---|
+| `recordLockMetrics` | `sqlServerLockQuery` | `sqlserver.lock.by_mode.count` (×7 / DB), `sqlserver.lock.by_resource.count` (×11 / DB) |
+| `recordThreadPoolMetrics` | `sqlServerThreadPoolQuery` | 4 thread-pool metrics |
+| `recordTempDBMetrics` | `sqlServerTempDBQuery` | `sqlserver.tempdb.allocation.wait_time.total` (×4), `sqlserver.tempdb.contention.waiters.count`, `sqlserver.tempdb.data_files.count`, `sqlserver.tempdb.space.usage` (×4) |
+| `recordTempDBFileMetrics` | `sqlServerTempDBFileQuery` | `sqlserver.tempdb.file.size` (one per file) |
+
+Each function follows the receiver's existing `recordXxxMetrics(ctx) error` pattern. Wired into `ScrapeMetrics` switch and `setupQueries`.
+
+### Enabled-gating
+
+Each scraper exits early when none of its target metrics are enabled, matching the pattern used in `recordOSMemoryMetrics`.
+
+## File touch list (per receiver)
+
+Applied identically to `receiver/sqlserverreceiver/` and `receiver/nrsqlserverreceiver/`:
+
+| File | Change |
+|---|---|
+| `metadata.yaml` | +7 attribute defs, +11 metric defs |
+| `queries.go` | +4 query consts (lock, threadpool, tempdb, tempdb-file) |
+| `scraper.go` | +4 record functions, +4 calls in `ScrapeMetrics` switch |
+| `factory.go` | +4 entries in `setupQueries` |
+| `factory_test.go` | bump expected metric count (77 → 88) |
+| `internal/metadata/generated_*.go` | regenerated by `mdatagen` |
+| `documentation.md` | regenerated by `mdatagen` |
+
+Plus `.chloggen/sqlserver-lock-threadpool-tempdb-metrics.yaml`.
+
+## Testing
+
+Same approach as PR #222: rely on the auto-generated `generated_metrics_test.go` for unit-level coverage of each new metric. No new fixture files unless `mdatagen` complains. Integration tests in `integration_test.go` are not modified — defaults are `enabled: false`, so existing baselines stay stable.
+
+### Pre-commit gate
+
+```bash
+cd receiver/sqlserverreceiver   && go generate ./... && make fmt && make gci && make lint && go test ./...
+cd receiver/nrsqlserverreceiver && go generate ./... && make fmt && make gci && make lint && go test ./...
+```
+
+All must pass.
+
+## Rollout
+
+1. Implement on `lock-threadpool-tempdb-metrics`.
+2. Local validation passes.
+3. PR to `sqlserver-core-metrics` (same target as PR #222).
+4. After merge, remaining categories from the audit:
+   - failover_cluster (10)
+   - database_principals (8)
+   - database_role_membership (11)
+
+That leaves 29 to go after this branch — done in a future PR.

--- a/receiver/nrsqlserverreceiver/documentation.md
+++ b/receiver/nrsqlserverreceiver/documentation.md
@@ -395,6 +395,139 @@ This metric is only available when the receiver is configured to directly connec
 | db.namespace | The database name. | Any Str | Recommended | - |
 | page_file.state | The state of the database page file (reserved space) allocation. | Str: ``used``, ``free``, ``total`` | Recommended | - |
 
+### sqlserver.database.principals.count
+
+Number of database security principals broken down by type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| principal.type | Database security principal type. | Str: ``sql_user``, ``windows_user``, ``role``, ``application_role``, ``certificate_mapped_user``, ``asymmetric_key_mapped_user`` | Recommended | - |
+
+### sqlserver.database.principals.old
+
+Number of database principals created more than one year ago.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.principals.orphaned_users
+
+Number of SQL users in the database that have no matching server login.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.principals.recently_created
+
+Number of database principals created in the last 30 days.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.role.members.count
+
+Number of database role members broken down by member kind.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {members} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| member.kind | Role-membership member breakdown bucket. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
+
+### sqlserver.database.role.memberships.count
+
+Number of database role memberships broken down by kind.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {memberships} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| membership.kind | Role-membership grouping bucket. | Str: ``active``, ``custom``, ``nested``, ``users`` | Recommended | - |
+
+### sqlserver.database.role.permission.risk_level
+
+Risk level assigned to each database role (1=low, 4=high).
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| role | The name of the database or server role. | Any Str | Recommended | - |
+
+### sqlserver.database.role.roles.count
+
+Number of database roles broken down by usage state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {roles} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| role.state | Database role usage state. | Str: ``empty``, ``with_members`` | Recommended | - |
+
 ### sqlserver.database.security.role_membership.count
 
 Number of members in a database role.
@@ -457,6 +590,154 @@ Total number of deadlocks.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {deadlocks}/s | Gauge | Double | Development |
+
+### sqlserver.failover_cluster.ag.cluster_type
+
+Cluster type of the Always-On Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| ag.cluster_type | Cluster type of the Always-On Availability Group. | Str: ``wsfc``, ``external``, ``none``, ``unknown`` | Recommended | - |
+
+### sqlserver.failover_cluster.ag.failure_condition_level
+
+Failure condition level configured for the Availability Group (1-5).
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.ag.health_check_timeout
+
+Health-check timeout configured for the Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.ag.required_sync_secondaries
+
+Number of synchronized secondary replicas required to commit on the Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {secondaries} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.replica.database.queue_size
+
+Size of the log-send or redo queue for an AG database replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| replica.queue_kind | Type of AG database-replica queue. | Str: ``log_send``, ``redo`` | Recommended | - |
+
+### sqlserver.failover_cluster.replica.database.redo.rate
+
+Redo rate for an AG database replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.replica.flow_control_time
+
+Cumulative time spent in AG flow control, in milliseconds per second observed.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Double | Development |
+
+### sqlserver.failover_cluster.replica.role
+
+Role of the availability replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| replica.role | Availability replica role. | Str: ``primary``, ``secondary``, ``resolving``, ``unknown`` | Recommended | - |
+
+### sqlserver.failover_cluster.replica.synchronization_health
+
+Synchronization health of the availability replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| replica.sync_health | Synchronization health of the availability replica. | Str: ``healthy``, ``partially_healthy``, ``not_healthy``, ``unknown`` | Recommended | - |
 
 ### sqlserver.index.search.rate
 
@@ -531,6 +812,40 @@ This metric is only available when the receiver is configured to directly connec
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Cumulative | true | Development |
+
+### sqlserver.lock.by_mode.count
+
+Number of currently active locks held in the database, grouped by lock mode.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| lock.mode | SQL Server lock request mode. | Str: ``shared``, ``exclusive``, ``update``, ``intent``, ``schema``, ``bulk_update``, ``shared_intent_exclusive`` | Recommended | - |
+
+### sqlserver.lock.by_resource.count
+
+Number of currently active locks held in the database, grouped by resource type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| lock.resource | SQL Server lock resource type. | Str: ``key``, ``page``, ``row``, ``table``, ``extent``, ``file``, ``hobt``, ``metadata``, ``application``, ``allocation_unit``, ``database_level`` | Recommended | - |
 
 ### sqlserver.lock.timeout.rate
 
@@ -889,6 +1204,127 @@ The number of tables.
 | table.state | The state of the table. | Str: ``active``, ``inactive`` | Recommended | - |
 | table.status | The status of the table. | Str: ``temporary``, ``permanent`` | Recommended | - |
 
+### sqlserver.tempdb.allocation.wait_time.total
+
+Cumulative wait time on tempdb allocation pages, broken down by page type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| allocation.page_type | TempDB allocation-page wait type. | Str: ``gam``, ``sgam``, ``pfs``, ``other`` | Recommended | - |
+
+### sqlserver.tempdb.contention.waiters.count
+
+Number of tempdb pagelatch wait types with at least one active waiter.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {waiters} | Gauge | Int | Development |
+
+### sqlserver.tempdb.data_files.count
+
+Number of tempdb data files configured on the instance.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {files} | Gauge | Int | Development |
+
+### sqlserver.tempdb.file.size
+
+Size of each tempdb data or log file.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| file_type | The type of file being monitored. | Any Str | Recommended | - |
+| tempdb.file.id | Numeric file_id within tempdb (sys.master_files.file_id). | Any Int | Recommended | - |
+
+### sqlserver.tempdb.space.usage
+
+Space used by tempdb, broken down by allocation category.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| tempdb.space_kind | TempDB space usage category. | Str: ``user_objects``, ``internal_objects``, ``version_store``, ``free`` | Recommended | - |
+
+### sqlserver.thread_pool.tasks.count
+
+Number of SQL Server tasks broken down by state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tasks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| task.state | SQL Server task state for thread-pool diagnostics. | Str: ``current``, ``queued``, ``waiting_for_threadpool`` | Recommended | - |
+
+### sqlserver.thread_pool.workers.count
+
+Number of SQL Server worker threads broken down by state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {workers} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| worker.state | SQL Server worker state. | Str: ``running``, ``suspended_or_sleeping`` | Recommended | - |
+
+### sqlserver.thread_pool.workers.max
+
+Maximum number of SQL Server worker threads configured on the instance.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {workers} | Gauge | Int | Development |
+
+### sqlserver.thread_pool.workers.utilization
+
+Fraction of configured SQL Server worker threads currently running.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
 ### sqlserver.transaction.delay
 
 Time consumed in transaction delays.
@@ -897,6 +1333,16 @@ Time consumed in transaction delays.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | ms | Sum | Double | Cumulative | false | Development |
 
+### sqlserver.transaction.longest_running_time
+
+Age in seconds of the longest currently-open transaction on the server.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
 ### sqlserver.transaction.mirror_write.rate
 
 Total number of mirror write transactions.
@@ -904,6 +1350,26 @@ Total number of mirror write transactions.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {transactions}/s | Gauge | Double | Development |
+
+### sqlserver.transaction.version_cleanup.rate
+
+Cumulative bytes cleaned from the tempdb version store.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Double | Cumulative | true | Development |
+
+### sqlserver.transaction.version_generation.rate
+
+Cumulative bytes of row versions written to the tempdb version store.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Double | Cumulative | true | Development |
 
 ## Default Events
 

--- a/receiver/nrsqlserverreceiver/documentation.md
+++ b/receiver/nrsqlserverreceiver/documentation.md
@@ -475,7 +475,7 @@ This metric is only available when the receiver is configured to directly connec
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | db.namespace | The database name. | Any Str | Recommended | - |
-| member.kind | Role-membership member breakdown bucket. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
+| member.kind | Role-membership member breakdown bucket. `high_privilege` covers db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
 
 ### sqlserver.database.role.memberships.count
 

--- a/receiver/nrsqlserverreceiver/factory.go
+++ b/receiver/nrsqlserverreceiver/factory.go
@@ -122,7 +122,116 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabasePageFileQuery(cfg.InstanceName))
 	}
 
+	if cfg.Metrics.SqlserverLockByModeCount.Enabled || cfg.Metrics.SqlserverLockByResourceCount.Enabled {
+		queries = append(queries, getSQLServerLockQuery(cfg.InstanceName))
+	}
+
+	if isThreadPoolQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerThreadPoolQuery(cfg.InstanceName))
+	}
+
+	if isTempDBQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerTempDBQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverTempdbFileSize.Enabled {
+		queries = append(queries, getSQLServerTempDBFileQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterAGQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterAGQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterReplicaQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterReplicaQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterReplicaDatabaseQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterReplicaDatabaseQuery(cfg.InstanceName))
+	}
+
+	if isDatabasePrincipalsQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerDatabasePrincipalsQuery(cfg.InstanceName))
+	}
+
+	if isDatabaseRoleMembershipQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerDatabaseRoleMembershipQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverDatabaseRolePermissionRiskLevel.Enabled {
+		queries = append(queries, getSQLServerDatabaseRoleRiskLevelQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverTransactionLongestRunningTime.Enabled {
+		queries = append(queries, getSQLServerLongestRunningTransactionQuery(cfg.InstanceName))
+	}
+
 	return queries
+}
+
+func isDatabasePrincipalsQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverDatabasePrincipalsCount.Enabled ||
+		metrics.SqlserverDatabasePrincipalsOld.Enabled ||
+		metrics.SqlserverDatabasePrincipalsOrphanedUsers.Enabled ||
+		metrics.SqlserverDatabasePrincipalsRecentlyCreated.Enabled
+}
+
+func isDatabaseRoleMembershipQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverDatabaseRoleMembersCount.Enabled ||
+		metrics.SqlserverDatabaseRoleMembershipsCount.Enabled ||
+		metrics.SqlserverDatabaseRoleRolesCount.Enabled
+}
+
+func isFailoverClusterAGQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterAgClusterType.Enabled ||
+		metrics.SqlserverFailoverClusterAgFailureConditionLevel.Enabled ||
+		metrics.SqlserverFailoverClusterAgHealthCheckTimeout.Enabled ||
+		metrics.SqlserverFailoverClusterAgRequiredSyncSecondaries.Enabled
+}
+
+func isFailoverClusterReplicaQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterReplicaRole.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaSynchronizationHealth.Enabled
+}
+
+func isFailoverClusterReplicaDatabaseQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterReplicaDatabaseQueueSize.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaDatabaseRedoRate.Enabled
+}
+
+func isThreadPoolQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverThreadPoolWorkersCount.Enabled ||
+		metrics.SqlserverThreadPoolWorkersMax.Enabled ||
+		metrics.SqlserverThreadPoolWorkersUtilization.Enabled ||
+		metrics.SqlserverThreadPoolTasksCount.Enabled
+}
+
+func isTempDBQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverTempdbAllocationWaitTimeTotal.Enabled ||
+		metrics.SqlserverTempdbContentionWaitersCount.Enabled ||
+		metrics.SqlserverTempdbDataFilesCount.Enabled ||
+		metrics.SqlserverTempdbSpaceUsage.Enabled
 }
 
 func setupLogQueries(cfg *Config) []string {
@@ -333,6 +442,9 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		metrics.SqlserverPageBufferCacheHitRatio.Enabled ||
 		metrics.SqlserverPageLookupRate.Enabled ||
 		metrics.SqlserverProcessesBlocked.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaFlowControlTime.Enabled ||
+		metrics.SqlserverTransactionVersionCleanupRate.Enabled ||
+		metrics.SqlserverTransactionVersionGenerationRate.Enabled ||
 		metrics.SqlserverReplicaDataRate.Enabled ||
 		metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
 		metrics.SqlserverResourcePoolDiskOperations.Enabled ||

--- a/receiver/nrsqlserverreceiver/factory_test.go
+++ b/receiver/nrsqlserverreceiver/factory_test.go
@@ -262,7 +262,7 @@ func TestSetupQueries(t *testing.T) {
 
 	metricsMetadata, ok := metadata["metrics"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, metricsMetadata, 78, "Every time metrics are added or removed, the function `setupQueries` must "+
+	require.Len(t, metricsMetadata, 109, "Every time metrics are added or removed, the function `setupQueries` must "+
 		"be modified to properly account for the change. Please update `setupQueries` and then, "+
 		"and only then, update the expected metric count here.")
 }

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_config.go
@@ -529,6 +529,395 @@ func (ms *SqlserverDatabasePageFileSizeMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverDatabasePrincipalsCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.count metric.
+type SqlserverDatabasePrincipalsCountMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace   SqlserverDatabasePrincipalsCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType SqlserverDatabasePrincipalsCountMetricAttributeKey = "principal.type"
+)
+
+// SqlserverDatabasePrincipalsCountMetricConfig provides config for the sqlserver.database.principals.count metric.
+type SqlserverDatabasePrincipalsCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.count doesn't have an attribute %v, valid attributes: [db.namespace, principal.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsOldMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.old metric.
+type SqlserverDatabasePrincipalsOldMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsOldMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsOldMetricConfig provides config for the sqlserver.database.principals.old metric.
+type SqlserverDatabasePrincipalsOldMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsOldMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsOldMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsOldMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.old doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.orphaned_users metric.
+type SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsOrphanedUsersMetricConfig provides config for the sqlserver.database.principals.orphaned_users metric.
+type SqlserverDatabasePrincipalsOrphanedUsersMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.orphaned_users doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.recently_created metric.
+type SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig provides config for the sqlserver.database.principals.recently_created metric.
+type SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.recently_created doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleMembersCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.members.count metric.
+type SqlserverDatabaseRoleMembersCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace SqlserverDatabaseRoleMembersCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind  SqlserverDatabaseRoleMembersCountMetricAttributeKey = "member.kind"
+)
+
+// SqlserverDatabaseRoleMembersCountMetricConfig provides config for the sqlserver.database.role.members.count metric.
+type SqlserverDatabaseRoleMembersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleMembersCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleMembersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleMembersCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.members.count doesn't have an attribute %v, valid attributes: [db.namespace, member.kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleMembershipsCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.memberships.count metric.
+type SqlserverDatabaseRoleMembershipsCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace    SqlserverDatabaseRoleMembershipsCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind SqlserverDatabaseRoleMembershipsCountMetricAttributeKey = "membership.kind"
+)
+
+// SqlserverDatabaseRoleMembershipsCountMetricConfig provides config for the sqlserver.database.role.memberships.count metric.
+type SqlserverDatabaseRoleMembershipsCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleMembershipsCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleMembershipsCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.memberships.count doesn't have an attribute %v, valid attributes: [db.namespace, membership.kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.permission.risk_level metric.
+type SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole        SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey = "role"
+)
+
+// SqlserverDatabaseRolePermissionRiskLevelMetricConfig provides config for the sqlserver.database.role.permission.risk_level metric.
+type SqlserverDatabaseRolePermissionRiskLevelMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRolePermissionRiskLevelMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRolePermissionRiskLevelMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.permission.risk_level doesn't have an attribute %v, valid attributes: [db.namespace, role]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleRolesCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.roles.count metric.
+type SqlserverDatabaseRoleRolesCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace SqlserverDatabaseRoleRolesCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState   SqlserverDatabaseRoleRolesCountMetricAttributeKey = "role.state"
+)
+
+// SqlserverDatabaseRoleRolesCountMetricConfig provides config for the sqlserver.database.role.roles.count metric.
+type SqlserverDatabaseRoleRolesCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleRolesCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleRolesCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleRolesCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.roles.count doesn't have an attribute %v, valid attributes: [db.namespace, role.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.security.role_membership.count metric.
 type SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey string
 
@@ -714,6 +1103,420 @@ func (ms *SqlserverDeadlockRateMetricConfig) Unmarshal(parser *confmap.Conf) err
 	return nil
 }
 
+// SqlserverFailoverClusterAgClusterTypeMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.cluster_type metric.
+type SqlserverFailoverClusterAgClusterTypeMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName        SqlserverFailoverClusterAgClusterTypeMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType SqlserverFailoverClusterAgClusterTypeMetricAttributeKey = "ag.cluster_type"
+)
+
+// SqlserverFailoverClusterAgClusterTypeMetricConfig provides config for the sqlserver.failover_cluster.ag.cluster_type metric.
+type SqlserverFailoverClusterAgClusterTypeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgClusterTypeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgClusterTypeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.cluster_type doesn't have an attribute %v, valid attributes: [ag.name, ag.cluster_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.failure_condition_level metric.
+type SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgFailureConditionLevelMetricConfig provides config for the sqlserver.failover_cluster.ag.failure_condition_level metric.
+type SqlserverFailoverClusterAgFailureConditionLevelMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.failure_condition_level doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.health_check_timeout metric.
+type SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig provides config for the sqlserver.failover_cluster.ag.health_check_timeout metric.
+type SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.health_check_timeout doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+type SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig provides config for the sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+type SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.required_sync_secondaries doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.database.queue_size metric.
+type SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace       SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "db.namespace"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind  SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "replica.queue_kind"
+)
+
+// SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig provides config for the sqlserver.failover_cluster.replica.database.queue_size metric.
+type SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.database.queue_size doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.database.redo.rate metric.
+type SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace       SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig provides config for the sqlserver.failover_cluster.replica.database.redo.rate metric.
+type SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.database.redo.rate doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig provides config for the sqlserver.failover_cluster.replica.flow_control_time metric.
+type SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaRoleMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.role metric.
+type SqlserverFailoverClusterReplicaRoleMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole       SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "replica.role"
+)
+
+// SqlserverFailoverClusterReplicaRoleMetricConfig provides config for the sqlserver.failover_cluster.replica.role metric.
+type SqlserverFailoverClusterReplicaRoleMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaRoleMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaRoleMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.role doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, replica.role]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.synchronization_health metric.
+type SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "replica.sync_health"
+)
+
+// SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig provides config for the sqlserver.failover_cluster.replica.synchronization_health metric.
+type SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.synchronization_health doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, replica.sync_health]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverIndexSearchRateMetricConfig provides config for the sqlserver.index.search.rate metric.
 type SqlserverIndexSearchRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -879,6 +1682,104 @@ func (ms *SqlserverLatchWaitTimeTotalMetricConfig) Unmarshal(parser *confmap.Con
 	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverLockByModeCountMetricAttributeKey specifies the key of an attribute for the sqlserver.lock.by_mode.count metric.
+type SqlserverLockByModeCountMetricAttributeKey string
+
+const (
+	SqlserverLockByModeCountMetricAttributeKeyDbNamespace SqlserverLockByModeCountMetricAttributeKey = "db.namespace"
+	SqlserverLockByModeCountMetricAttributeKeyLockMode    SqlserverLockByModeCountMetricAttributeKey = "lock.mode"
+)
+
+// SqlserverLockByModeCountMetricConfig provides config for the sqlserver.lock.by_mode.count metric.
+type SqlserverLockByModeCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverLockByModeCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverLockByModeCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverLockByModeCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode:
+		default:
+			return fmt.Errorf("metric sqlserver.lock.by_mode.count doesn't have an attribute %v, valid attributes: [db.namespace, lock.mode]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverLockByResourceCountMetricAttributeKey specifies the key of an attribute for the sqlserver.lock.by_resource.count metric.
+type SqlserverLockByResourceCountMetricAttributeKey string
+
+const (
+	SqlserverLockByResourceCountMetricAttributeKeyDbNamespace  SqlserverLockByResourceCountMetricAttributeKey = "db.namespace"
+	SqlserverLockByResourceCountMetricAttributeKeyLockResource SqlserverLockByResourceCountMetricAttributeKey = "lock.resource"
+)
+
+// SqlserverLockByResourceCountMetricConfig provides config for the sqlserver.lock.by_resource.count metric.
+type SqlserverLockByResourceCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverLockByResourceCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverLockByResourceCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverLockByResourceCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource:
+		default:
+			return fmt.Errorf("metric sqlserver.lock.by_resource.count doesn't have an attribute %v, valid attributes: [db.namespace, lock.resource]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
 	return nil
 }
 
@@ -2065,6 +2966,327 @@ func (ms *SqlserverTableCountMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.allocation.wait_time.total metric.
+type SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey string
+
+const (
+	SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey = "allocation.page_type"
+)
+
+// SqlserverTempdbAllocationWaitTimeTotalMetricConfig provides config for the sqlserver.tempdb.allocation.wait_time.total metric.
+type SqlserverTempdbAllocationWaitTimeTotalMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbAllocationWaitTimeTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbAllocationWaitTimeTotalMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.allocation.wait_time.total doesn't have an attribute %v, valid attributes: [allocation.page_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverTempdbContentionWaitersCountMetricConfig provides config for the sqlserver.tempdb.contention.waiters.count metric.
+type SqlserverTempdbContentionWaitersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTempdbContentionWaitersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTempdbDataFilesCountMetricConfig provides config for the sqlserver.tempdb.data_files.count metric.
+type SqlserverTempdbDataFilesCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTempdbDataFilesCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTempdbFileSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.file.size metric.
+type SqlserverTempdbFileSizeMetricAttributeKey string
+
+const (
+	SqlserverTempdbFileSizeMetricAttributeKeyFileType     SqlserverTempdbFileSizeMetricAttributeKey = "file_type"
+	SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID SqlserverTempdbFileSizeMetricAttributeKey = "tempdb.file.id"
+)
+
+// SqlserverTempdbFileSizeMetricConfig provides config for the sqlserver.tempdb.file.size metric.
+type SqlserverTempdbFileSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbFileSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbFileSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbFileSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.file.size doesn't have an attribute %v, valid attributes: [file_type, tempdb.file.id]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverTempdbSpaceUsageMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.space.usage metric.
+type SqlserverTempdbSpaceUsageMetricAttributeKey string
+
+const (
+	SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind SqlserverTempdbSpaceUsageMetricAttributeKey = "tempdb.space_kind"
+)
+
+// SqlserverTempdbSpaceUsageMetricConfig provides config for the sqlserver.tempdb.space.usage metric.
+type SqlserverTempdbSpaceUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbSpaceUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbSpaceUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbSpaceUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.space.usage doesn't have an attribute %v, valid attributes: [tempdb.space_kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolTasksCountMetricAttributeKey specifies the key of an attribute for the sqlserver.thread_pool.tasks.count metric.
+type SqlserverThreadPoolTasksCountMetricAttributeKey string
+
+const (
+	SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState SqlserverThreadPoolTasksCountMetricAttributeKey = "task.state"
+)
+
+// SqlserverThreadPoolTasksCountMetricConfig provides config for the sqlserver.thread_pool.tasks.count metric.
+type SqlserverThreadPoolTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverThreadPoolTasksCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverThreadPoolTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverThreadPoolTasksCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState:
+		default:
+			return fmt.Errorf("metric sqlserver.thread_pool.tasks.count doesn't have an attribute %v, valid attributes: [task.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolWorkersCountMetricAttributeKey specifies the key of an attribute for the sqlserver.thread_pool.workers.count metric.
+type SqlserverThreadPoolWorkersCountMetricAttributeKey string
+
+const (
+	SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState SqlserverThreadPoolWorkersCountMetricAttributeKey = "worker.state"
+)
+
+// SqlserverThreadPoolWorkersCountMetricConfig provides config for the sqlserver.thread_pool.workers.count metric.
+type SqlserverThreadPoolWorkersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverThreadPoolWorkersCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverThreadPoolWorkersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverThreadPoolWorkersCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState:
+		default:
+			return fmt.Errorf("metric sqlserver.thread_pool.workers.count doesn't have an attribute %v, valid attributes: [worker.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolWorkersMaxMetricConfig provides config for the sqlserver.thread_pool.workers.max metric.
+type SqlserverThreadPoolWorkersMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverThreadPoolWorkersMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverThreadPoolWorkersUtilizationMetricConfig provides config for the sqlserver.thread_pool.workers.utilization metric.
+type SqlserverThreadPoolWorkersUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverThreadPoolWorkersUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverTransactionDelayMetricConfig provides config for the sqlserver.transaction.delay metric.
 type SqlserverTransactionDelayMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -2072,6 +3294,26 @@ type SqlserverTransactionDelayMetricConfig struct {
 }
 
 func (ms *SqlserverTransactionDelayMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionLongestRunningTimeMetricConfig provides config for the sqlserver.transaction.longest_running_time metric.
+type SqlserverTransactionLongestRunningTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionLongestRunningTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -2112,6 +3354,46 @@ type SqlserverTransactionRateMetricConfig struct {
 }
 
 func (ms *SqlserverTransactionRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionVersionCleanupRateMetricConfig provides config for the sqlserver.transaction.version_cleanup.rate metric.
+type SqlserverTransactionVersionCleanupRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionVersionCleanupRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionVersionGenerationRateMetricConfig provides config for the sqlserver.transaction.version_generation.rate metric.
+type SqlserverTransactionVersionGenerationRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionVersionGenerationRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -2287,84 +3569,115 @@ func (ms *SqlserverUserConnectionCountMetricConfig) Unmarshal(parser *confmap.Co
 
 // MetricsConfig provides config for nrsqlserver metrics.
 type MetricsConfig struct {
-	SqlserverAttentionRate                       SqlserverAttentionRateMetricConfig                       `mapstructure:"sqlserver.attention.rate"`
-	SqlserverBatchCompilationUtilization         SqlserverBatchCompilationUtilizationMetricConfig         `mapstructure:"sqlserver.batch.compilation.utilization"`
-	SqlserverBatchPageSplitUtilization           SqlserverBatchPageSplitUtilizationMetricConfig           `mapstructure:"sqlserver.batch.page_split.utilization"`
-	SqlserverBatchRequestRate                    SqlserverBatchRequestRateMetricConfig                    `mapstructure:"sqlserver.batch.request.rate"`
-	SqlserverBatchSQLCompilationRate             SqlserverBatchSQLCompilationRateMetricConfig             `mapstructure:"sqlserver.batch.sql_compilation.rate"`
-	SqlserverBatchSQLRecompilationRate           SqlserverBatchSQLRecompilationRateMetricConfig           `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
-	SqlserverComputerUptime                      SqlserverComputerUptimeMetricConfig                      `mapstructure:"sqlserver.computer.uptime"`
-	SqlserverCPUCount                            SqlserverCPUCountMetricConfig                            `mapstructure:"sqlserver.cpu.count"`
-	SqlserverDatabaseBackupOrRestoreRate         SqlserverDatabaseBackupOrRestoreRateMetricConfig         `mapstructure:"sqlserver.database.backup_or_restore.rate"`
-	SqlserverDatabaseCount                       SqlserverDatabaseCountMetricConfig                       `mapstructure:"sqlserver.database.count"`
-	SqlserverDatabaseExecutionErrors             SqlserverDatabaseExecutionErrorsMetricConfig             `mapstructure:"sqlserver.database.execution.errors"`
-	SqlserverDatabaseFileSize                    SqlserverDatabaseFileSizeMetricConfig                    `mapstructure:"sqlserver.database.file.size"`
-	SqlserverDatabaseFullScanRate                SqlserverDatabaseFullScanRateMetricConfig                `mapstructure:"sqlserver.database.full_scan.rate"`
-	SqlserverDatabaseIo                          SqlserverDatabaseIoMetricConfig                          `mapstructure:"sqlserver.database.io"`
-	SqlserverDatabaseLatency                     SqlserverDatabaseLatencyMetricConfig                     `mapstructure:"sqlserver.database.latency"`
-	SqlserverDatabaseOperations                  SqlserverDatabaseOperationsMetricConfig                  `mapstructure:"sqlserver.database.operations"`
-	SqlserverDatabasePageFileSize                SqlserverDatabasePageFileSizeMetricConfig                `mapstructure:"sqlserver.database.page_file.size"`
-	SqlserverDatabaseSecurityRoleMembershipCount SqlserverDatabaseSecurityRoleMembershipCountMetricConfig `mapstructure:"sqlserver.database.security.role_membership.count"`
-	SqlserverDatabaseTempdbSpace                 SqlserverDatabaseTempdbSpaceMetricConfig                 `mapstructure:"sqlserver.database.tempdb.space"`
-	SqlserverDatabaseTempdbVersionStoreSize      SqlserverDatabaseTempdbVersionStoreSizeMetricConfig      `mapstructure:"sqlserver.database.tempdb.version_store.size"`
-	SqlserverDatabaseTransactionsActive          SqlserverDatabaseTransactionsActiveMetricConfig          `mapstructure:"sqlserver.database.transactions.active"`
-	SqlserverDeadlockRate                        SqlserverDeadlockRateMetricConfig                        `mapstructure:"sqlserver.deadlock.rate"`
-	SqlserverIndexSearchRate                     SqlserverIndexSearchRateMetricConfig                     `mapstructure:"sqlserver.index.search.rate"`
-	SqlserverKillConnectionErrorRate             SqlserverKillConnectionErrorRateMetricConfig             `mapstructure:"sqlserver.kill_connection.error.rate"`
-	SqlserverLatchSuperlatchCount                SqlserverLatchSuperlatchCountMetricConfig                `mapstructure:"sqlserver.latch.superlatch.count"`
-	SqlserverLatchSuperlatchTransitionRate       SqlserverLatchSuperlatchTransitionRateMetricConfig       `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
-	SqlserverLatchWaitRate                       SqlserverLatchWaitRateMetricConfig                       `mapstructure:"sqlserver.latch.wait.rate"`
-	SqlserverLatchWaitTimeAvg                    SqlserverLatchWaitTimeAvgMetricConfig                    `mapstructure:"sqlserver.latch.wait_time.avg"`
-	SqlserverLatchWaitTimeTotal                  SqlserverLatchWaitTimeTotalMetricConfig                  `mapstructure:"sqlserver.latch.wait_time.total"`
-	SqlserverLockTimeoutRate                     SqlserverLockTimeoutRateMetricConfig                     `mapstructure:"sqlserver.lock.timeout.rate"`
-	SqlserverLockWaitCount                       SqlserverLockWaitCountMetricConfig                       `mapstructure:"sqlserver.lock.wait.count"`
-	SqlserverLockWaitRate                        SqlserverLockWaitRateMetricConfig                        `mapstructure:"sqlserver.lock.wait.rate"`
-	SqlserverLockWaitTimeAvg                     SqlserverLockWaitTimeAvgMetricConfig                     `mapstructure:"sqlserver.lock.wait_time.avg"`
-	SqlserverLoginRate                           SqlserverLoginRateMetricConfig                           `mapstructure:"sqlserver.login.rate"`
-	SqlserverLogoutRate                          SqlserverLogoutRateMetricConfig                          `mapstructure:"sqlserver.logout.rate"`
-	SqlserverMemoryArea                          SqlserverMemoryAreaMetricConfig                          `mapstructure:"sqlserver.memory.area"`
-	SqlserverMemoryCacheObjectCount              SqlserverMemoryCacheObjectCountMetricConfig              `mapstructure:"sqlserver.memory.cache.object.count"`
-	SqlserverMemoryGrantsPendingCount            SqlserverMemoryGrantsPendingCountMetricConfig            `mapstructure:"sqlserver.memory.grants.pending.count"`
-	SqlserverMemoryPageCount                     SqlserverMemoryPageCountMetricConfig                     `mapstructure:"sqlserver.memory.page.count"`
-	SqlserverMemoryTarget                        SqlserverMemoryTargetMetricConfig                        `mapstructure:"sqlserver.memory.target"`
-	SqlserverMemoryUsage                         SqlserverMemoryUsageMetricConfig                         `mapstructure:"sqlserver.memory.usage"`
-	SqlserverOsDiskSize                          SqlserverOsDiskSizeMetricConfig                          `mapstructure:"sqlserver.os.disk.size"`
-	SqlserverOsMemoryUsage                       SqlserverOsMemoryUsageMetricConfig                       `mapstructure:"sqlserver.os.memory.usage"`
-	SqlserverOsMemoryUtilization                 SqlserverOsMemoryUtilizationMetricConfig                 `mapstructure:"sqlserver.os.memory.utilization"`
-	SqlserverOsSchedulerRunnableTasksCount       SqlserverOsSchedulerRunnableTasksCountMetricConfig       `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
-	SqlserverOsWaitDuration                      SqlserverOsWaitDurationMetricConfig                      `mapstructure:"sqlserver.os.wait.duration"`
-	SqlserverOsWaitTasksCount                    SqlserverOsWaitTasksCountMetricConfig                    `mapstructure:"sqlserver.os.wait.tasks.count"`
-	SqlserverPageBufferCacheFreeListStallsRate   SqlserverPageBufferCacheFreeListStallsRateMetricConfig   `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
-	SqlserverPageBufferCacheHitRatio             SqlserverPageBufferCacheHitRatioMetricConfig             `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
-	SqlserverPageCheckpointFlushRate             SqlserverPageCheckpointFlushRateMetricConfig             `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
-	SqlserverPageLazyWriteRate                   SqlserverPageLazyWriteRateMetricConfig                   `mapstructure:"sqlserver.page.lazy_write.rate"`
-	SqlserverPageLifeExpectancy                  SqlserverPageLifeExpectancyMetricConfig                  `mapstructure:"sqlserver.page.life_expectancy"`
-	SqlserverPageLookupRate                      SqlserverPageLookupRateMetricConfig                      `mapstructure:"sqlserver.page.lookup.rate"`
-	SqlserverPageOperationRate                   SqlserverPageOperationRateMetricConfig                   `mapstructure:"sqlserver.page.operation.rate"`
-	SqlserverPageSplitRate                       SqlserverPageSplitRateMetricConfig                       `mapstructure:"sqlserver.page.split.rate"`
-	SqlserverParameterizationRate                SqlserverParameterizationRateMetricConfig                `mapstructure:"sqlserver.parameterization.rate"`
-	SqlserverPlanExecutionRate                   SqlserverPlanExecutionRateMetricConfig                   `mapstructure:"sqlserver.plan.execution.rate"`
-	SqlserverProcessCount                        SqlserverProcessCountMetricConfig                        `mapstructure:"sqlserver.process.count"`
-	SqlserverProcessesBlocked                    SqlserverProcessesBlockedMetricConfig                    `mapstructure:"sqlserver.processes.blocked"`
-	SqlserverRecompilationRatio                  SqlserverRecompilationRatioMetricConfig                  `mapstructure:"sqlserver.recompilation.ratio"`
-	SqlserverReplicaDataRate                     SqlserverReplicaDataRateMetricConfig                     `mapstructure:"sqlserver.replica.data.rate"`
-	SqlserverResourcePoolDiskOperations          SqlserverResourcePoolDiskOperationsMetricConfig          `mapstructure:"sqlserver.resource_pool.disk.operations"`
-	SqlserverResourcePoolDiskThrottledReadRate   SqlserverResourcePoolDiskThrottledReadRateMetricConfig   `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
-	SqlserverResourcePoolDiskThrottledWriteRate  SqlserverResourcePoolDiskThrottledWriteRateMetricConfig  `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
-	SqlserverServerSecurityPrincipalCount        SqlserverServerSecurityPrincipalCountMetricConfig        `mapstructure:"sqlserver.server.security.principal.count"`
-	SqlserverServerSecurityRoleMembershipCount   SqlserverServerSecurityRoleMembershipCountMetricConfig   `mapstructure:"sqlserver.server.security.role_membership.count"`
-	SqlserverTableCount                          SqlserverTableCountMetricConfig                          `mapstructure:"sqlserver.table.count"`
-	SqlserverTransactionDelay                    SqlserverTransactionDelayMetricConfig                    `mapstructure:"sqlserver.transaction.delay"`
-	SqlserverTransactionMirrorWriteRate          SqlserverTransactionMirrorWriteRateMetricConfig          `mapstructure:"sqlserver.transaction.mirror_write.rate"`
-	SqlserverTransactionRate                     SqlserverTransactionRateMetricConfig                     `mapstructure:"sqlserver.transaction.rate"`
-	SqlserverTransactionWriteRate                SqlserverTransactionWriteRateMetricConfig                `mapstructure:"sqlserver.transaction.write.rate"`
-	SqlserverTransactionLogFlushDataRate         SqlserverTransactionLogFlushDataRateMetricConfig         `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
-	SqlserverTransactionLogFlushRate             SqlserverTransactionLogFlushRateMetricConfig             `mapstructure:"sqlserver.transaction_log.flush.rate"`
-	SqlserverTransactionLogFlushWaitRate         SqlserverTransactionLogFlushWaitRateMetricConfig         `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
-	SqlserverTransactionLogGrowthCount           SqlserverTransactionLogGrowthCountMetricConfig           `mapstructure:"sqlserver.transaction_log.growth.count"`
-	SqlserverTransactionLogShrinkCount           SqlserverTransactionLogShrinkCountMetricConfig           `mapstructure:"sqlserver.transaction_log.shrink.count"`
-	SqlserverTransactionLogUsage                 SqlserverTransactionLogUsageMetricConfig                 `mapstructure:"sqlserver.transaction_log.usage"`
-	SqlserverUserConnectionCount                 SqlserverUserConnectionCountMetricConfig                 `mapstructure:"sqlserver.user.connection.count"`
+	SqlserverAttentionRate                               SqlserverAttentionRateMetricConfig                               `mapstructure:"sqlserver.attention.rate"`
+	SqlserverBatchCompilationUtilization                 SqlserverBatchCompilationUtilizationMetricConfig                 `mapstructure:"sqlserver.batch.compilation.utilization"`
+	SqlserverBatchPageSplitUtilization                   SqlserverBatchPageSplitUtilizationMetricConfig                   `mapstructure:"sqlserver.batch.page_split.utilization"`
+	SqlserverBatchRequestRate                            SqlserverBatchRequestRateMetricConfig                            `mapstructure:"sqlserver.batch.request.rate"`
+	SqlserverBatchSQLCompilationRate                     SqlserverBatchSQLCompilationRateMetricConfig                     `mapstructure:"sqlserver.batch.sql_compilation.rate"`
+	SqlserverBatchSQLRecompilationRate                   SqlserverBatchSQLRecompilationRateMetricConfig                   `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
+	SqlserverComputerUptime                              SqlserverComputerUptimeMetricConfig                              `mapstructure:"sqlserver.computer.uptime"`
+	SqlserverCPUCount                                    SqlserverCPUCountMetricConfig                                    `mapstructure:"sqlserver.cpu.count"`
+	SqlserverDatabaseBackupOrRestoreRate                 SqlserverDatabaseBackupOrRestoreRateMetricConfig                 `mapstructure:"sqlserver.database.backup_or_restore.rate"`
+	SqlserverDatabaseCount                               SqlserverDatabaseCountMetricConfig                               `mapstructure:"sqlserver.database.count"`
+	SqlserverDatabaseExecutionErrors                     SqlserverDatabaseExecutionErrorsMetricConfig                     `mapstructure:"sqlserver.database.execution.errors"`
+	SqlserverDatabaseFileSize                            SqlserverDatabaseFileSizeMetricConfig                            `mapstructure:"sqlserver.database.file.size"`
+	SqlserverDatabaseFullScanRate                        SqlserverDatabaseFullScanRateMetricConfig                        `mapstructure:"sqlserver.database.full_scan.rate"`
+	SqlserverDatabaseIo                                  SqlserverDatabaseIoMetricConfig                                  `mapstructure:"sqlserver.database.io"`
+	SqlserverDatabaseLatency                             SqlserverDatabaseLatencyMetricConfig                             `mapstructure:"sqlserver.database.latency"`
+	SqlserverDatabaseOperations                          SqlserverDatabaseOperationsMetricConfig                          `mapstructure:"sqlserver.database.operations"`
+	SqlserverDatabasePageFileSize                        SqlserverDatabasePageFileSizeMetricConfig                        `mapstructure:"sqlserver.database.page_file.size"`
+	SqlserverDatabasePrincipalsCount                     SqlserverDatabasePrincipalsCountMetricConfig                     `mapstructure:"sqlserver.database.principals.count"`
+	SqlserverDatabasePrincipalsOld                       SqlserverDatabasePrincipalsOldMetricConfig                       `mapstructure:"sqlserver.database.principals.old"`
+	SqlserverDatabasePrincipalsOrphanedUsers             SqlserverDatabasePrincipalsOrphanedUsersMetricConfig             `mapstructure:"sqlserver.database.principals.orphaned_users"`
+	SqlserverDatabasePrincipalsRecentlyCreated           SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig           `mapstructure:"sqlserver.database.principals.recently_created"`
+	SqlserverDatabaseRoleMembersCount                    SqlserverDatabaseRoleMembersCountMetricConfig                    `mapstructure:"sqlserver.database.role.members.count"`
+	SqlserverDatabaseRoleMembershipsCount                SqlserverDatabaseRoleMembershipsCountMetricConfig                `mapstructure:"sqlserver.database.role.memberships.count"`
+	SqlserverDatabaseRolePermissionRiskLevel             SqlserverDatabaseRolePermissionRiskLevelMetricConfig             `mapstructure:"sqlserver.database.role.permission.risk_level"`
+	SqlserverDatabaseRoleRolesCount                      SqlserverDatabaseRoleRolesCountMetricConfig                      `mapstructure:"sqlserver.database.role.roles.count"`
+	SqlserverDatabaseSecurityRoleMembershipCount         SqlserverDatabaseSecurityRoleMembershipCountMetricConfig         `mapstructure:"sqlserver.database.security.role_membership.count"`
+	SqlserverDatabaseTempdbSpace                         SqlserverDatabaseTempdbSpaceMetricConfig                         `mapstructure:"sqlserver.database.tempdb.space"`
+	SqlserverDatabaseTempdbVersionStoreSize              SqlserverDatabaseTempdbVersionStoreSizeMetricConfig              `mapstructure:"sqlserver.database.tempdb.version_store.size"`
+	SqlserverDatabaseTransactionsActive                  SqlserverDatabaseTransactionsActiveMetricConfig                  `mapstructure:"sqlserver.database.transactions.active"`
+	SqlserverDeadlockRate                                SqlserverDeadlockRateMetricConfig                                `mapstructure:"sqlserver.deadlock.rate"`
+	SqlserverFailoverClusterAgClusterType                SqlserverFailoverClusterAgClusterTypeMetricConfig                `mapstructure:"sqlserver.failover_cluster.ag.cluster_type"`
+	SqlserverFailoverClusterAgFailureConditionLevel      SqlserverFailoverClusterAgFailureConditionLevelMetricConfig      `mapstructure:"sqlserver.failover_cluster.ag.failure_condition_level"`
+	SqlserverFailoverClusterAgHealthCheckTimeout         SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig         `mapstructure:"sqlserver.failover_cluster.ag.health_check_timeout"`
+	SqlserverFailoverClusterAgRequiredSyncSecondaries    SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig    `mapstructure:"sqlserver.failover_cluster.ag.required_sync_secondaries"`
+	SqlserverFailoverClusterReplicaDatabaseQueueSize     SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig     `mapstructure:"sqlserver.failover_cluster.replica.database.queue_size"`
+	SqlserverFailoverClusterReplicaDatabaseRedoRate      SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig      `mapstructure:"sqlserver.failover_cluster.replica.database.redo.rate"`
+	SqlserverFailoverClusterReplicaFlowControlTime       SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig       `mapstructure:"sqlserver.failover_cluster.replica.flow_control_time"`
+	SqlserverFailoverClusterReplicaRole                  SqlserverFailoverClusterReplicaRoleMetricConfig                  `mapstructure:"sqlserver.failover_cluster.replica.role"`
+	SqlserverFailoverClusterReplicaSynchronizationHealth SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig `mapstructure:"sqlserver.failover_cluster.replica.synchronization_health"`
+	SqlserverIndexSearchRate                             SqlserverIndexSearchRateMetricConfig                             `mapstructure:"sqlserver.index.search.rate"`
+	SqlserverKillConnectionErrorRate                     SqlserverKillConnectionErrorRateMetricConfig                     `mapstructure:"sqlserver.kill_connection.error.rate"`
+	SqlserverLatchSuperlatchCount                        SqlserverLatchSuperlatchCountMetricConfig                        `mapstructure:"sqlserver.latch.superlatch.count"`
+	SqlserverLatchSuperlatchTransitionRate               SqlserverLatchSuperlatchTransitionRateMetricConfig               `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
+	SqlserverLatchWaitRate                               SqlserverLatchWaitRateMetricConfig                               `mapstructure:"sqlserver.latch.wait.rate"`
+	SqlserverLatchWaitTimeAvg                            SqlserverLatchWaitTimeAvgMetricConfig                            `mapstructure:"sqlserver.latch.wait_time.avg"`
+	SqlserverLatchWaitTimeTotal                          SqlserverLatchWaitTimeTotalMetricConfig                          `mapstructure:"sqlserver.latch.wait_time.total"`
+	SqlserverLockByModeCount                             SqlserverLockByModeCountMetricConfig                             `mapstructure:"sqlserver.lock.by_mode.count"`
+	SqlserverLockByResourceCount                         SqlserverLockByResourceCountMetricConfig                         `mapstructure:"sqlserver.lock.by_resource.count"`
+	SqlserverLockTimeoutRate                             SqlserverLockTimeoutRateMetricConfig                             `mapstructure:"sqlserver.lock.timeout.rate"`
+	SqlserverLockWaitCount                               SqlserverLockWaitCountMetricConfig                               `mapstructure:"sqlserver.lock.wait.count"`
+	SqlserverLockWaitRate                                SqlserverLockWaitRateMetricConfig                                `mapstructure:"sqlserver.lock.wait.rate"`
+	SqlserverLockWaitTimeAvg                             SqlserverLockWaitTimeAvgMetricConfig                             `mapstructure:"sqlserver.lock.wait_time.avg"`
+	SqlserverLoginRate                                   SqlserverLoginRateMetricConfig                                   `mapstructure:"sqlserver.login.rate"`
+	SqlserverLogoutRate                                  SqlserverLogoutRateMetricConfig                                  `mapstructure:"sqlserver.logout.rate"`
+	SqlserverMemoryArea                                  SqlserverMemoryAreaMetricConfig                                  `mapstructure:"sqlserver.memory.area"`
+	SqlserverMemoryCacheObjectCount                      SqlserverMemoryCacheObjectCountMetricConfig                      `mapstructure:"sqlserver.memory.cache.object.count"`
+	SqlserverMemoryGrantsPendingCount                    SqlserverMemoryGrantsPendingCountMetricConfig                    `mapstructure:"sqlserver.memory.grants.pending.count"`
+	SqlserverMemoryPageCount                             SqlserverMemoryPageCountMetricConfig                             `mapstructure:"sqlserver.memory.page.count"`
+	SqlserverMemoryTarget                                SqlserverMemoryTargetMetricConfig                                `mapstructure:"sqlserver.memory.target"`
+	SqlserverMemoryUsage                                 SqlserverMemoryUsageMetricConfig                                 `mapstructure:"sqlserver.memory.usage"`
+	SqlserverOsDiskSize                                  SqlserverOsDiskSizeMetricConfig                                  `mapstructure:"sqlserver.os.disk.size"`
+	SqlserverOsMemoryUsage                               SqlserverOsMemoryUsageMetricConfig                               `mapstructure:"sqlserver.os.memory.usage"`
+	SqlserverOsMemoryUtilization                         SqlserverOsMemoryUtilizationMetricConfig                         `mapstructure:"sqlserver.os.memory.utilization"`
+	SqlserverOsSchedulerRunnableTasksCount               SqlserverOsSchedulerRunnableTasksCountMetricConfig               `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
+	SqlserverOsWaitDuration                              SqlserverOsWaitDurationMetricConfig                              `mapstructure:"sqlserver.os.wait.duration"`
+	SqlserverOsWaitTasksCount                            SqlserverOsWaitTasksCountMetricConfig                            `mapstructure:"sqlserver.os.wait.tasks.count"`
+	SqlserverPageBufferCacheFreeListStallsRate           SqlserverPageBufferCacheFreeListStallsRateMetricConfig           `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
+	SqlserverPageBufferCacheHitRatio                     SqlserverPageBufferCacheHitRatioMetricConfig                     `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
+	SqlserverPageCheckpointFlushRate                     SqlserverPageCheckpointFlushRateMetricConfig                     `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
+	SqlserverPageLazyWriteRate                           SqlserverPageLazyWriteRateMetricConfig                           `mapstructure:"sqlserver.page.lazy_write.rate"`
+	SqlserverPageLifeExpectancy                          SqlserverPageLifeExpectancyMetricConfig                          `mapstructure:"sqlserver.page.life_expectancy"`
+	SqlserverPageLookupRate                              SqlserverPageLookupRateMetricConfig                              `mapstructure:"sqlserver.page.lookup.rate"`
+	SqlserverPageOperationRate                           SqlserverPageOperationRateMetricConfig                           `mapstructure:"sqlserver.page.operation.rate"`
+	SqlserverPageSplitRate                               SqlserverPageSplitRateMetricConfig                               `mapstructure:"sqlserver.page.split.rate"`
+	SqlserverParameterizationRate                        SqlserverParameterizationRateMetricConfig                        `mapstructure:"sqlserver.parameterization.rate"`
+	SqlserverPlanExecutionRate                           SqlserverPlanExecutionRateMetricConfig                           `mapstructure:"sqlserver.plan.execution.rate"`
+	SqlserverProcessCount                                SqlserverProcessCountMetricConfig                                `mapstructure:"sqlserver.process.count"`
+	SqlserverProcessesBlocked                            SqlserverProcessesBlockedMetricConfig                            `mapstructure:"sqlserver.processes.blocked"`
+	SqlserverRecompilationRatio                          SqlserverRecompilationRatioMetricConfig                          `mapstructure:"sqlserver.recompilation.ratio"`
+	SqlserverReplicaDataRate                             SqlserverReplicaDataRateMetricConfig                             `mapstructure:"sqlserver.replica.data.rate"`
+	SqlserverResourcePoolDiskOperations                  SqlserverResourcePoolDiskOperationsMetricConfig                  `mapstructure:"sqlserver.resource_pool.disk.operations"`
+	SqlserverResourcePoolDiskThrottledReadRate           SqlserverResourcePoolDiskThrottledReadRateMetricConfig           `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
+	SqlserverResourcePoolDiskThrottledWriteRate          SqlserverResourcePoolDiskThrottledWriteRateMetricConfig          `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
+	SqlserverServerSecurityPrincipalCount                SqlserverServerSecurityPrincipalCountMetricConfig                `mapstructure:"sqlserver.server.security.principal.count"`
+	SqlserverServerSecurityRoleMembershipCount           SqlserverServerSecurityRoleMembershipCountMetricConfig           `mapstructure:"sqlserver.server.security.role_membership.count"`
+	SqlserverTableCount                                  SqlserverTableCountMetricConfig                                  `mapstructure:"sqlserver.table.count"`
+	SqlserverTempdbAllocationWaitTimeTotal               SqlserverTempdbAllocationWaitTimeTotalMetricConfig               `mapstructure:"sqlserver.tempdb.allocation.wait_time.total"`
+	SqlserverTempdbContentionWaitersCount                SqlserverTempdbContentionWaitersCountMetricConfig                `mapstructure:"sqlserver.tempdb.contention.waiters.count"`
+	SqlserverTempdbDataFilesCount                        SqlserverTempdbDataFilesCountMetricConfig                        `mapstructure:"sqlserver.tempdb.data_files.count"`
+	SqlserverTempdbFileSize                              SqlserverTempdbFileSizeMetricConfig                              `mapstructure:"sqlserver.tempdb.file.size"`
+	SqlserverTempdbSpaceUsage                            SqlserverTempdbSpaceUsageMetricConfig                            `mapstructure:"sqlserver.tempdb.space.usage"`
+	SqlserverThreadPoolTasksCount                        SqlserverThreadPoolTasksCountMetricConfig                        `mapstructure:"sqlserver.thread_pool.tasks.count"`
+	SqlserverThreadPoolWorkersCount                      SqlserverThreadPoolWorkersCountMetricConfig                      `mapstructure:"sqlserver.thread_pool.workers.count"`
+	SqlserverThreadPoolWorkersMax                        SqlserverThreadPoolWorkersMaxMetricConfig                        `mapstructure:"sqlserver.thread_pool.workers.max"`
+	SqlserverThreadPoolWorkersUtilization                SqlserverThreadPoolWorkersUtilizationMetricConfig                `mapstructure:"sqlserver.thread_pool.workers.utilization"`
+	SqlserverTransactionDelay                            SqlserverTransactionDelayMetricConfig                            `mapstructure:"sqlserver.transaction.delay"`
+	SqlserverTransactionLongestRunningTime               SqlserverTransactionLongestRunningTimeMetricConfig               `mapstructure:"sqlserver.transaction.longest_running_time"`
+	SqlserverTransactionMirrorWriteRate                  SqlserverTransactionMirrorWriteRateMetricConfig                  `mapstructure:"sqlserver.transaction.mirror_write.rate"`
+	SqlserverTransactionRate                             SqlserverTransactionRateMetricConfig                             `mapstructure:"sqlserver.transaction.rate"`
+	SqlserverTransactionVersionCleanupRate               SqlserverTransactionVersionCleanupRateMetricConfig               `mapstructure:"sqlserver.transaction.version_cleanup.rate"`
+	SqlserverTransactionVersionGenerationRate            SqlserverTransactionVersionGenerationRateMetricConfig            `mapstructure:"sqlserver.transaction.version_generation.rate"`
+	SqlserverTransactionWriteRate                        SqlserverTransactionWriteRateMetricConfig                        `mapstructure:"sqlserver.transaction.write.rate"`
+	SqlserverTransactionLogFlushDataRate                 SqlserverTransactionLogFlushDataRateMetricConfig                 `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
+	SqlserverTransactionLogFlushRate                     SqlserverTransactionLogFlushRateMetricConfig                     `mapstructure:"sqlserver.transaction_log.flush.rate"`
+	SqlserverTransactionLogFlushWaitRate                 SqlserverTransactionLogFlushWaitRateMetricConfig                 `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
+	SqlserverTransactionLogGrowthCount                   SqlserverTransactionLogGrowthCountMetricConfig                   `mapstructure:"sqlserver.transaction_log.growth.count"`
+	SqlserverTransactionLogShrinkCount                   SqlserverTransactionLogShrinkCountMetricConfig                   `mapstructure:"sqlserver.transaction_log.shrink.count"`
+	SqlserverTransactionLogUsage                         SqlserverTransactionLogUsageMetricConfig                         `mapstructure:"sqlserver.transaction_log.usage"`
+	SqlserverUserConnectionCount                         SqlserverUserConnectionCountMetricConfig                         `mapstructure:"sqlserver.user.connection.count"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -2432,6 +3745,46 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 		},
+		SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+		},
+		SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+		},
+		SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+		},
+		SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+		},
+		SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+		},
 		SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
@@ -2452,6 +3805,49 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 			Enabled: false,
+		},
+		SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+		},
+		SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+		},
+		SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+		},
+		SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+			Enabled: false,
+		},
+		SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+		},
+		SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 		},
 		SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 			Enabled: false,
@@ -2475,6 +3871,16 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 			Enabled: false,
+		},
+		SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+		},
+		SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 		},
 		SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 			Enabled: false,
@@ -2620,7 +4026,47 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 		},
+		SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+		},
+		SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+		},
+		SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+		},
+		SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+		},
+		SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+		},
+		SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+			Enabled: false,
+		},
+		SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+			Enabled: false,
+		},
 		SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 			Enabled: false,
 		},
 		SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
@@ -2628,6 +4074,12 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
 			Enabled: true,
+		},
+		SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
+			Enabled: false,
 		},
 		SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
 			Enabled: true,

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_config_test.go
@@ -90,6 +90,46 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 					},
+					SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+					},
+					SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+					},
+					SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+					},
+					SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+					},
+					SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -110,6 +150,49 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: true,
+					},
+					SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+					},
+					SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+					},
+					SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+					},
+					SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+						Enabled: true,
+					},
+					SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+					},
+					SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 						Enabled: true,
@@ -133,6 +216,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 						Enabled: true,
+					},
+					SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+					},
+					SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 					},
 					SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 						Enabled: true,
@@ -278,13 +371,59 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 					},
+					SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+					},
+					SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+					},
+					SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+					},
+					SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+					},
+					SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+					},
+					SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+						Enabled: true,
+					},
+					SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+						Enabled: true,
+					},
 					SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
@@ -392,6 +531,46 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 					},
+					SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+					},
+					SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+					},
+					SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+					},
+					SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+					},
+					SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -412,6 +591,49 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: false,
+					},
+					SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+					},
+					SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+					},
+					SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+					},
+					SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+						Enabled: false,
+					},
+					SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+					},
+					SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 						Enabled: false,
@@ -435,6 +657,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 						Enabled: false,
+					},
+					SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+					},
+					SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 					},
 					SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 						Enabled: false,
@@ -580,13 +812,59 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 					},
+					SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+					},
+					SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+					},
+					SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+					},
+					SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+					},
+					SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+					},
+					SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+						Enabled: false,
+					},
+					SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+						Enabled: false,
+					},
 					SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
@@ -631,7 +909,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabasePrincipalsCountMetricConfig{}, SqlserverDatabasePrincipalsOldMetricConfig{}, SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{}, SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{}, SqlserverDatabaseRoleMembersCountMetricConfig{}, SqlserverDatabaseRoleMembershipsCountMetricConfig{}, SqlserverDatabaseRolePermissionRiskLevelMetricConfig{}, SqlserverDatabaseRoleRolesCountMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverFailoverClusterAgClusterTypeMetricConfig{}, SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{}, SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{}, SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{}, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{}, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{}, SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{}, SqlserverFailoverClusterReplicaRoleMetricConfig{}, SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockByModeCountMetricConfig{}, SqlserverLockByResourceCountMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTempdbAllocationWaitTimeTotalMetricConfig{}, SqlserverTempdbContentionWaitersCountMetricConfig{}, SqlserverTempdbDataFilesCountMetricConfig{}, SqlserverTempdbFileSizeMetricConfig{}, SqlserverTempdbSpaceUsageMetricConfig{}, SqlserverThreadPoolTasksCountMetricConfig{}, SqlserverThreadPoolWorkersCountMetricConfig{}, SqlserverThreadPoolWorkersMaxMetricConfig{}, SqlserverThreadPoolWorkersUtilizationMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionLongestRunningTimeMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionVersionCleanupRateMetricConfig{}, SqlserverTransactionVersionGenerationRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -709,6 +987,102 @@ func TestSqlserverDatabasePageFileSizeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverDatabasePrincipalsCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.count doesn't have an attribute invalid, valid attributes: [db.namespace, principal.type]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsOldMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsOld
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsOldMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.old doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsOld
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsOrphanedUsersMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsOrphanedUsers
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.orphaned_users doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsOrphanedUsers
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsRecentlyCreatedMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsRecentlyCreated
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.recently_created doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsRecentlyCreated
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleMembersCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleMembersCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleMembersCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.members.count doesn't have an attribute invalid, valid attributes: [db.namespace, member.kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleMembersCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleMembershipsCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleMembershipsCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.memberships.count doesn't have an attribute invalid, valid attributes: [db.namespace, membership.kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleMembershipsCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRolePermissionRiskLevelMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRolePermissionRiskLevel
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.permission.risk_level doesn't have an attribute invalid, valid attributes: [db.namespace, role]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRolePermissionRiskLevel
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleRolesCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleRolesCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleRolesCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.roles.count doesn't have an attribute invalid, valid attributes: [db.namespace, role.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleRolesCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverDatabaseSecurityRoleMembershipCountMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverDatabaseSecurityRoleMembershipCount
 	require.NoError(t, cfg.Validate())
@@ -745,6 +1119,102 @@ func TestSqlserverDatabaseTransactionsActiveMetricsConfig_Validate(t *testing.T)
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverFailoverClusterAgClusterTypeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgClusterType
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.cluster_type doesn't have an attribute invalid, valid attributes: [ag.name, ag.cluster_type]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgClusterType
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgFailureConditionLevelMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgFailureConditionLevel
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.failure_condition_level doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgFailureConditionLevel
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgHealthCheckTimeoutMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgHealthCheckTimeout
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.health_check_timeout doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgHealthCheckTimeout
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgRequiredSyncSecondariesMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgRequiredSyncSecondaries
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.required_sync_secondaries doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgRequiredSyncSecondaries
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaDatabaseQueueSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseQueueSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.database.queue_size doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseQueueSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaDatabaseRedoRateMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseRedoRate
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.database.redo.rate doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseRedoRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaRoleMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaRole
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.role doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, replica.role]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaRole
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaSynchronizationHealthMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaSynchronizationHealth
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.synchronization_health doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, replica.sync_health]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaSynchronizationHealth
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverLatchSuperlatchTransitionRateMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverLatchSuperlatchTransitionRate
 	require.NoError(t, cfg.Validate())
@@ -753,6 +1223,30 @@ func TestSqlserverLatchSuperlatchTransitionRateMetricsConfig_Validate(t *testing
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.latch.superlatch.transition.rate doesn't have an attribute invalid, valid attributes: [transition.direction]")
 
 	cfg = DefaultMetricsConfig().SqlserverLatchSuperlatchTransitionRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverLockByModeCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverLockByModeCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverLockByModeCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.lock.by_mode.count doesn't have an attribute invalid, valid attributes: [db.namespace, lock.mode]")
+
+	cfg = DefaultMetricsConfig().SqlserverLockByModeCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverLockByResourceCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverLockByResourceCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverLockByResourceCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.lock.by_resource.count doesn't have an attribute invalid, valid attributes: [db.namespace, lock.resource]")
+
+	cfg = DefaultMetricsConfig().SqlserverLockByResourceCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -933,6 +1427,66 @@ func TestSqlserverTableCountMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.table.count doesn't have an attribute invalid, valid attributes: [table.state, table.status]")
 
 	cfg = DefaultMetricsConfig().SqlserverTableCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbAllocationWaitTimeTotalMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbAllocationWaitTimeTotal
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.allocation.wait_time.total doesn't have an attribute invalid, valid attributes: [allocation.page_type]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbAllocationWaitTimeTotal
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbFileSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbFileSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbFileSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.file.size doesn't have an attribute invalid, valid attributes: [file_type, tempdb.file.id]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbFileSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbSpaceUsageMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbSpaceUsage
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbSpaceUsageMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.space.usage doesn't have an attribute invalid, valid attributes: [tempdb.space_kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbSpaceUsage
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverThreadPoolTasksCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverThreadPoolTasksCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverThreadPoolTasksCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.thread_pool.tasks.count doesn't have an attribute invalid, valid attributes: [task.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverThreadPoolTasksCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverThreadPoolWorkersCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverThreadPoolWorkersCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverThreadPoolWorkersCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.thread_pool.workers.count doesn't have an attribute invalid, valid attributes: [worker.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverThreadPoolWorkersCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics.go
@@ -22,6 +22,74 @@ const (
 	AggregationStrategyMax = "max"
 )
 
+// AttributeAgClusterType specifies the value ag.cluster_type attribute.
+type AttributeAgClusterType int
+
+const (
+	_ AttributeAgClusterType = iota
+	AttributeAgClusterTypeWsfc
+	AttributeAgClusterTypeExternal
+	AttributeAgClusterTypeNone
+	AttributeAgClusterTypeUnknown
+)
+
+// String returns the string representation of the AttributeAgClusterType.
+func (av AttributeAgClusterType) String() string {
+	switch av {
+	case AttributeAgClusterTypeWsfc:
+		return "wsfc"
+	case AttributeAgClusterTypeExternal:
+		return "external"
+	case AttributeAgClusterTypeNone:
+		return "none"
+	case AttributeAgClusterTypeUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeAgClusterType is a helper map of string to AttributeAgClusterType attribute value.
+var MapAttributeAgClusterType = map[string]AttributeAgClusterType{
+	"wsfc":     AttributeAgClusterTypeWsfc,
+	"external": AttributeAgClusterTypeExternal,
+	"none":     AttributeAgClusterTypeNone,
+	"unknown":  AttributeAgClusterTypeUnknown,
+}
+
+// AttributeAllocationPageType specifies the value allocation.page_type attribute.
+type AttributeAllocationPageType int
+
+const (
+	_ AttributeAllocationPageType = iota
+	AttributeAllocationPageTypeGam
+	AttributeAllocationPageTypeSgam
+	AttributeAllocationPageTypePfs
+	AttributeAllocationPageTypeOther
+)
+
+// String returns the string representation of the AttributeAllocationPageType.
+func (av AttributeAllocationPageType) String() string {
+	switch av {
+	case AttributeAllocationPageTypeGam:
+		return "gam"
+	case AttributeAllocationPageTypeSgam:
+		return "sgam"
+	case AttributeAllocationPageTypePfs:
+		return "pfs"
+	case AttributeAllocationPageTypeOther:
+		return "other"
+	}
+	return ""
+}
+
+// MapAttributeAllocationPageType is a helper map of string to AttributeAllocationPageType attribute value.
+var MapAttributeAllocationPageType = map[string]AttributeAllocationPageType{
+	"gam":   AttributeAllocationPageTypeGam,
+	"sgam":  AttributeAllocationPageTypeSgam,
+	"pfs":   AttributeAllocationPageTypePfs,
+	"other": AttributeAllocationPageTypeOther,
+}
+
 // AttributeCacheState specifies the value cache.state attribute.
 type AttributeCacheState int
 
@@ -114,6 +182,182 @@ func (av AttributeDirection) String() string {
 var MapAttributeDirection = map[string]AttributeDirection{
 	"read":  AttributeDirectionRead,
 	"write": AttributeDirectionWrite,
+}
+
+// AttributeLockMode specifies the value lock.mode attribute.
+type AttributeLockMode int
+
+const (
+	_ AttributeLockMode = iota
+	AttributeLockModeShared
+	AttributeLockModeExclusive
+	AttributeLockModeUpdate
+	AttributeLockModeIntent
+	AttributeLockModeSchema
+	AttributeLockModeBulkUpdate
+	AttributeLockModeSharedIntentExclusive
+)
+
+// String returns the string representation of the AttributeLockMode.
+func (av AttributeLockMode) String() string {
+	switch av {
+	case AttributeLockModeShared:
+		return "shared"
+	case AttributeLockModeExclusive:
+		return "exclusive"
+	case AttributeLockModeUpdate:
+		return "update"
+	case AttributeLockModeIntent:
+		return "intent"
+	case AttributeLockModeSchema:
+		return "schema"
+	case AttributeLockModeBulkUpdate:
+		return "bulk_update"
+	case AttributeLockModeSharedIntentExclusive:
+		return "shared_intent_exclusive"
+	}
+	return ""
+}
+
+// MapAttributeLockMode is a helper map of string to AttributeLockMode attribute value.
+var MapAttributeLockMode = map[string]AttributeLockMode{
+	"shared":                  AttributeLockModeShared,
+	"exclusive":               AttributeLockModeExclusive,
+	"update":                  AttributeLockModeUpdate,
+	"intent":                  AttributeLockModeIntent,
+	"schema":                  AttributeLockModeSchema,
+	"bulk_update":             AttributeLockModeBulkUpdate,
+	"shared_intent_exclusive": AttributeLockModeSharedIntentExclusive,
+}
+
+// AttributeLockResource specifies the value lock.resource attribute.
+type AttributeLockResource int
+
+const (
+	_ AttributeLockResource = iota
+	AttributeLockResourceKey
+	AttributeLockResourcePage
+	AttributeLockResourceRow
+	AttributeLockResourceTable
+	AttributeLockResourceExtent
+	AttributeLockResourceFile
+	AttributeLockResourceHobt
+	AttributeLockResourceMetadata
+	AttributeLockResourceApplication
+	AttributeLockResourceAllocationUnit
+	AttributeLockResourceDatabaseLevel
+)
+
+// String returns the string representation of the AttributeLockResource.
+func (av AttributeLockResource) String() string {
+	switch av {
+	case AttributeLockResourceKey:
+		return "key"
+	case AttributeLockResourcePage:
+		return "page"
+	case AttributeLockResourceRow:
+		return "row"
+	case AttributeLockResourceTable:
+		return "table"
+	case AttributeLockResourceExtent:
+		return "extent"
+	case AttributeLockResourceFile:
+		return "file"
+	case AttributeLockResourceHobt:
+		return "hobt"
+	case AttributeLockResourceMetadata:
+		return "metadata"
+	case AttributeLockResourceApplication:
+		return "application"
+	case AttributeLockResourceAllocationUnit:
+		return "allocation_unit"
+	case AttributeLockResourceDatabaseLevel:
+		return "database_level"
+	}
+	return ""
+}
+
+// MapAttributeLockResource is a helper map of string to AttributeLockResource attribute value.
+var MapAttributeLockResource = map[string]AttributeLockResource{
+	"key":             AttributeLockResourceKey,
+	"page":            AttributeLockResourcePage,
+	"row":             AttributeLockResourceRow,
+	"table":           AttributeLockResourceTable,
+	"extent":          AttributeLockResourceExtent,
+	"file":            AttributeLockResourceFile,
+	"hobt":            AttributeLockResourceHobt,
+	"metadata":        AttributeLockResourceMetadata,
+	"application":     AttributeLockResourceApplication,
+	"allocation_unit": AttributeLockResourceAllocationUnit,
+	"database_level":  AttributeLockResourceDatabaseLevel,
+}
+
+// AttributeMemberKind specifies the value member.kind attribute.
+type AttributeMemberKind int
+
+const (
+	_ AttributeMemberKind = iota
+	AttributeMemberKindAppRole
+	AttributeMemberKindCrossRole
+	AttributeMemberKindHighPrivilege
+	AttributeMemberKindUnique
+)
+
+// String returns the string representation of the AttributeMemberKind.
+func (av AttributeMemberKind) String() string {
+	switch av {
+	case AttributeMemberKindAppRole:
+		return "app_role"
+	case AttributeMemberKindCrossRole:
+		return "cross_role"
+	case AttributeMemberKindHighPrivilege:
+		return "high_privilege"
+	case AttributeMemberKindUnique:
+		return "unique"
+	}
+	return ""
+}
+
+// MapAttributeMemberKind is a helper map of string to AttributeMemberKind attribute value.
+var MapAttributeMemberKind = map[string]AttributeMemberKind{
+	"app_role":       AttributeMemberKindAppRole,
+	"cross_role":     AttributeMemberKindCrossRole,
+	"high_privilege": AttributeMemberKindHighPrivilege,
+	"unique":         AttributeMemberKindUnique,
+}
+
+// AttributeMembershipKind specifies the value membership.kind attribute.
+type AttributeMembershipKind int
+
+const (
+	_ AttributeMembershipKind = iota
+	AttributeMembershipKindActive
+	AttributeMembershipKindCustom
+	AttributeMembershipKindNested
+	AttributeMembershipKindUsers
+)
+
+// String returns the string representation of the AttributeMembershipKind.
+func (av AttributeMembershipKind) String() string {
+	switch av {
+	case AttributeMembershipKindActive:
+		return "active"
+	case AttributeMembershipKindCustom:
+		return "custom"
+	case AttributeMembershipKindNested:
+		return "nested"
+	case AttributeMembershipKindUsers:
+		return "users"
+	}
+	return ""
+}
+
+// MapAttributeMembershipKind is a helper map of string to AttributeMembershipKind attribute value.
+var MapAttributeMembershipKind = map[string]AttributeMembershipKind{
+	"active": AttributeMembershipKindActive,
+	"custom": AttributeMembershipKindCustom,
+	"nested": AttributeMembershipKindNested,
+	"users":  AttributeMembershipKindUsers,
 }
 
 // AttributeMemoryPool specifies the value memory.pool attribute.
@@ -290,6 +534,48 @@ var MapAttributePageFileState = map[string]AttributePageFileState{
 	"total": AttributePageFileStateTotal,
 }
 
+// AttributePrincipalType specifies the value principal.type attribute.
+type AttributePrincipalType int
+
+const (
+	_ AttributePrincipalType = iota
+	AttributePrincipalTypeSQLUser
+	AttributePrincipalTypeWindowsUser
+	AttributePrincipalTypeRole
+	AttributePrincipalTypeApplicationRole
+	AttributePrincipalTypeCertificateMappedUser
+	AttributePrincipalTypeAsymmetricKeyMappedUser
+)
+
+// String returns the string representation of the AttributePrincipalType.
+func (av AttributePrincipalType) String() string {
+	switch av {
+	case AttributePrincipalTypeSQLUser:
+		return "sql_user"
+	case AttributePrincipalTypeWindowsUser:
+		return "windows_user"
+	case AttributePrincipalTypeRole:
+		return "role"
+	case AttributePrincipalTypeApplicationRole:
+		return "application_role"
+	case AttributePrincipalTypeCertificateMappedUser:
+		return "certificate_mapped_user"
+	case AttributePrincipalTypeAsymmetricKeyMappedUser:
+		return "asymmetric_key_mapped_user"
+	}
+	return ""
+}
+
+// MapAttributePrincipalType is a helper map of string to AttributePrincipalType attribute value.
+var MapAttributePrincipalType = map[string]AttributePrincipalType{
+	"sql_user":                   AttributePrincipalTypeSQLUser,
+	"windows_user":               AttributePrincipalTypeWindowsUser,
+	"role":                       AttributePrincipalTypeRole,
+	"application_role":           AttributePrincipalTypeApplicationRole,
+	"certificate_mapped_user":    AttributePrincipalTypeCertificateMappedUser,
+	"asymmetric_key_mapped_user": AttributePrincipalTypeAsymmetricKeyMappedUser,
+}
+
 // AttributeProcessStatus specifies the value process.status attribute.
 type AttributeProcessStatus int
 
@@ -360,6 +646,126 @@ func (av AttributeReplicaDirection) String() string {
 var MapAttributeReplicaDirection = map[string]AttributeReplicaDirection{
 	"transmit": AttributeReplicaDirectionTransmit,
 	"receive":  AttributeReplicaDirectionReceive,
+}
+
+// AttributeReplicaQueueKind specifies the value replica.queue_kind attribute.
+type AttributeReplicaQueueKind int
+
+const (
+	_ AttributeReplicaQueueKind = iota
+	AttributeReplicaQueueKindLogSend
+	AttributeReplicaQueueKindRedo
+)
+
+// String returns the string representation of the AttributeReplicaQueueKind.
+func (av AttributeReplicaQueueKind) String() string {
+	switch av {
+	case AttributeReplicaQueueKindLogSend:
+		return "log_send"
+	case AttributeReplicaQueueKindRedo:
+		return "redo"
+	}
+	return ""
+}
+
+// MapAttributeReplicaQueueKind is a helper map of string to AttributeReplicaQueueKind attribute value.
+var MapAttributeReplicaQueueKind = map[string]AttributeReplicaQueueKind{
+	"log_send": AttributeReplicaQueueKindLogSend,
+	"redo":     AttributeReplicaQueueKindRedo,
+}
+
+// AttributeReplicaRole specifies the value replica.role attribute.
+type AttributeReplicaRole int
+
+const (
+	_ AttributeReplicaRole = iota
+	AttributeReplicaRolePrimary
+	AttributeReplicaRoleSecondary
+	AttributeReplicaRoleResolving
+	AttributeReplicaRoleUnknown
+)
+
+// String returns the string representation of the AttributeReplicaRole.
+func (av AttributeReplicaRole) String() string {
+	switch av {
+	case AttributeReplicaRolePrimary:
+		return "primary"
+	case AttributeReplicaRoleSecondary:
+		return "secondary"
+	case AttributeReplicaRoleResolving:
+		return "resolving"
+	case AttributeReplicaRoleUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeReplicaRole is a helper map of string to AttributeReplicaRole attribute value.
+var MapAttributeReplicaRole = map[string]AttributeReplicaRole{
+	"primary":   AttributeReplicaRolePrimary,
+	"secondary": AttributeReplicaRoleSecondary,
+	"resolving": AttributeReplicaRoleResolving,
+	"unknown":   AttributeReplicaRoleUnknown,
+}
+
+// AttributeReplicaSyncHealth specifies the value replica.sync_health attribute.
+type AttributeReplicaSyncHealth int
+
+const (
+	_ AttributeReplicaSyncHealth = iota
+	AttributeReplicaSyncHealthHealthy
+	AttributeReplicaSyncHealthPartiallyHealthy
+	AttributeReplicaSyncHealthNotHealthy
+	AttributeReplicaSyncHealthUnknown
+)
+
+// String returns the string representation of the AttributeReplicaSyncHealth.
+func (av AttributeReplicaSyncHealth) String() string {
+	switch av {
+	case AttributeReplicaSyncHealthHealthy:
+		return "healthy"
+	case AttributeReplicaSyncHealthPartiallyHealthy:
+		return "partially_healthy"
+	case AttributeReplicaSyncHealthNotHealthy:
+		return "not_healthy"
+	case AttributeReplicaSyncHealthUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeReplicaSyncHealth is a helper map of string to AttributeReplicaSyncHealth attribute value.
+var MapAttributeReplicaSyncHealth = map[string]AttributeReplicaSyncHealth{
+	"healthy":           AttributeReplicaSyncHealthHealthy,
+	"partially_healthy": AttributeReplicaSyncHealthPartiallyHealthy,
+	"not_healthy":       AttributeReplicaSyncHealthNotHealthy,
+	"unknown":           AttributeReplicaSyncHealthUnknown,
+}
+
+// AttributeRoleState specifies the value role.state attribute.
+type AttributeRoleState int
+
+const (
+	_ AttributeRoleState = iota
+	AttributeRoleStateEmpty
+	AttributeRoleStateWithMembers
+)
+
+// String returns the string representation of the AttributeRoleState.
+func (av AttributeRoleState) String() string {
+	switch av {
+	case AttributeRoleStateEmpty:
+		return "empty"
+	case AttributeRoleStateWithMembers:
+		return "with_members"
+	}
+	return ""
+}
+
+// MapAttributeRoleState is a helper map of string to AttributeRoleState attribute value.
+var MapAttributeRoleState = map[string]AttributeRoleState{
+	"empty":        AttributeRoleStateEmpty,
+	"with_members": AttributeRoleStateWithMembers,
 }
 
 // AttributeSqlserverParameterizationResult specifies the value sqlserver.parameterization.result attribute.
@@ -478,6 +884,70 @@ var MapAttributeTableStatus = map[string]AttributeTableStatus{
 	"permanent": AttributeTableStatusPermanent,
 }
 
+// AttributeTaskState specifies the value task.state attribute.
+type AttributeTaskState int
+
+const (
+	_ AttributeTaskState = iota
+	AttributeTaskStateCurrent
+	AttributeTaskStateQueued
+	AttributeTaskStateWaitingForThreadpool
+)
+
+// String returns the string representation of the AttributeTaskState.
+func (av AttributeTaskState) String() string {
+	switch av {
+	case AttributeTaskStateCurrent:
+		return "current"
+	case AttributeTaskStateQueued:
+		return "queued"
+	case AttributeTaskStateWaitingForThreadpool:
+		return "waiting_for_threadpool"
+	}
+	return ""
+}
+
+// MapAttributeTaskState is a helper map of string to AttributeTaskState attribute value.
+var MapAttributeTaskState = map[string]AttributeTaskState{
+	"current":                AttributeTaskStateCurrent,
+	"queued":                 AttributeTaskStateQueued,
+	"waiting_for_threadpool": AttributeTaskStateWaitingForThreadpool,
+}
+
+// AttributeTempdbSpaceKind specifies the value tempdb.space_kind attribute.
+type AttributeTempdbSpaceKind int
+
+const (
+	_ AttributeTempdbSpaceKind = iota
+	AttributeTempdbSpaceKindUserObjects
+	AttributeTempdbSpaceKindInternalObjects
+	AttributeTempdbSpaceKindVersionStore
+	AttributeTempdbSpaceKindFree
+)
+
+// String returns the string representation of the AttributeTempdbSpaceKind.
+func (av AttributeTempdbSpaceKind) String() string {
+	switch av {
+	case AttributeTempdbSpaceKindUserObjects:
+		return "user_objects"
+	case AttributeTempdbSpaceKindInternalObjects:
+		return "internal_objects"
+	case AttributeTempdbSpaceKindVersionStore:
+		return "version_store"
+	case AttributeTempdbSpaceKindFree:
+		return "free"
+	}
+	return ""
+}
+
+// MapAttributeTempdbSpaceKind is a helper map of string to AttributeTempdbSpaceKind attribute value.
+var MapAttributeTempdbSpaceKind = map[string]AttributeTempdbSpaceKind{
+	"user_objects":     AttributeTempdbSpaceKindUserObjects,
+	"internal_objects": AttributeTempdbSpaceKindInternalObjects,
+	"version_store":    AttributeTempdbSpaceKindVersionStore,
+	"free":             AttributeTempdbSpaceKindFree,
+}
+
 // AttributeTempdbState specifies the value tempdb.state attribute.
 type AttributeTempdbState int
 
@@ -528,6 +998,32 @@ func (av AttributeTransitionDirection) String() string {
 var MapAttributeTransitionDirection = map[string]AttributeTransitionDirection{
 	"promotion": AttributeTransitionDirectionPromotion,
 	"demotion":  AttributeTransitionDirectionDemotion,
+}
+
+// AttributeWorkerState specifies the value worker.state attribute.
+type AttributeWorkerState int
+
+const (
+	_ AttributeWorkerState = iota
+	AttributeWorkerStateRunning
+	AttributeWorkerStateSuspendedOrSleeping
+)
+
+// String returns the string representation of the AttributeWorkerState.
+func (av AttributeWorkerState) String() string {
+	switch av {
+	case AttributeWorkerStateRunning:
+		return "running"
+	case AttributeWorkerStateSuspendedOrSleeping:
+		return "suspended_or_sleeping"
+	}
+	return ""
+}
+
+// MapAttributeWorkerState is a helper map of string to AttributeWorkerState attribute value.
+var MapAttributeWorkerState = map[string]AttributeWorkerState{
+	"running":               AttributeWorkerStateRunning,
+	"suspended_or_sleeping": AttributeWorkerStateSuspendedOrSleeping,
 }
 
 var MetricsInfo = metricsInfo{
@@ -588,6 +1084,38 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.database.page_file.size",
 		Attributes: []string{"db.namespace", "page_file.state"},
 	},
+	SqlserverDatabasePrincipalsCount: metricInfo{
+		Name:       "sqlserver.database.principals.count",
+		Attributes: []string{"db.namespace", "principal.type"},
+	},
+	SqlserverDatabasePrincipalsOld: metricInfo{
+		Name:       "sqlserver.database.principals.old",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabasePrincipalsOrphanedUsers: metricInfo{
+		Name:       "sqlserver.database.principals.orphaned_users",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabasePrincipalsRecentlyCreated: metricInfo{
+		Name:       "sqlserver.database.principals.recently_created",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabaseRoleMembersCount: metricInfo{
+		Name:       "sqlserver.database.role.members.count",
+		Attributes: []string{"db.namespace", "member.kind"},
+	},
+	SqlserverDatabaseRoleMembershipsCount: metricInfo{
+		Name:       "sqlserver.database.role.memberships.count",
+		Attributes: []string{"db.namespace", "membership.kind"},
+	},
+	SqlserverDatabaseRolePermissionRiskLevel: metricInfo{
+		Name:       "sqlserver.database.role.permission.risk_level",
+		Attributes: []string{"db.namespace", "role"},
+	},
+	SqlserverDatabaseRoleRolesCount: metricInfo{
+		Name:       "sqlserver.database.role.roles.count",
+		Attributes: []string{"db.namespace", "role.state"},
+	},
 	SqlserverDatabaseSecurityRoleMembershipCount: metricInfo{
 		Name:       "sqlserver.database.security.role_membership.count",
 		Attributes: []string{"db.namespace", "role"},
@@ -605,6 +1133,41 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverDeadlockRate: metricInfo{
 		Name: "sqlserver.deadlock.rate",
+	},
+	SqlserverFailoverClusterAgClusterType: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.cluster_type",
+		Attributes: []string{"ag.name", "ag.cluster_type"},
+	},
+	SqlserverFailoverClusterAgFailureConditionLevel: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.failure_condition_level",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterAgHealthCheckTimeout: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.health_check_timeout",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterAgRequiredSyncSecondaries: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.required_sync_secondaries",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterReplicaDatabaseQueueSize: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.database.queue_size",
+		Attributes: []string{"ag.name", "replica.server_name", "db.namespace", "replica.queue_kind"},
+	},
+	SqlserverFailoverClusterReplicaDatabaseRedoRate: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.database.redo.rate",
+		Attributes: []string{"ag.name", "replica.server_name", "db.namespace"},
+	},
+	SqlserverFailoverClusterReplicaFlowControlTime: metricInfo{
+		Name: "sqlserver.failover_cluster.replica.flow_control_time",
+	},
+	SqlserverFailoverClusterReplicaRole: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.role",
+		Attributes: []string{"ag.name", "replica.server_name", "replica.role"},
+	},
+	SqlserverFailoverClusterReplicaSynchronizationHealth: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.synchronization_health",
+		Attributes: []string{"ag.name", "replica.server_name", "replica.sync_health"},
 	},
 	SqlserverIndexSearchRate: metricInfo{
 		Name: "sqlserver.index.search.rate",
@@ -627,6 +1190,14 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverLatchWaitTimeTotal: metricInfo{
 		Name: "sqlserver.latch.wait_time.total",
+	},
+	SqlserverLockByModeCount: metricInfo{
+		Name:       "sqlserver.lock.by_mode.count",
+		Attributes: []string{"db.namespace", "lock.mode"},
+	},
+	SqlserverLockByResourceCount: metricInfo{
+		Name:       "sqlserver.lock.by_resource.count",
+		Attributes: []string{"db.namespace", "lock.resource"},
 	},
 	SqlserverLockTimeoutRate: metricInfo{
 		Name: "sqlserver.lock.timeout.rate",
@@ -757,14 +1328,55 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.table.count",
 		Attributes: []string{"table.state", "table.status"},
 	},
+	SqlserverTempdbAllocationWaitTimeTotal: metricInfo{
+		Name:       "sqlserver.tempdb.allocation.wait_time.total",
+		Attributes: []string{"allocation.page_type"},
+	},
+	SqlserverTempdbContentionWaitersCount: metricInfo{
+		Name: "sqlserver.tempdb.contention.waiters.count",
+	},
+	SqlserverTempdbDataFilesCount: metricInfo{
+		Name: "sqlserver.tempdb.data_files.count",
+	},
+	SqlserverTempdbFileSize: metricInfo{
+		Name:       "sqlserver.tempdb.file.size",
+		Attributes: []string{"file_type", "tempdb.file.id"},
+	},
+	SqlserverTempdbSpaceUsage: metricInfo{
+		Name:       "sqlserver.tempdb.space.usage",
+		Attributes: []string{"tempdb.space_kind"},
+	},
+	SqlserverThreadPoolTasksCount: metricInfo{
+		Name:       "sqlserver.thread_pool.tasks.count",
+		Attributes: []string{"task.state"},
+	},
+	SqlserverThreadPoolWorkersCount: metricInfo{
+		Name:       "sqlserver.thread_pool.workers.count",
+		Attributes: []string{"worker.state"},
+	},
+	SqlserverThreadPoolWorkersMax: metricInfo{
+		Name: "sqlserver.thread_pool.workers.max",
+	},
+	SqlserverThreadPoolWorkersUtilization: metricInfo{
+		Name: "sqlserver.thread_pool.workers.utilization",
+	},
 	SqlserverTransactionDelay: metricInfo{
 		Name: "sqlserver.transaction.delay",
+	},
+	SqlserverTransactionLongestRunningTime: metricInfo{
+		Name: "sqlserver.transaction.longest_running_time",
 	},
 	SqlserverTransactionMirrorWriteRate: metricInfo{
 		Name: "sqlserver.transaction.mirror_write.rate",
 	},
 	SqlserverTransactionRate: metricInfo{
 		Name: "sqlserver.transaction.rate",
+	},
+	SqlserverTransactionVersionCleanupRate: metricInfo{
+		Name: "sqlserver.transaction.version_cleanup.rate",
+	},
+	SqlserverTransactionVersionGenerationRate: metricInfo{
+		Name: "sqlserver.transaction.version_generation.rate",
 	},
 	SqlserverTransactionWriteRate: metricInfo{
 		Name: "sqlserver.transaction.write.rate",
@@ -793,84 +1405,115 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	SqlserverAttentionRate                       metricInfo
-	SqlserverBatchCompilationUtilization         metricInfo
-	SqlserverBatchPageSplitUtilization           metricInfo
-	SqlserverBatchRequestRate                    metricInfo
-	SqlserverBatchSQLCompilationRate             metricInfo
-	SqlserverBatchSQLRecompilationRate           metricInfo
-	SqlserverComputerUptime                      metricInfo
-	SqlserverCPUCount                            metricInfo
-	SqlserverDatabaseBackupOrRestoreRate         metricInfo
-	SqlserverDatabaseCount                       metricInfo
-	SqlserverDatabaseExecutionErrors             metricInfo
-	SqlserverDatabaseFileSize                    metricInfo
-	SqlserverDatabaseFullScanRate                metricInfo
-	SqlserverDatabaseIo                          metricInfo
-	SqlserverDatabaseLatency                     metricInfo
-	SqlserverDatabaseOperations                  metricInfo
-	SqlserverDatabasePageFileSize                metricInfo
-	SqlserverDatabaseSecurityRoleMembershipCount metricInfo
-	SqlserverDatabaseTempdbSpace                 metricInfo
-	SqlserverDatabaseTempdbVersionStoreSize      metricInfo
-	SqlserverDatabaseTransactionsActive          metricInfo
-	SqlserverDeadlockRate                        metricInfo
-	SqlserverIndexSearchRate                     metricInfo
-	SqlserverKillConnectionErrorRate             metricInfo
-	SqlserverLatchSuperlatchCount                metricInfo
-	SqlserverLatchSuperlatchTransitionRate       metricInfo
-	SqlserverLatchWaitRate                       metricInfo
-	SqlserverLatchWaitTimeAvg                    metricInfo
-	SqlserverLatchWaitTimeTotal                  metricInfo
-	SqlserverLockTimeoutRate                     metricInfo
-	SqlserverLockWaitCount                       metricInfo
-	SqlserverLockWaitRate                        metricInfo
-	SqlserverLockWaitTimeAvg                     metricInfo
-	SqlserverLoginRate                           metricInfo
-	SqlserverLogoutRate                          metricInfo
-	SqlserverMemoryArea                          metricInfo
-	SqlserverMemoryCacheObjectCount              metricInfo
-	SqlserverMemoryGrantsPendingCount            metricInfo
-	SqlserverMemoryPageCount                     metricInfo
-	SqlserverMemoryTarget                        metricInfo
-	SqlserverMemoryUsage                         metricInfo
-	SqlserverOsDiskSize                          metricInfo
-	SqlserverOsMemoryUsage                       metricInfo
-	SqlserverOsMemoryUtilization                 metricInfo
-	SqlserverOsSchedulerRunnableTasksCount       metricInfo
-	SqlserverOsWaitDuration                      metricInfo
-	SqlserverOsWaitTasksCount                    metricInfo
-	SqlserverPageBufferCacheFreeListStallsRate   metricInfo
-	SqlserverPageBufferCacheHitRatio             metricInfo
-	SqlserverPageCheckpointFlushRate             metricInfo
-	SqlserverPageLazyWriteRate                   metricInfo
-	SqlserverPageLifeExpectancy                  metricInfo
-	SqlserverPageLookupRate                      metricInfo
-	SqlserverPageOperationRate                   metricInfo
-	SqlserverPageSplitRate                       metricInfo
-	SqlserverParameterizationRate                metricInfo
-	SqlserverPlanExecutionRate                   metricInfo
-	SqlserverProcessCount                        metricInfo
-	SqlserverProcessesBlocked                    metricInfo
-	SqlserverRecompilationRatio                  metricInfo
-	SqlserverReplicaDataRate                     metricInfo
-	SqlserverResourcePoolDiskOperations          metricInfo
-	SqlserverResourcePoolDiskThrottledReadRate   metricInfo
-	SqlserverResourcePoolDiskThrottledWriteRate  metricInfo
-	SqlserverServerSecurityPrincipalCount        metricInfo
-	SqlserverServerSecurityRoleMembershipCount   metricInfo
-	SqlserverTableCount                          metricInfo
-	SqlserverTransactionDelay                    metricInfo
-	SqlserverTransactionMirrorWriteRate          metricInfo
-	SqlserverTransactionRate                     metricInfo
-	SqlserverTransactionWriteRate                metricInfo
-	SqlserverTransactionLogFlushDataRate         metricInfo
-	SqlserverTransactionLogFlushRate             metricInfo
-	SqlserverTransactionLogFlushWaitRate         metricInfo
-	SqlserverTransactionLogGrowthCount           metricInfo
-	SqlserverTransactionLogShrinkCount           metricInfo
-	SqlserverTransactionLogUsage                 metricInfo
-	SqlserverUserConnectionCount                 metricInfo
+	SqlserverAttentionRate                               metricInfo
+	SqlserverBatchCompilationUtilization                 metricInfo
+	SqlserverBatchPageSplitUtilization                   metricInfo
+	SqlserverBatchRequestRate                            metricInfo
+	SqlserverBatchSQLCompilationRate                     metricInfo
+	SqlserverBatchSQLRecompilationRate                   metricInfo
+	SqlserverComputerUptime                              metricInfo
+	SqlserverCPUCount                                    metricInfo
+	SqlserverDatabaseBackupOrRestoreRate                 metricInfo
+	SqlserverDatabaseCount                               metricInfo
+	SqlserverDatabaseExecutionErrors                     metricInfo
+	SqlserverDatabaseFileSize                            metricInfo
+	SqlserverDatabaseFullScanRate                        metricInfo
+	SqlserverDatabaseIo                                  metricInfo
+	SqlserverDatabaseLatency                             metricInfo
+	SqlserverDatabaseOperations                          metricInfo
+	SqlserverDatabasePageFileSize                        metricInfo
+	SqlserverDatabasePrincipalsCount                     metricInfo
+	SqlserverDatabasePrincipalsOld                       metricInfo
+	SqlserverDatabasePrincipalsOrphanedUsers             metricInfo
+	SqlserverDatabasePrincipalsRecentlyCreated           metricInfo
+	SqlserverDatabaseRoleMembersCount                    metricInfo
+	SqlserverDatabaseRoleMembershipsCount                metricInfo
+	SqlserverDatabaseRolePermissionRiskLevel             metricInfo
+	SqlserverDatabaseRoleRolesCount                      metricInfo
+	SqlserverDatabaseSecurityRoleMembershipCount         metricInfo
+	SqlserverDatabaseTempdbSpace                         metricInfo
+	SqlserverDatabaseTempdbVersionStoreSize              metricInfo
+	SqlserverDatabaseTransactionsActive                  metricInfo
+	SqlserverDeadlockRate                                metricInfo
+	SqlserverFailoverClusterAgClusterType                metricInfo
+	SqlserverFailoverClusterAgFailureConditionLevel      metricInfo
+	SqlserverFailoverClusterAgHealthCheckTimeout         metricInfo
+	SqlserverFailoverClusterAgRequiredSyncSecondaries    metricInfo
+	SqlserverFailoverClusterReplicaDatabaseQueueSize     metricInfo
+	SqlserverFailoverClusterReplicaDatabaseRedoRate      metricInfo
+	SqlserverFailoverClusterReplicaFlowControlTime       metricInfo
+	SqlserverFailoverClusterReplicaRole                  metricInfo
+	SqlserverFailoverClusterReplicaSynchronizationHealth metricInfo
+	SqlserverIndexSearchRate                             metricInfo
+	SqlserverKillConnectionErrorRate                     metricInfo
+	SqlserverLatchSuperlatchCount                        metricInfo
+	SqlserverLatchSuperlatchTransitionRate               metricInfo
+	SqlserverLatchWaitRate                               metricInfo
+	SqlserverLatchWaitTimeAvg                            metricInfo
+	SqlserverLatchWaitTimeTotal                          metricInfo
+	SqlserverLockByModeCount                             metricInfo
+	SqlserverLockByResourceCount                         metricInfo
+	SqlserverLockTimeoutRate                             metricInfo
+	SqlserverLockWaitCount                               metricInfo
+	SqlserverLockWaitRate                                metricInfo
+	SqlserverLockWaitTimeAvg                             metricInfo
+	SqlserverLoginRate                                   metricInfo
+	SqlserverLogoutRate                                  metricInfo
+	SqlserverMemoryArea                                  metricInfo
+	SqlserverMemoryCacheObjectCount                      metricInfo
+	SqlserverMemoryGrantsPendingCount                    metricInfo
+	SqlserverMemoryPageCount                             metricInfo
+	SqlserverMemoryTarget                                metricInfo
+	SqlserverMemoryUsage                                 metricInfo
+	SqlserverOsDiskSize                                  metricInfo
+	SqlserverOsMemoryUsage                               metricInfo
+	SqlserverOsMemoryUtilization                         metricInfo
+	SqlserverOsSchedulerRunnableTasksCount               metricInfo
+	SqlserverOsWaitDuration                              metricInfo
+	SqlserverOsWaitTasksCount                            metricInfo
+	SqlserverPageBufferCacheFreeListStallsRate           metricInfo
+	SqlserverPageBufferCacheHitRatio                     metricInfo
+	SqlserverPageCheckpointFlushRate                     metricInfo
+	SqlserverPageLazyWriteRate                           metricInfo
+	SqlserverPageLifeExpectancy                          metricInfo
+	SqlserverPageLookupRate                              metricInfo
+	SqlserverPageOperationRate                           metricInfo
+	SqlserverPageSplitRate                               metricInfo
+	SqlserverParameterizationRate                        metricInfo
+	SqlserverPlanExecutionRate                           metricInfo
+	SqlserverProcessCount                                metricInfo
+	SqlserverProcessesBlocked                            metricInfo
+	SqlserverRecompilationRatio                          metricInfo
+	SqlserverReplicaDataRate                             metricInfo
+	SqlserverResourcePoolDiskOperations                  metricInfo
+	SqlserverResourcePoolDiskThrottledReadRate           metricInfo
+	SqlserverResourcePoolDiskThrottledWriteRate          metricInfo
+	SqlserverServerSecurityPrincipalCount                metricInfo
+	SqlserverServerSecurityRoleMembershipCount           metricInfo
+	SqlserverTableCount                                  metricInfo
+	SqlserverTempdbAllocationWaitTimeTotal               metricInfo
+	SqlserverTempdbContentionWaitersCount                metricInfo
+	SqlserverTempdbDataFilesCount                        metricInfo
+	SqlserverTempdbFileSize                              metricInfo
+	SqlserverTempdbSpaceUsage                            metricInfo
+	SqlserverThreadPoolTasksCount                        metricInfo
+	SqlserverThreadPoolWorkersCount                      metricInfo
+	SqlserverThreadPoolWorkersMax                        metricInfo
+	SqlserverThreadPoolWorkersUtilization                metricInfo
+	SqlserverTransactionDelay                            metricInfo
+	SqlserverTransactionLongestRunningTime               metricInfo
+	SqlserverTransactionMirrorWriteRate                  metricInfo
+	SqlserverTransactionRate                             metricInfo
+	SqlserverTransactionVersionCleanupRate               metricInfo
+	SqlserverTransactionVersionGenerationRate            metricInfo
+	SqlserverTransactionWriteRate                        metricInfo
+	SqlserverTransactionLogFlushDataRate                 metricInfo
+	SqlserverTransactionLogFlushRate                     metricInfo
+	SqlserverTransactionLogFlushWaitRate                 metricInfo
+	SqlserverTransactionLogGrowthCount                   metricInfo
+	SqlserverTransactionLogShrinkCount                   metricInfo
+	SqlserverTransactionLogUsage                         metricInfo
+	SqlserverUserConnectionCount                         metricInfo
 }
 
 type metricInfo struct {
@@ -2001,6 +2644,733 @@ func newMetricSqlserverDatabasePageFileSize(cfg SqlserverDatabasePageFileSizeMet
 	return m
 }
 
+type metricSqlserverDatabasePrincipalsCount struct {
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsCountMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                      // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.count metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsCount) init() {
+	m.data.SetName("sqlserver.database.principals.count")
+	m.data.SetDescription("Number of database security principals broken down by type.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, principalTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType) {
+		dp.Attributes().PutStr("principal.type", principalTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsCount(cfg SqlserverDatabasePrincipalsCountMetricConfig) metricSqlserverDatabasePrincipalsCount {
+	m := metricSqlserverDatabasePrincipalsCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsOld struct {
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsOldMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []int64                                    // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.old metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsOld) init() {
+	m.data.SetName("sqlserver.database.principals.old")
+	m.data.SetDescription("Number of database principals created more than one year ago.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsOld) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsOld) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsOld) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsOld(cfg SqlserverDatabasePrincipalsOldMetricConfig) metricSqlserverDatabasePrincipalsOld {
+	m := metricSqlserverDatabasePrincipalsOld{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsOrphanedUsers struct {
+	data          pmetric.Metric                                       // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsOrphanedUsersMetricConfig // metric config provided by user.
+	capacity      int                                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.orphaned_users metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) init() {
+	m.data.SetName("sqlserver.database.principals.orphaned_users")
+	m.data.SetDescription("Number of SQL users in the database that have no matching server login.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsOrphanedUsers(cfg SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) metricSqlserverDatabasePrincipalsOrphanedUsers {
+	m := metricSqlserverDatabasePrincipalsOrphanedUsers{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsRecentlyCreated struct {
+	data          pmetric.Metric                                         // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig // metric config provided by user.
+	capacity      int                                                    // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.recently_created metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) init() {
+	m.data.SetName("sqlserver.database.principals.recently_created")
+	m.data.SetDescription("Number of database principals created in the last 30 days.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsRecentlyCreated(cfg SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) metricSqlserverDatabasePrincipalsRecentlyCreated {
+	m := metricSqlserverDatabasePrincipalsRecentlyCreated{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleMembersCount struct {
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        SqlserverDatabaseRoleMembersCountMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                       // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.members.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleMembersCount) init() {
+	m.data.SetName("sqlserver.database.role.members.count")
+	m.data.SetDescription("Number of database role members broken down by member kind.")
+	m.data.SetUnit("{members}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleMembersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, memberKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind) {
+		dp.Attributes().PutStr("member.kind", memberKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleMembersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleMembersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleMembersCount(cfg SqlserverDatabaseRoleMembersCountMetricConfig) metricSqlserverDatabaseRoleMembersCount {
+	m := metricSqlserverDatabaseRoleMembersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleMembershipsCount struct {
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        SqlserverDatabaseRoleMembershipsCountMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.memberships.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) init() {
+	m.data.SetName("sqlserver.database.role.memberships.count")
+	m.data.SetDescription("Number of database role memberships broken down by kind.")
+	m.data.SetUnit("{memberships}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleMembershipsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, membershipKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind) {
+		dp.Attributes().PutStr("membership.kind", membershipKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleMembershipsCount(cfg SqlserverDatabaseRoleMembershipsCountMetricConfig) metricSqlserverDatabaseRoleMembershipsCount {
+	m := metricSqlserverDatabaseRoleMembershipsCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRolePermissionRiskLevel struct {
+	data          pmetric.Metric                                       // data buffer for generated metric.
+	config        SqlserverDatabaseRolePermissionRiskLevelMetricConfig // metric config provided by user.
+	capacity      int                                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.permission.risk_level metric with initial data.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) init() {
+	m.data.SetName("sqlserver.database.role.permission.risk_level")
+	m.data.SetDescription("Risk level assigned to each database role (1=low, 4=high).")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, roleAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole) {
+		dp.Attributes().PutStr("role", roleAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRolePermissionRiskLevel(cfg SqlserverDatabaseRolePermissionRiskLevelMetricConfig) metricSqlserverDatabaseRolePermissionRiskLevel {
+	m := metricSqlserverDatabaseRolePermissionRiskLevel{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleRolesCount struct {
+	data          pmetric.Metric                              // data buffer for generated metric.
+	config        SqlserverDatabaseRoleRolesCountMetricConfig // metric config provided by user.
+	capacity      int                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.roles.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleRolesCount) init() {
+	m.data.SetName("sqlserver.database.role.roles.count")
+	m.data.SetDescription("Number of database roles broken down by usage state.")
+	m.data.SetUnit("{roles}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleRolesCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, roleStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState) {
+		dp.Attributes().PutStr("role.state", roleStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleRolesCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleRolesCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleRolesCount(cfg SqlserverDatabaseRoleRolesCountMetricConfig) metricSqlserverDatabaseRoleRolesCount {
+	m := metricSqlserverDatabaseRoleRolesCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDatabaseSecurityRoleMembershipCount struct {
 	data          pmetric.Metric                                           // data buffer for generated metric.
 	config        SqlserverDatabaseSecurityRoleMembershipCountMetricConfig // metric config provided by user.
@@ -2365,6 +3735,798 @@ func (m *metricSqlserverDeadlockRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverDeadlockRate(cfg SqlserverDeadlockRateMetricConfig) metricSqlserverDeadlockRate {
 	m := metricSqlserverDeadlockRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgClusterType struct {
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgClusterTypeMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.cluster_type metric with initial data.
+func (m *metricSqlserverFailoverClusterAgClusterType) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.cluster_type")
+	m.data.SetDescription("Cluster type of the Always-On Availability Group.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgClusterType) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, agClusterTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType) {
+		dp.Attributes().PutStr("ag.cluster_type", agClusterTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgClusterType) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgClusterType) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgClusterType(cfg SqlserverFailoverClusterAgClusterTypeMetricConfig) metricSqlserverFailoverClusterAgClusterType {
+	m := metricSqlserverFailoverClusterAgClusterType{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgFailureConditionLevel struct {
+	data          pmetric.Metric                                              // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgFailureConditionLevelMetricConfig // metric config provided by user.
+	capacity      int                                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.failure_condition_level metric with initial data.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.failure_condition_level")
+	m.data.SetDescription("Failure condition level configured for the Availability Group (1-5).")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgFailureConditionLevel(cfg SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) metricSqlserverFailoverClusterAgFailureConditionLevel {
+	m := metricSqlserverFailoverClusterAgFailureConditionLevel{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgHealthCheckTimeout struct {
+	data          pmetric.Metric                                           // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig // metric config provided by user.
+	capacity      int                                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.health_check_timeout metric with initial data.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.health_check_timeout")
+	m.data.SetDescription("Health-check timeout configured for the Availability Group.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgHealthCheckTimeout(cfg SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) metricSqlserverFailoverClusterAgHealthCheckTimeout {
+	m := metricSqlserverFailoverClusterAgHealthCheckTimeout{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgRequiredSyncSecondaries struct {
+	data          pmetric.Metric                                                // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig // metric config provided by user.
+	capacity      int                                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                       // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.required_sync_secondaries metric with initial data.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.required_sync_secondaries")
+	m.data.SetDescription("Number of synchronized secondary replicas required to commit on the Availability Group.")
+	m.data.SetUnit("{secondaries}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgRequiredSyncSecondaries(cfg SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) metricSqlserverFailoverClusterAgRequiredSyncSecondaries {
+	m := metricSqlserverFailoverClusterAgRequiredSyncSecondaries{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaDatabaseQueueSize struct {
+	data          pmetric.Metric                                               // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig // metric config provided by user.
+	capacity      int                                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                      // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.database.queue_size metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.database.queue_size")
+	m.data.SetDescription("Size of the log-send or redo queue for an AG database replica.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string, replicaQueueKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind) {
+		dp.Attributes().PutStr("replica.queue_kind", replicaQueueKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaDatabaseQueueSize(cfg SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) metricSqlserverFailoverClusterReplicaDatabaseQueueSize {
+	m := metricSqlserverFailoverClusterReplicaDatabaseQueueSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaDatabaseRedoRate struct {
+	data          pmetric.Metric                                              // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig // metric config provided by user.
+	capacity      int                                                         // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.database.redo.rate metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.database.redo.rate")
+	m.data.SetDescription("Redo rate for an AG database replica.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaDatabaseRedoRate(cfg SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) metricSqlserverFailoverClusterReplicaDatabaseRedoRate {
+	m := metricSqlserverFailoverClusterReplicaDatabaseRedoRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaFlowControlTime struct {
+	data     pmetric.Metric                                             // data buffer for generated metric.
+	config   SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig // metric config provided by user.
+	capacity int                                                        // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.failover_cluster.replica.flow_control_time metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.flow_control_time")
+	m.data.SetDescription("Cumulative time spent in AG flow control, in milliseconds per second observed.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaFlowControlTime(cfg SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig) metricSqlserverFailoverClusterReplicaFlowControlTime {
+	m := metricSqlserverFailoverClusterReplicaFlowControlTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaRole struct {
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaRoleMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                                         // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.role metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaRole) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.role")
+	m.data.SetDescription("Role of the availability replica.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaRole) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaRoleAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole) {
+		dp.Attributes().PutStr("replica.role", replicaRoleAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaRole) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaRole) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaRole(cfg SqlserverFailoverClusterReplicaRoleMetricConfig) metricSqlserverFailoverClusterReplicaRole {
+	m := metricSqlserverFailoverClusterReplicaRole{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaSynchronizationHealth struct {
+	data          pmetric.Metric                                                   // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig // metric config provided by user.
+	capacity      int                                                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.synchronization_health metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.synchronization_health")
+	m.data.SetDescription("Synchronization health of the availability replica.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaSyncHealthAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth) {
+		dp.Attributes().PutStr("replica.sync_health", replicaSyncHealthAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaSynchronizationHealth(cfg SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) metricSqlserverFailoverClusterReplicaSynchronizationHealth {
+	m := metricSqlserverFailoverClusterReplicaSynchronizationHealth{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -2756,6 +4918,190 @@ func (m *metricSqlserverLatchWaitTimeTotal) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverLatchWaitTimeTotal(cfg SqlserverLatchWaitTimeTotalMetricConfig) metricSqlserverLatchWaitTimeTotal {
 	m := metricSqlserverLatchWaitTimeTotal{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverLockByModeCount struct {
+	data          pmetric.Metric                       // data buffer for generated metric.
+	config        SqlserverLockByModeCountMetricConfig // metric config provided by user.
+	capacity      int                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.lock.by_mode.count metric with initial data.
+func (m *metricSqlserverLockByModeCount) init() {
+	m.data.SetName("sqlserver.lock.by_mode.count")
+	m.data.SetDescription("Number of currently active locks held in the database, grouped by lock mode.")
+	m.data.SetUnit("{locks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverLockByModeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, lockModeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByModeCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByModeCountMetricAttributeKeyLockMode) {
+		dp.Attributes().PutStr("lock.mode", lockModeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverLockByModeCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverLockByModeCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverLockByModeCount(cfg SqlserverLockByModeCountMetricConfig) metricSqlserverLockByModeCount {
+	m := metricSqlserverLockByModeCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverLockByResourceCount struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        SqlserverLockByResourceCountMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.lock.by_resource.count metric with initial data.
+func (m *metricSqlserverLockByResourceCount) init() {
+	m.data.SetName("sqlserver.lock.by_resource.count")
+	m.data.SetDescription("Number of currently active locks held in the database, grouped by resource type.")
+	m.data.SetUnit("{locks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverLockByResourceCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, lockResourceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByResourceCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByResourceCountMetricAttributeKeyLockResource) {
+		dp.Attributes().PutStr("lock.resource", lockResourceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverLockByResourceCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverLockByResourceCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverLockByResourceCount(cfg SqlserverLockByResourceCountMetricConfig) metricSqlserverLockByResourceCount {
+	m := metricSqlserverLockByResourceCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5270,6 +7616,656 @@ func newMetricSqlserverTableCount(cfg SqlserverTableCountMetricConfig) metricSql
 	return m
 }
 
+type metricSqlserverTempdbAllocationWaitTimeTotal struct {
+	data          pmetric.Metric                                     // data buffer for generated metric.
+	config        SqlserverTempdbAllocationWaitTimeTotalMetricConfig // metric config provided by user.
+	capacity      int                                                // max observed number of data points added to the metric.
+	aggDataPoints []float64                                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.allocation.wait_time.total metric with initial data.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) init() {
+	m.data.SetName("sqlserver.tempdb.allocation.wait_time.total")
+	m.data.SetDescription("Cumulative wait time on tempdb allocation pages, broken down by page type.")
+	m.data.SetUnit("s")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, allocationPageTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType) {
+		dp.Attributes().PutStr("allocation.page_type", allocationPageTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbAllocationWaitTimeTotal(cfg SqlserverTempdbAllocationWaitTimeTotalMetricConfig) metricSqlserverTempdbAllocationWaitTimeTotal {
+	m := metricSqlserverTempdbAllocationWaitTimeTotal{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbContentionWaitersCount struct {
+	data     pmetric.Metric                                    // data buffer for generated metric.
+	config   SqlserverTempdbContentionWaitersCountMetricConfig // metric config provided by user.
+	capacity int                                               // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.tempdb.contention.waiters.count metric with initial data.
+func (m *metricSqlserverTempdbContentionWaitersCount) init() {
+	m.data.SetName("sqlserver.tempdb.contention.waiters.count")
+	m.data.SetDescription("Number of tempdb pagelatch wait types with at least one active waiter.")
+	m.data.SetUnit("{waiters}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTempdbContentionWaitersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbContentionWaitersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbContentionWaitersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbContentionWaitersCount(cfg SqlserverTempdbContentionWaitersCountMetricConfig) metricSqlserverTempdbContentionWaitersCount {
+	m := metricSqlserverTempdbContentionWaitersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbDataFilesCount struct {
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   SqlserverTempdbDataFilesCountMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.tempdb.data_files.count metric with initial data.
+func (m *metricSqlserverTempdbDataFilesCount) init() {
+	m.data.SetName("sqlserver.tempdb.data_files.count")
+	m.data.SetDescription("Number of tempdb data files configured on the instance.")
+	m.data.SetUnit("{files}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTempdbDataFilesCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbDataFilesCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbDataFilesCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbDataFilesCount(cfg SqlserverTempdbDataFilesCountMetricConfig) metricSqlserverTempdbDataFilesCount {
+	m := metricSqlserverTempdbDataFilesCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbFileSize struct {
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        SqlserverTempdbFileSizeMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.file.size metric with initial data.
+func (m *metricSqlserverTempdbFileSize) init() {
+	m.data.SetName("sqlserver.tempdb.file.size")
+	m.data.SetDescription("Size of each tempdb data or log file.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbFileSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, fileTypeAttributeValue string, tempdbFileIDAttributeValue int64) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbFileSizeMetricAttributeKeyFileType) {
+		dp.Attributes().PutStr("file_type", fileTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID) {
+		dp.Attributes().PutInt("tempdb.file.id", tempdbFileIDAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbFileSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbFileSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbFileSize(cfg SqlserverTempdbFileSizeMetricConfig) metricSqlserverTempdbFileSize {
+	m := metricSqlserverTempdbFileSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbSpaceUsage struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        SqlserverTempdbSpaceUsageMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.space.usage metric with initial data.
+func (m *metricSqlserverTempdbSpaceUsage) init() {
+	m.data.SetName("sqlserver.tempdb.space.usage")
+	m.data.SetDescription("Space used by tempdb, broken down by allocation category.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbSpaceUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tempdbSpaceKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind) {
+		dp.Attributes().PutStr("tempdb.space_kind", tempdbSpaceKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbSpaceUsage) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbSpaceUsage) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbSpaceUsage(cfg SqlserverTempdbSpaceUsageMetricConfig) metricSqlserverTempdbSpaceUsage {
+	m := metricSqlserverTempdbSpaceUsage{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolTasksCount struct {
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        SqlserverThreadPoolTasksCountMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.thread_pool.tasks.count metric with initial data.
+func (m *metricSqlserverThreadPoolTasksCount) init() {
+	m.data.SetName("sqlserver.thread_pool.tasks.count")
+	m.data.SetDescription("Number of SQL Server tasks broken down by state.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverThreadPoolTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, taskStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState) {
+		dp.Attributes().PutStr("task.state", taskStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolTasksCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolTasksCount(cfg SqlserverThreadPoolTasksCountMetricConfig) metricSqlserverThreadPoolTasksCount {
+	m := metricSqlserverThreadPoolTasksCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersCount struct {
+	data          pmetric.Metric                              // data buffer for generated metric.
+	config        SqlserverThreadPoolWorkersCountMetricConfig // metric config provided by user.
+	capacity      int                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.thread_pool.workers.count metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersCount) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.count")
+	m.data.SetDescription("Number of SQL Server worker threads broken down by state.")
+	m.data.SetUnit("{workers}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverThreadPoolWorkersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, workerStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState) {
+		dp.Attributes().PutStr("worker.state", workerStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersCount(cfg SqlserverThreadPoolWorkersCountMetricConfig) metricSqlserverThreadPoolWorkersCount {
+	m := metricSqlserverThreadPoolWorkersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersMax struct {
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   SqlserverThreadPoolWorkersMaxMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.thread_pool.workers.max metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersMax) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.max")
+	m.data.SetDescription("Maximum number of SQL Server worker threads configured on the instance.")
+	m.data.SetUnit("{workers}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverThreadPoolWorkersMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersMax) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersMax) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersMax(cfg SqlserverThreadPoolWorkersMaxMetricConfig) metricSqlserverThreadPoolWorkersMax {
+	m := metricSqlserverThreadPoolWorkersMax{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersUtilization struct {
+	data     pmetric.Metric                                    // data buffer for generated metric.
+	config   SqlserverThreadPoolWorkersUtilizationMetricConfig // metric config provided by user.
+	capacity int                                               // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.thread_pool.workers.utilization metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersUtilization) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.utilization")
+	m.data.SetDescription("Fraction of configured SQL Server worker threads currently running.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverThreadPoolWorkersUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersUtilization(cfg SqlserverThreadPoolWorkersUtilizationMetricConfig) metricSqlserverThreadPoolWorkersUtilization {
+	m := metricSqlserverThreadPoolWorkersUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverTransactionDelay struct {
 	data     pmetric.Metric                        // data buffer for generated metric.
 	config   SqlserverTransactionDelayMetricConfig // metric config provided by user.
@@ -5314,6 +8310,56 @@ func (m *metricSqlserverTransactionDelay) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverTransactionDelay(cfg SqlserverTransactionDelayMetricConfig) metricSqlserverTransactionDelay {
 	m := metricSqlserverTransactionDelay{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionLongestRunningTime struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverTransactionLongestRunningTimeMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.longest_running_time metric with initial data.
+func (m *metricSqlserverTransactionLongestRunningTime) init() {
+	m.data.SetName("sqlserver.transaction.longest_running_time")
+	m.data.SetDescription("Age in seconds of the longest currently-open transaction on the server.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTransactionLongestRunningTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionLongestRunningTime) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionLongestRunningTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionLongestRunningTime(cfg SqlserverTransactionLongestRunningTimeMetricConfig) metricSqlserverTransactionLongestRunningTime {
+	m := metricSqlserverTransactionLongestRunningTime{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5414,6 +8460,110 @@ func (m *metricSqlserverTransactionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverTransactionRate(cfg SqlserverTransactionRateMetricConfig) metricSqlserverTransactionRate {
 	m := metricSqlserverTransactionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionVersionCleanupRate struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverTransactionVersionCleanupRateMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.version_cleanup.rate metric with initial data.
+func (m *metricSqlserverTransactionVersionCleanupRate) init() {
+	m.data.SetName("sqlserver.transaction.version_cleanup.rate")
+	m.data.SetDescription("Cumulative bytes cleaned from the tempdb version store.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSqlserverTransactionVersionCleanupRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionVersionCleanupRate) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionVersionCleanupRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionVersionCleanupRate(cfg SqlserverTransactionVersionCleanupRateMetricConfig) metricSqlserverTransactionVersionCleanupRate {
+	m := metricSqlserverTransactionVersionCleanupRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionVersionGenerationRate struct {
+	data     pmetric.Metric                                        // data buffer for generated metric.
+	config   SqlserverTransactionVersionGenerationRateMetricConfig // metric config provided by user.
+	capacity int                                                   // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.version_generation.rate metric with initial data.
+func (m *metricSqlserverTransactionVersionGenerationRate) init() {
+	m.data.SetName("sqlserver.transaction.version_generation.rate")
+	m.data.SetDescription("Cumulative bytes of row versions written to the tempdb version store.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSqlserverTransactionVersionGenerationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionVersionGenerationRate) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionVersionGenerationRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionVersionGenerationRate(cfg SqlserverTransactionVersionGenerationRateMetricConfig) metricSqlserverTransactionVersionGenerationRate {
+	m := metricSqlserverTransactionVersionGenerationRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5829,91 +8979,122 @@ func newMetricSqlserverUserConnectionCount(cfg SqlserverUserConnectionCountMetri
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                                             MetricsBuilderConfig // config of the metrics builder.
-	startTime                                          pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                                    int                  // maximum observed number of metrics per resource.
-	metricsBuffer                                      pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                                          component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter                     map[string]filter.Filter
-	resourceAttributeExcludeFilter                     map[string]filter.Filter
-	metricSqlserverAttentionRate                       metricSqlserverAttentionRate
-	metricSqlserverBatchCompilationUtilization         metricSqlserverBatchCompilationUtilization
-	metricSqlserverBatchPageSplitUtilization           metricSqlserverBatchPageSplitUtilization
-	metricSqlserverBatchRequestRate                    metricSqlserverBatchRequestRate
-	metricSqlserverBatchSQLCompilationRate             metricSqlserverBatchSQLCompilationRate
-	metricSqlserverBatchSQLRecompilationRate           metricSqlserverBatchSQLRecompilationRate
-	metricSqlserverComputerUptime                      metricSqlserverComputerUptime
-	metricSqlserverCPUCount                            metricSqlserverCPUCount
-	metricSqlserverDatabaseBackupOrRestoreRate         metricSqlserverDatabaseBackupOrRestoreRate
-	metricSqlserverDatabaseCount                       metricSqlserverDatabaseCount
-	metricSqlserverDatabaseExecutionErrors             metricSqlserverDatabaseExecutionErrors
-	metricSqlserverDatabaseFileSize                    metricSqlserverDatabaseFileSize
-	metricSqlserverDatabaseFullScanRate                metricSqlserverDatabaseFullScanRate
-	metricSqlserverDatabaseIo                          metricSqlserverDatabaseIo
-	metricSqlserverDatabaseLatency                     metricSqlserverDatabaseLatency
-	metricSqlserverDatabaseOperations                  metricSqlserverDatabaseOperations
-	metricSqlserverDatabasePageFileSize                metricSqlserverDatabasePageFileSize
-	metricSqlserverDatabaseSecurityRoleMembershipCount metricSqlserverDatabaseSecurityRoleMembershipCount
-	metricSqlserverDatabaseTempdbSpace                 metricSqlserverDatabaseTempdbSpace
-	metricSqlserverDatabaseTempdbVersionStoreSize      metricSqlserverDatabaseTempdbVersionStoreSize
-	metricSqlserverDatabaseTransactionsActive          metricSqlserverDatabaseTransactionsActive
-	metricSqlserverDeadlockRate                        metricSqlserverDeadlockRate
-	metricSqlserverIndexSearchRate                     metricSqlserverIndexSearchRate
-	metricSqlserverKillConnectionErrorRate             metricSqlserverKillConnectionErrorRate
-	metricSqlserverLatchSuperlatchCount                metricSqlserverLatchSuperlatchCount
-	metricSqlserverLatchSuperlatchTransitionRate       metricSqlserverLatchSuperlatchTransitionRate
-	metricSqlserverLatchWaitRate                       metricSqlserverLatchWaitRate
-	metricSqlserverLatchWaitTimeAvg                    metricSqlserverLatchWaitTimeAvg
-	metricSqlserverLatchWaitTimeTotal                  metricSqlserverLatchWaitTimeTotal
-	metricSqlserverLockTimeoutRate                     metricSqlserverLockTimeoutRate
-	metricSqlserverLockWaitCount                       metricSqlserverLockWaitCount
-	metricSqlserverLockWaitRate                        metricSqlserverLockWaitRate
-	metricSqlserverLockWaitTimeAvg                     metricSqlserverLockWaitTimeAvg
-	metricSqlserverLoginRate                           metricSqlserverLoginRate
-	metricSqlserverLogoutRate                          metricSqlserverLogoutRate
-	metricSqlserverMemoryArea                          metricSqlserverMemoryArea
-	metricSqlserverMemoryCacheObjectCount              metricSqlserverMemoryCacheObjectCount
-	metricSqlserverMemoryGrantsPendingCount            metricSqlserverMemoryGrantsPendingCount
-	metricSqlserverMemoryPageCount                     metricSqlserverMemoryPageCount
-	metricSqlserverMemoryTarget                        metricSqlserverMemoryTarget
-	metricSqlserverMemoryUsage                         metricSqlserverMemoryUsage
-	metricSqlserverOsDiskSize                          metricSqlserverOsDiskSize
-	metricSqlserverOsMemoryUsage                       metricSqlserverOsMemoryUsage
-	metricSqlserverOsMemoryUtilization                 metricSqlserverOsMemoryUtilization
-	metricSqlserverOsSchedulerRunnableTasksCount       metricSqlserverOsSchedulerRunnableTasksCount
-	metricSqlserverOsWaitDuration                      metricSqlserverOsWaitDuration
-	metricSqlserverOsWaitTasksCount                    metricSqlserverOsWaitTasksCount
-	metricSqlserverPageBufferCacheFreeListStallsRate   metricSqlserverPageBufferCacheFreeListStallsRate
-	metricSqlserverPageBufferCacheHitRatio             metricSqlserverPageBufferCacheHitRatio
-	metricSqlserverPageCheckpointFlushRate             metricSqlserverPageCheckpointFlushRate
-	metricSqlserverPageLazyWriteRate                   metricSqlserverPageLazyWriteRate
-	metricSqlserverPageLifeExpectancy                  metricSqlserverPageLifeExpectancy
-	metricSqlserverPageLookupRate                      metricSqlserverPageLookupRate
-	metricSqlserverPageOperationRate                   metricSqlserverPageOperationRate
-	metricSqlserverPageSplitRate                       metricSqlserverPageSplitRate
-	metricSqlserverParameterizationRate                metricSqlserverParameterizationRate
-	metricSqlserverPlanExecutionRate                   metricSqlserverPlanExecutionRate
-	metricSqlserverProcessCount                        metricSqlserverProcessCount
-	metricSqlserverProcessesBlocked                    metricSqlserverProcessesBlocked
-	metricSqlserverRecompilationRatio                  metricSqlserverRecompilationRatio
-	metricSqlserverReplicaDataRate                     metricSqlserverReplicaDataRate
-	metricSqlserverResourcePoolDiskOperations          metricSqlserverResourcePoolDiskOperations
-	metricSqlserverResourcePoolDiskThrottledReadRate   metricSqlserverResourcePoolDiskThrottledReadRate
-	metricSqlserverResourcePoolDiskThrottledWriteRate  metricSqlserverResourcePoolDiskThrottledWriteRate
-	metricSqlserverServerSecurityPrincipalCount        metricSqlserverServerSecurityPrincipalCount
-	metricSqlserverServerSecurityRoleMembershipCount   metricSqlserverServerSecurityRoleMembershipCount
-	metricSqlserverTableCount                          metricSqlserverTableCount
-	metricSqlserverTransactionDelay                    metricSqlserverTransactionDelay
-	metricSqlserverTransactionMirrorWriteRate          metricSqlserverTransactionMirrorWriteRate
-	metricSqlserverTransactionRate                     metricSqlserverTransactionRate
-	metricSqlserverTransactionWriteRate                metricSqlserverTransactionWriteRate
-	metricSqlserverTransactionLogFlushDataRate         metricSqlserverTransactionLogFlushDataRate
-	metricSqlserverTransactionLogFlushRate             metricSqlserverTransactionLogFlushRate
-	metricSqlserverTransactionLogFlushWaitRate         metricSqlserverTransactionLogFlushWaitRate
-	metricSqlserverTransactionLogGrowthCount           metricSqlserverTransactionLogGrowthCount
-	metricSqlserverTransactionLogShrinkCount           metricSqlserverTransactionLogShrinkCount
-	metricSqlserverTransactionLogUsage                 metricSqlserverTransactionLogUsage
-	metricSqlserverUserConnectionCount                 metricSqlserverUserConnectionCount
+	config                                                     MetricsBuilderConfig // config of the metrics builder.
+	startTime                                                  pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                                            int                  // maximum observed number of metrics per resource.
+	metricsBuffer                                              pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                                                  component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter                             map[string]filter.Filter
+	resourceAttributeExcludeFilter                             map[string]filter.Filter
+	metricSqlserverAttentionRate                               metricSqlserverAttentionRate
+	metricSqlserverBatchCompilationUtilization                 metricSqlserverBatchCompilationUtilization
+	metricSqlserverBatchPageSplitUtilization                   metricSqlserverBatchPageSplitUtilization
+	metricSqlserverBatchRequestRate                            metricSqlserverBatchRequestRate
+	metricSqlserverBatchSQLCompilationRate                     metricSqlserverBatchSQLCompilationRate
+	metricSqlserverBatchSQLRecompilationRate                   metricSqlserverBatchSQLRecompilationRate
+	metricSqlserverComputerUptime                              metricSqlserverComputerUptime
+	metricSqlserverCPUCount                                    metricSqlserverCPUCount
+	metricSqlserverDatabaseBackupOrRestoreRate                 metricSqlserverDatabaseBackupOrRestoreRate
+	metricSqlserverDatabaseCount                               metricSqlserverDatabaseCount
+	metricSqlserverDatabaseExecutionErrors                     metricSqlserverDatabaseExecutionErrors
+	metricSqlserverDatabaseFileSize                            metricSqlserverDatabaseFileSize
+	metricSqlserverDatabaseFullScanRate                        metricSqlserverDatabaseFullScanRate
+	metricSqlserverDatabaseIo                                  metricSqlserverDatabaseIo
+	metricSqlserverDatabaseLatency                             metricSqlserverDatabaseLatency
+	metricSqlserverDatabaseOperations                          metricSqlserverDatabaseOperations
+	metricSqlserverDatabasePageFileSize                        metricSqlserverDatabasePageFileSize
+	metricSqlserverDatabasePrincipalsCount                     metricSqlserverDatabasePrincipalsCount
+	metricSqlserverDatabasePrincipalsOld                       metricSqlserverDatabasePrincipalsOld
+	metricSqlserverDatabasePrincipalsOrphanedUsers             metricSqlserverDatabasePrincipalsOrphanedUsers
+	metricSqlserverDatabasePrincipalsRecentlyCreated           metricSqlserverDatabasePrincipalsRecentlyCreated
+	metricSqlserverDatabaseRoleMembersCount                    metricSqlserverDatabaseRoleMembersCount
+	metricSqlserverDatabaseRoleMembershipsCount                metricSqlserverDatabaseRoleMembershipsCount
+	metricSqlserverDatabaseRolePermissionRiskLevel             metricSqlserverDatabaseRolePermissionRiskLevel
+	metricSqlserverDatabaseRoleRolesCount                      metricSqlserverDatabaseRoleRolesCount
+	metricSqlserverDatabaseSecurityRoleMembershipCount         metricSqlserverDatabaseSecurityRoleMembershipCount
+	metricSqlserverDatabaseTempdbSpace                         metricSqlserverDatabaseTempdbSpace
+	metricSqlserverDatabaseTempdbVersionStoreSize              metricSqlserverDatabaseTempdbVersionStoreSize
+	metricSqlserverDatabaseTransactionsActive                  metricSqlserverDatabaseTransactionsActive
+	metricSqlserverDeadlockRate                                metricSqlserverDeadlockRate
+	metricSqlserverFailoverClusterAgClusterType                metricSqlserverFailoverClusterAgClusterType
+	metricSqlserverFailoverClusterAgFailureConditionLevel      metricSqlserverFailoverClusterAgFailureConditionLevel
+	metricSqlserverFailoverClusterAgHealthCheckTimeout         metricSqlserverFailoverClusterAgHealthCheckTimeout
+	metricSqlserverFailoverClusterAgRequiredSyncSecondaries    metricSqlserverFailoverClusterAgRequiredSyncSecondaries
+	metricSqlserverFailoverClusterReplicaDatabaseQueueSize     metricSqlserverFailoverClusterReplicaDatabaseQueueSize
+	metricSqlserverFailoverClusterReplicaDatabaseRedoRate      metricSqlserverFailoverClusterReplicaDatabaseRedoRate
+	metricSqlserverFailoverClusterReplicaFlowControlTime       metricSqlserverFailoverClusterReplicaFlowControlTime
+	metricSqlserverFailoverClusterReplicaRole                  metricSqlserverFailoverClusterReplicaRole
+	metricSqlserverFailoverClusterReplicaSynchronizationHealth metricSqlserverFailoverClusterReplicaSynchronizationHealth
+	metricSqlserverIndexSearchRate                             metricSqlserverIndexSearchRate
+	metricSqlserverKillConnectionErrorRate                     metricSqlserverKillConnectionErrorRate
+	metricSqlserverLatchSuperlatchCount                        metricSqlserverLatchSuperlatchCount
+	metricSqlserverLatchSuperlatchTransitionRate               metricSqlserverLatchSuperlatchTransitionRate
+	metricSqlserverLatchWaitRate                               metricSqlserverLatchWaitRate
+	metricSqlserverLatchWaitTimeAvg                            metricSqlserverLatchWaitTimeAvg
+	metricSqlserverLatchWaitTimeTotal                          metricSqlserverLatchWaitTimeTotal
+	metricSqlserverLockByModeCount                             metricSqlserverLockByModeCount
+	metricSqlserverLockByResourceCount                         metricSqlserverLockByResourceCount
+	metricSqlserverLockTimeoutRate                             metricSqlserverLockTimeoutRate
+	metricSqlserverLockWaitCount                               metricSqlserverLockWaitCount
+	metricSqlserverLockWaitRate                                metricSqlserverLockWaitRate
+	metricSqlserverLockWaitTimeAvg                             metricSqlserverLockWaitTimeAvg
+	metricSqlserverLoginRate                                   metricSqlserverLoginRate
+	metricSqlserverLogoutRate                                  metricSqlserverLogoutRate
+	metricSqlserverMemoryArea                                  metricSqlserverMemoryArea
+	metricSqlserverMemoryCacheObjectCount                      metricSqlserverMemoryCacheObjectCount
+	metricSqlserverMemoryGrantsPendingCount                    metricSqlserverMemoryGrantsPendingCount
+	metricSqlserverMemoryPageCount                             metricSqlserverMemoryPageCount
+	metricSqlserverMemoryTarget                                metricSqlserverMemoryTarget
+	metricSqlserverMemoryUsage                                 metricSqlserverMemoryUsage
+	metricSqlserverOsDiskSize                                  metricSqlserverOsDiskSize
+	metricSqlserverOsMemoryUsage                               metricSqlserverOsMemoryUsage
+	metricSqlserverOsMemoryUtilization                         metricSqlserverOsMemoryUtilization
+	metricSqlserverOsSchedulerRunnableTasksCount               metricSqlserverOsSchedulerRunnableTasksCount
+	metricSqlserverOsWaitDuration                              metricSqlserverOsWaitDuration
+	metricSqlserverOsWaitTasksCount                            metricSqlserverOsWaitTasksCount
+	metricSqlserverPageBufferCacheFreeListStallsRate           metricSqlserverPageBufferCacheFreeListStallsRate
+	metricSqlserverPageBufferCacheHitRatio                     metricSqlserverPageBufferCacheHitRatio
+	metricSqlserverPageCheckpointFlushRate                     metricSqlserverPageCheckpointFlushRate
+	metricSqlserverPageLazyWriteRate                           metricSqlserverPageLazyWriteRate
+	metricSqlserverPageLifeExpectancy                          metricSqlserverPageLifeExpectancy
+	metricSqlserverPageLookupRate                              metricSqlserverPageLookupRate
+	metricSqlserverPageOperationRate                           metricSqlserverPageOperationRate
+	metricSqlserverPageSplitRate                               metricSqlserverPageSplitRate
+	metricSqlserverParameterizationRate                        metricSqlserverParameterizationRate
+	metricSqlserverPlanExecutionRate                           metricSqlserverPlanExecutionRate
+	metricSqlserverProcessCount                                metricSqlserverProcessCount
+	metricSqlserverProcessesBlocked                            metricSqlserverProcessesBlocked
+	metricSqlserverRecompilationRatio                          metricSqlserverRecompilationRatio
+	metricSqlserverReplicaDataRate                             metricSqlserverReplicaDataRate
+	metricSqlserverResourcePoolDiskOperations                  metricSqlserverResourcePoolDiskOperations
+	metricSqlserverResourcePoolDiskThrottledReadRate           metricSqlserverResourcePoolDiskThrottledReadRate
+	metricSqlserverResourcePoolDiskThrottledWriteRate          metricSqlserverResourcePoolDiskThrottledWriteRate
+	metricSqlserverServerSecurityPrincipalCount                metricSqlserverServerSecurityPrincipalCount
+	metricSqlserverServerSecurityRoleMembershipCount           metricSqlserverServerSecurityRoleMembershipCount
+	metricSqlserverTableCount                                  metricSqlserverTableCount
+	metricSqlserverTempdbAllocationWaitTimeTotal               metricSqlserverTempdbAllocationWaitTimeTotal
+	metricSqlserverTempdbContentionWaitersCount                metricSqlserverTempdbContentionWaitersCount
+	metricSqlserverTempdbDataFilesCount                        metricSqlserverTempdbDataFilesCount
+	metricSqlserverTempdbFileSize                              metricSqlserverTempdbFileSize
+	metricSqlserverTempdbSpaceUsage                            metricSqlserverTempdbSpaceUsage
+	metricSqlserverThreadPoolTasksCount                        metricSqlserverThreadPoolTasksCount
+	metricSqlserverThreadPoolWorkersCount                      metricSqlserverThreadPoolWorkersCount
+	metricSqlserverThreadPoolWorkersMax                        metricSqlserverThreadPoolWorkersMax
+	metricSqlserverThreadPoolWorkersUtilization                metricSqlserverThreadPoolWorkersUtilization
+	metricSqlserverTransactionDelay                            metricSqlserverTransactionDelay
+	metricSqlserverTransactionLongestRunningTime               metricSqlserverTransactionLongestRunningTime
+	metricSqlserverTransactionMirrorWriteRate                  metricSqlserverTransactionMirrorWriteRate
+	metricSqlserverTransactionRate                             metricSqlserverTransactionRate
+	metricSqlserverTransactionVersionCleanupRate               metricSqlserverTransactionVersionCleanupRate
+	metricSqlserverTransactionVersionGenerationRate            metricSqlserverTransactionVersionGenerationRate
+	metricSqlserverTransactionWriteRate                        metricSqlserverTransactionWriteRate
+	metricSqlserverTransactionLogFlushDataRate                 metricSqlserverTransactionLogFlushDataRate
+	metricSqlserverTransactionLogFlushRate                     metricSqlserverTransactionLogFlushRate
+	metricSqlserverTransactionLogFlushWaitRate                 metricSqlserverTransactionLogFlushWaitRate
+	metricSqlserverTransactionLogGrowthCount                   metricSqlserverTransactionLogGrowthCount
+	metricSqlserverTransactionLogShrinkCount                   metricSqlserverTransactionLogShrinkCount
+	metricSqlserverTransactionLogUsage                         metricSqlserverTransactionLogUsage
+	metricSqlserverUserConnectionCount                         metricSqlserverUserConnectionCount
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -5940,85 +9121,116 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricsBuffer:                pmetric.NewMetrics(),
 		buildInfo:                    settings.BuildInfo,
 		metricSqlserverAttentionRate: newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
-		metricSqlserverBatchCompilationUtilization:         newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
-		metricSqlserverBatchPageSplitUtilization:           newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
-		metricSqlserverBatchRequestRate:                    newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
-		metricSqlserverBatchSQLCompilationRate:             newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
-		metricSqlserverBatchSQLRecompilationRate:           newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
-		metricSqlserverComputerUptime:                      newMetricSqlserverComputerUptime(mbc.Metrics.SqlserverComputerUptime),
-		metricSqlserverCPUCount:                            newMetricSqlserverCPUCount(mbc.Metrics.SqlserverCPUCount),
-		metricSqlserverDatabaseBackupOrRestoreRate:         newMetricSqlserverDatabaseBackupOrRestoreRate(mbc.Metrics.SqlserverDatabaseBackupOrRestoreRate),
-		metricSqlserverDatabaseCount:                       newMetricSqlserverDatabaseCount(mbc.Metrics.SqlserverDatabaseCount),
-		metricSqlserverDatabaseExecutionErrors:             newMetricSqlserverDatabaseExecutionErrors(mbc.Metrics.SqlserverDatabaseExecutionErrors),
-		metricSqlserverDatabaseFileSize:                    newMetricSqlserverDatabaseFileSize(mbc.Metrics.SqlserverDatabaseFileSize),
-		metricSqlserverDatabaseFullScanRate:                newMetricSqlserverDatabaseFullScanRate(mbc.Metrics.SqlserverDatabaseFullScanRate),
-		metricSqlserverDatabaseIo:                          newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
-		metricSqlserverDatabaseLatency:                     newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
-		metricSqlserverDatabaseOperations:                  newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
-		metricSqlserverDatabasePageFileSize:                newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
-		metricSqlserverDatabaseSecurityRoleMembershipCount: newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
-		metricSqlserverDatabaseTempdbSpace:                 newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
-		metricSqlserverDatabaseTempdbVersionStoreSize:      newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
-		metricSqlserverDatabaseTransactionsActive:          newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
-		metricSqlserverDeadlockRate:                        newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
-		metricSqlserverIndexSearchRate:                     newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
-		metricSqlserverKillConnectionErrorRate:             newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
-		metricSqlserverLatchSuperlatchCount:                newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
-		metricSqlserverLatchSuperlatchTransitionRate:       newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
-		metricSqlserverLatchWaitRate:                       newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
-		metricSqlserverLatchWaitTimeAvg:                    newMetricSqlserverLatchWaitTimeAvg(mbc.Metrics.SqlserverLatchWaitTimeAvg),
-		metricSqlserverLatchWaitTimeTotal:                  newMetricSqlserverLatchWaitTimeTotal(mbc.Metrics.SqlserverLatchWaitTimeTotal),
-		metricSqlserverLockTimeoutRate:                     newMetricSqlserverLockTimeoutRate(mbc.Metrics.SqlserverLockTimeoutRate),
-		metricSqlserverLockWaitCount:                       newMetricSqlserverLockWaitCount(mbc.Metrics.SqlserverLockWaitCount),
-		metricSqlserverLockWaitRate:                        newMetricSqlserverLockWaitRate(mbc.Metrics.SqlserverLockWaitRate),
-		metricSqlserverLockWaitTimeAvg:                     newMetricSqlserverLockWaitTimeAvg(mbc.Metrics.SqlserverLockWaitTimeAvg),
-		metricSqlserverLoginRate:                           newMetricSqlserverLoginRate(mbc.Metrics.SqlserverLoginRate),
-		metricSqlserverLogoutRate:                          newMetricSqlserverLogoutRate(mbc.Metrics.SqlserverLogoutRate),
-		metricSqlserverMemoryArea:                          newMetricSqlserverMemoryArea(mbc.Metrics.SqlserverMemoryArea),
-		metricSqlserverMemoryCacheObjectCount:              newMetricSqlserverMemoryCacheObjectCount(mbc.Metrics.SqlserverMemoryCacheObjectCount),
-		metricSqlserverMemoryGrantsPendingCount:            newMetricSqlserverMemoryGrantsPendingCount(mbc.Metrics.SqlserverMemoryGrantsPendingCount),
-		metricSqlserverMemoryPageCount:                     newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
-		metricSqlserverMemoryTarget:                        newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
-		metricSqlserverMemoryUsage:                         newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
-		metricSqlserverOsDiskSize:                          newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
-		metricSqlserverOsMemoryUsage:                       newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
-		metricSqlserverOsMemoryUtilization:                 newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
-		metricSqlserverOsSchedulerRunnableTasksCount:       newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
-		metricSqlserverOsWaitDuration:                      newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
-		metricSqlserverOsWaitTasksCount:                    newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
-		metricSqlserverPageBufferCacheFreeListStallsRate:   newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
-		metricSqlserverPageBufferCacheHitRatio:             newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
-		metricSqlserverPageCheckpointFlushRate:             newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
-		metricSqlserverPageLazyWriteRate:                   newMetricSqlserverPageLazyWriteRate(mbc.Metrics.SqlserverPageLazyWriteRate),
-		metricSqlserverPageLifeExpectancy:                  newMetricSqlserverPageLifeExpectancy(mbc.Metrics.SqlserverPageLifeExpectancy),
-		metricSqlserverPageLookupRate:                      newMetricSqlserverPageLookupRate(mbc.Metrics.SqlserverPageLookupRate),
-		metricSqlserverPageOperationRate:                   newMetricSqlserverPageOperationRate(mbc.Metrics.SqlserverPageOperationRate),
-		metricSqlserverPageSplitRate:                       newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
-		metricSqlserverParameterizationRate:                newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
-		metricSqlserverPlanExecutionRate:                   newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
-		metricSqlserverProcessCount:                        newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
-		metricSqlserverProcessesBlocked:                    newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
-		metricSqlserverRecompilationRatio:                  newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
-		metricSqlserverReplicaDataRate:                     newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
-		metricSqlserverResourcePoolDiskOperations:          newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
-		metricSqlserverResourcePoolDiskThrottledReadRate:   newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
-		metricSqlserverResourcePoolDiskThrottledWriteRate:  newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
-		metricSqlserverServerSecurityPrincipalCount:        newMetricSqlserverServerSecurityPrincipalCount(mbc.Metrics.SqlserverServerSecurityPrincipalCount),
-		metricSqlserverServerSecurityRoleMembershipCount:   newMetricSqlserverServerSecurityRoleMembershipCount(mbc.Metrics.SqlserverServerSecurityRoleMembershipCount),
-		metricSqlserverTableCount:                          newMetricSqlserverTableCount(mbc.Metrics.SqlserverTableCount),
-		metricSqlserverTransactionDelay:                    newMetricSqlserverTransactionDelay(mbc.Metrics.SqlserverTransactionDelay),
-		metricSqlserverTransactionMirrorWriteRate:          newMetricSqlserverTransactionMirrorWriteRate(mbc.Metrics.SqlserverTransactionMirrorWriteRate),
-		metricSqlserverTransactionRate:                     newMetricSqlserverTransactionRate(mbc.Metrics.SqlserverTransactionRate),
-		metricSqlserverTransactionWriteRate:                newMetricSqlserverTransactionWriteRate(mbc.Metrics.SqlserverTransactionWriteRate),
-		metricSqlserverTransactionLogFlushDataRate:         newMetricSqlserverTransactionLogFlushDataRate(mbc.Metrics.SqlserverTransactionLogFlushDataRate),
-		metricSqlserverTransactionLogFlushRate:             newMetricSqlserverTransactionLogFlushRate(mbc.Metrics.SqlserverTransactionLogFlushRate),
-		metricSqlserverTransactionLogFlushWaitRate:         newMetricSqlserverTransactionLogFlushWaitRate(mbc.Metrics.SqlserverTransactionLogFlushWaitRate),
-		metricSqlserverTransactionLogGrowthCount:           newMetricSqlserverTransactionLogGrowthCount(mbc.Metrics.SqlserverTransactionLogGrowthCount),
-		metricSqlserverTransactionLogShrinkCount:           newMetricSqlserverTransactionLogShrinkCount(mbc.Metrics.SqlserverTransactionLogShrinkCount),
-		metricSqlserverTransactionLogUsage:                 newMetricSqlserverTransactionLogUsage(mbc.Metrics.SqlserverTransactionLogUsage),
-		metricSqlserverUserConnectionCount:                 newMetricSqlserverUserConnectionCount(mbc.Metrics.SqlserverUserConnectionCount),
-		resourceAttributeIncludeFilter:                     make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:                     make(map[string]filter.Filter),
+		metricSqlserverBatchCompilationUtilization:                 newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
+		metricSqlserverBatchPageSplitUtilization:                   newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
+		metricSqlserverBatchRequestRate:                            newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
+		metricSqlserverBatchSQLCompilationRate:                     newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
+		metricSqlserverBatchSQLRecompilationRate:                   newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
+		metricSqlserverComputerUptime:                              newMetricSqlserverComputerUptime(mbc.Metrics.SqlserverComputerUptime),
+		metricSqlserverCPUCount:                                    newMetricSqlserverCPUCount(mbc.Metrics.SqlserverCPUCount),
+		metricSqlserverDatabaseBackupOrRestoreRate:                 newMetricSqlserverDatabaseBackupOrRestoreRate(mbc.Metrics.SqlserverDatabaseBackupOrRestoreRate),
+		metricSqlserverDatabaseCount:                               newMetricSqlserverDatabaseCount(mbc.Metrics.SqlserverDatabaseCount),
+		metricSqlserverDatabaseExecutionErrors:                     newMetricSqlserverDatabaseExecutionErrors(mbc.Metrics.SqlserverDatabaseExecutionErrors),
+		metricSqlserverDatabaseFileSize:                            newMetricSqlserverDatabaseFileSize(mbc.Metrics.SqlserverDatabaseFileSize),
+		metricSqlserverDatabaseFullScanRate:                        newMetricSqlserverDatabaseFullScanRate(mbc.Metrics.SqlserverDatabaseFullScanRate),
+		metricSqlserverDatabaseIo:                                  newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
+		metricSqlserverDatabaseLatency:                             newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
+		metricSqlserverDatabaseOperations:                          newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
+		metricSqlserverDatabasePageFileSize:                        newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
+		metricSqlserverDatabasePrincipalsCount:                     newMetricSqlserverDatabasePrincipalsCount(mbc.Metrics.SqlserverDatabasePrincipalsCount),
+		metricSqlserverDatabasePrincipalsOld:                       newMetricSqlserverDatabasePrincipalsOld(mbc.Metrics.SqlserverDatabasePrincipalsOld),
+		metricSqlserverDatabasePrincipalsOrphanedUsers:             newMetricSqlserverDatabasePrincipalsOrphanedUsers(mbc.Metrics.SqlserverDatabasePrincipalsOrphanedUsers),
+		metricSqlserverDatabasePrincipalsRecentlyCreated:           newMetricSqlserverDatabasePrincipalsRecentlyCreated(mbc.Metrics.SqlserverDatabasePrincipalsRecentlyCreated),
+		metricSqlserverDatabaseRoleMembersCount:                    newMetricSqlserverDatabaseRoleMembersCount(mbc.Metrics.SqlserverDatabaseRoleMembersCount),
+		metricSqlserverDatabaseRoleMembershipsCount:                newMetricSqlserverDatabaseRoleMembershipsCount(mbc.Metrics.SqlserverDatabaseRoleMembershipsCount),
+		metricSqlserverDatabaseRolePermissionRiskLevel:             newMetricSqlserverDatabaseRolePermissionRiskLevel(mbc.Metrics.SqlserverDatabaseRolePermissionRiskLevel),
+		metricSqlserverDatabaseRoleRolesCount:                      newMetricSqlserverDatabaseRoleRolesCount(mbc.Metrics.SqlserverDatabaseRoleRolesCount),
+		metricSqlserverDatabaseSecurityRoleMembershipCount:         newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
+		metricSqlserverDatabaseTempdbSpace:                         newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
+		metricSqlserverDatabaseTempdbVersionStoreSize:              newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
+		metricSqlserverDatabaseTransactionsActive:                  newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
+		metricSqlserverDeadlockRate:                                newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
+		metricSqlserverFailoverClusterAgClusterType:                newMetricSqlserverFailoverClusterAgClusterType(mbc.Metrics.SqlserverFailoverClusterAgClusterType),
+		metricSqlserverFailoverClusterAgFailureConditionLevel:      newMetricSqlserverFailoverClusterAgFailureConditionLevel(mbc.Metrics.SqlserverFailoverClusterAgFailureConditionLevel),
+		metricSqlserverFailoverClusterAgHealthCheckTimeout:         newMetricSqlserverFailoverClusterAgHealthCheckTimeout(mbc.Metrics.SqlserverFailoverClusterAgHealthCheckTimeout),
+		metricSqlserverFailoverClusterAgRequiredSyncSecondaries:    newMetricSqlserverFailoverClusterAgRequiredSyncSecondaries(mbc.Metrics.SqlserverFailoverClusterAgRequiredSyncSecondaries),
+		metricSqlserverFailoverClusterReplicaDatabaseQueueSize:     newMetricSqlserverFailoverClusterReplicaDatabaseQueueSize(mbc.Metrics.SqlserverFailoverClusterReplicaDatabaseQueueSize),
+		metricSqlserverFailoverClusterReplicaDatabaseRedoRate:      newMetricSqlserverFailoverClusterReplicaDatabaseRedoRate(mbc.Metrics.SqlserverFailoverClusterReplicaDatabaseRedoRate),
+		metricSqlserverFailoverClusterReplicaFlowControlTime:       newMetricSqlserverFailoverClusterReplicaFlowControlTime(mbc.Metrics.SqlserverFailoverClusterReplicaFlowControlTime),
+		metricSqlserverFailoverClusterReplicaRole:                  newMetricSqlserverFailoverClusterReplicaRole(mbc.Metrics.SqlserverFailoverClusterReplicaRole),
+		metricSqlserverFailoverClusterReplicaSynchronizationHealth: newMetricSqlserverFailoverClusterReplicaSynchronizationHealth(mbc.Metrics.SqlserverFailoverClusterReplicaSynchronizationHealth),
+		metricSqlserverIndexSearchRate:                             newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
+		metricSqlserverKillConnectionErrorRate:                     newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
+		metricSqlserverLatchSuperlatchCount:                        newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
+		metricSqlserverLatchSuperlatchTransitionRate:               newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
+		metricSqlserverLatchWaitRate:                               newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
+		metricSqlserverLatchWaitTimeAvg:                            newMetricSqlserverLatchWaitTimeAvg(mbc.Metrics.SqlserverLatchWaitTimeAvg),
+		metricSqlserverLatchWaitTimeTotal:                          newMetricSqlserverLatchWaitTimeTotal(mbc.Metrics.SqlserverLatchWaitTimeTotal),
+		metricSqlserverLockByModeCount:                             newMetricSqlserverLockByModeCount(mbc.Metrics.SqlserverLockByModeCount),
+		metricSqlserverLockByResourceCount:                         newMetricSqlserverLockByResourceCount(mbc.Metrics.SqlserverLockByResourceCount),
+		metricSqlserverLockTimeoutRate:                             newMetricSqlserverLockTimeoutRate(mbc.Metrics.SqlserverLockTimeoutRate),
+		metricSqlserverLockWaitCount:                               newMetricSqlserverLockWaitCount(mbc.Metrics.SqlserverLockWaitCount),
+		metricSqlserverLockWaitRate:                                newMetricSqlserverLockWaitRate(mbc.Metrics.SqlserverLockWaitRate),
+		metricSqlserverLockWaitTimeAvg:                             newMetricSqlserverLockWaitTimeAvg(mbc.Metrics.SqlserverLockWaitTimeAvg),
+		metricSqlserverLoginRate:                                   newMetricSqlserverLoginRate(mbc.Metrics.SqlserverLoginRate),
+		metricSqlserverLogoutRate:                                  newMetricSqlserverLogoutRate(mbc.Metrics.SqlserverLogoutRate),
+		metricSqlserverMemoryArea:                                  newMetricSqlserverMemoryArea(mbc.Metrics.SqlserverMemoryArea),
+		metricSqlserverMemoryCacheObjectCount:                      newMetricSqlserverMemoryCacheObjectCount(mbc.Metrics.SqlserverMemoryCacheObjectCount),
+		metricSqlserverMemoryGrantsPendingCount:                    newMetricSqlserverMemoryGrantsPendingCount(mbc.Metrics.SqlserverMemoryGrantsPendingCount),
+		metricSqlserverMemoryPageCount:                             newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
+		metricSqlserverMemoryTarget:                                newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
+		metricSqlserverMemoryUsage:                                 newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
+		metricSqlserverOsDiskSize:                                  newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
+		metricSqlserverOsMemoryUsage:                               newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
+		metricSqlserverOsMemoryUtilization:                         newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
+		metricSqlserverOsSchedulerRunnableTasksCount:               newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
+		metricSqlserverOsWaitDuration:                              newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
+		metricSqlserverOsWaitTasksCount:                            newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
+		metricSqlserverPageBufferCacheFreeListStallsRate:           newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
+		metricSqlserverPageBufferCacheHitRatio:                     newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
+		metricSqlserverPageCheckpointFlushRate:                     newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
+		metricSqlserverPageLazyWriteRate:                           newMetricSqlserverPageLazyWriteRate(mbc.Metrics.SqlserverPageLazyWriteRate),
+		metricSqlserverPageLifeExpectancy:                          newMetricSqlserverPageLifeExpectancy(mbc.Metrics.SqlserverPageLifeExpectancy),
+		metricSqlserverPageLookupRate:                              newMetricSqlserverPageLookupRate(mbc.Metrics.SqlserverPageLookupRate),
+		metricSqlserverPageOperationRate:                           newMetricSqlserverPageOperationRate(mbc.Metrics.SqlserverPageOperationRate),
+		metricSqlserverPageSplitRate:                               newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
+		metricSqlserverParameterizationRate:                        newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
+		metricSqlserverPlanExecutionRate:                           newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
+		metricSqlserverProcessCount:                                newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
+		metricSqlserverProcessesBlocked:                            newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
+		metricSqlserverRecompilationRatio:                          newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
+		metricSqlserverReplicaDataRate:                             newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
+		metricSqlserverResourcePoolDiskOperations:                  newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
+		metricSqlserverResourcePoolDiskThrottledReadRate:           newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
+		metricSqlserverResourcePoolDiskThrottledWriteRate:          newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
+		metricSqlserverServerSecurityPrincipalCount:                newMetricSqlserverServerSecurityPrincipalCount(mbc.Metrics.SqlserverServerSecurityPrincipalCount),
+		metricSqlserverServerSecurityRoleMembershipCount:           newMetricSqlserverServerSecurityRoleMembershipCount(mbc.Metrics.SqlserverServerSecurityRoleMembershipCount),
+		metricSqlserverTableCount:                                  newMetricSqlserverTableCount(mbc.Metrics.SqlserverTableCount),
+		metricSqlserverTempdbAllocationWaitTimeTotal:               newMetricSqlserverTempdbAllocationWaitTimeTotal(mbc.Metrics.SqlserverTempdbAllocationWaitTimeTotal),
+		metricSqlserverTempdbContentionWaitersCount:                newMetricSqlserverTempdbContentionWaitersCount(mbc.Metrics.SqlserverTempdbContentionWaitersCount),
+		metricSqlserverTempdbDataFilesCount:                        newMetricSqlserverTempdbDataFilesCount(mbc.Metrics.SqlserverTempdbDataFilesCount),
+		metricSqlserverTempdbFileSize:                              newMetricSqlserverTempdbFileSize(mbc.Metrics.SqlserverTempdbFileSize),
+		metricSqlserverTempdbSpaceUsage:                            newMetricSqlserverTempdbSpaceUsage(mbc.Metrics.SqlserverTempdbSpaceUsage),
+		metricSqlserverThreadPoolTasksCount:                        newMetricSqlserverThreadPoolTasksCount(mbc.Metrics.SqlserverThreadPoolTasksCount),
+		metricSqlserverThreadPoolWorkersCount:                      newMetricSqlserverThreadPoolWorkersCount(mbc.Metrics.SqlserverThreadPoolWorkersCount),
+		metricSqlserverThreadPoolWorkersMax:                        newMetricSqlserverThreadPoolWorkersMax(mbc.Metrics.SqlserverThreadPoolWorkersMax),
+		metricSqlserverThreadPoolWorkersUtilization:                newMetricSqlserverThreadPoolWorkersUtilization(mbc.Metrics.SqlserverThreadPoolWorkersUtilization),
+		metricSqlserverTransactionDelay:                            newMetricSqlserverTransactionDelay(mbc.Metrics.SqlserverTransactionDelay),
+		metricSqlserverTransactionLongestRunningTime:               newMetricSqlserverTransactionLongestRunningTime(mbc.Metrics.SqlserverTransactionLongestRunningTime),
+		metricSqlserverTransactionMirrorWriteRate:                  newMetricSqlserverTransactionMirrorWriteRate(mbc.Metrics.SqlserverTransactionMirrorWriteRate),
+		metricSqlserverTransactionRate:                             newMetricSqlserverTransactionRate(mbc.Metrics.SqlserverTransactionRate),
+		metricSqlserverTransactionVersionCleanupRate:               newMetricSqlserverTransactionVersionCleanupRate(mbc.Metrics.SqlserverTransactionVersionCleanupRate),
+		metricSqlserverTransactionVersionGenerationRate:            newMetricSqlserverTransactionVersionGenerationRate(mbc.Metrics.SqlserverTransactionVersionGenerationRate),
+		metricSqlserverTransactionWriteRate:                        newMetricSqlserverTransactionWriteRate(mbc.Metrics.SqlserverTransactionWriteRate),
+		metricSqlserverTransactionLogFlushDataRate:                 newMetricSqlserverTransactionLogFlushDataRate(mbc.Metrics.SqlserverTransactionLogFlushDataRate),
+		metricSqlserverTransactionLogFlushRate:                     newMetricSqlserverTransactionLogFlushRate(mbc.Metrics.SqlserverTransactionLogFlushRate),
+		metricSqlserverTransactionLogFlushWaitRate:                 newMetricSqlserverTransactionLogFlushWaitRate(mbc.Metrics.SqlserverTransactionLogFlushWaitRate),
+		metricSqlserverTransactionLogGrowthCount:                   newMetricSqlserverTransactionLogGrowthCount(mbc.Metrics.SqlserverTransactionLogGrowthCount),
+		metricSqlserverTransactionLogShrinkCount:                   newMetricSqlserverTransactionLogShrinkCount(mbc.Metrics.SqlserverTransactionLogShrinkCount),
+		metricSqlserverTransactionLogUsage:                         newMetricSqlserverTransactionLogUsage(mbc.Metrics.SqlserverTransactionLogUsage),
+		metricSqlserverUserConnectionCount:                         newMetricSqlserverUserConnectionCount(mbc.Metrics.SqlserverUserConnectionCount),
+		resourceAttributeIncludeFilter:                             make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:                             make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.HostName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["host.name"] = filter.CreateFilter(mbc.ResourceAttributes.HostName.MetricsInclude)
@@ -6160,11 +9372,28 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverDatabaseLatency.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseOperations.emit(ils.Metrics())
 	mb.metricSqlserverDatabasePageFileSize.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsOld.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsOrphanedUsers.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsRecentlyCreated.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleMembersCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleMembershipsCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRolePermissionRiskLevel.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleRolesCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbSpace.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTransactionsActive.emit(ils.Metrics())
 	mb.metricSqlserverDeadlockRate.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgClusterType.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgFailureConditionLevel.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaFlowControlTime.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaRole.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.emit(ils.Metrics())
 	mb.metricSqlserverIndexSearchRate.emit(ils.Metrics())
 	mb.metricSqlserverKillConnectionErrorRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchCount.emit(ils.Metrics())
@@ -6172,6 +9401,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverLatchWaitRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitTimeAvg.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitTimeTotal.emit(ils.Metrics())
+	mb.metricSqlserverLockByModeCount.emit(ils.Metrics())
+	mb.metricSqlserverLockByResourceCount.emit(ils.Metrics())
 	mb.metricSqlserverLockTimeoutRate.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitCount.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitRate.emit(ils.Metrics())
@@ -6210,9 +9441,21 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverServerSecurityPrincipalCount.emit(ils.Metrics())
 	mb.metricSqlserverServerSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverTableCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbAllocationWaitTimeTotal.emit(ils.Metrics())
+	mb.metricSqlserverTempdbContentionWaitersCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbDataFilesCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbFileSize.emit(ils.Metrics())
+	mb.metricSqlserverTempdbSpaceUsage.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolTasksCount.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersCount.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersMax.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersUtilization.emit(ils.Metrics())
 	mb.metricSqlserverTransactionDelay.emit(ils.Metrics())
+	mb.metricSqlserverTransactionLongestRunningTime.emit(ils.Metrics())
 	mb.metricSqlserverTransactionMirrorWriteRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionRate.emit(ils.Metrics())
+	mb.metricSqlserverTransactionVersionCleanupRate.emit(ils.Metrics())
+	mb.metricSqlserverTransactionVersionGenerationRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionWriteRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionLogFlushDataRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionLogFlushRate.emit(ils.Metrics())
@@ -6372,6 +9615,86 @@ func (mb *MetricsBuilder) RecordSqlserverDatabasePageFileSizeDataPoint(ts pcommo
 	return nil
 }
 
+// RecordSqlserverDatabasePrincipalsCountDataPoint adds a data point to sqlserver.database.principals.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, principalTypeAttributeValue AttributePrincipalType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, principalTypeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsOldDataPoint adds a data point to sqlserver.database.principals.old metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsOldDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsOld, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsOld.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint adds a data point to sqlserver.database.principals.orphaned_users metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsOrphanedUsers, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsOrphanedUsers.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint adds a data point to sqlserver.database.principals.recently_created metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsRecentlyCreated, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsRecentlyCreated.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleMembersCountDataPoint adds a data point to sqlserver.database.role.members.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleMembersCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, memberKindAttributeValue AttributeMemberKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleMembersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleMembersCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, memberKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleMembershipsCountDataPoint adds a data point to sqlserver.database.role.memberships.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, membershipKindAttributeValue AttributeMembershipKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleMembershipsCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleMembershipsCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, membershipKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint adds a data point to sqlserver.database.role.permission.risk_level metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRolePermissionRiskLevel, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRolePermissionRiskLevel.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, roleAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleRolesCountDataPoint adds a data point to sqlserver.database.role.roles.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleRolesCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleStateAttributeValue AttributeRoleState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleRolesCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleRolesCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, roleStateAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint adds a data point to sqlserver.database.security.role_membership.count metric.
 func (mb *MetricsBuilder) RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -6407,6 +9730,86 @@ func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timest
 	mb.metricSqlserverDeadlockRate.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverFailoverClusterAgClusterTypeDataPoint adds a data point to sqlserver.failover_cluster.ag.cluster_type metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, agClusterTypeAttributeValue AttributeAgClusterType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgClusterType, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgClusterType.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, agClusterTypeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint adds a data point to sqlserver.failover_cluster.ag.failure_condition_level metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgFailureConditionLevel, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgFailureConditionLevel.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint adds a data point to sqlserver.failover_cluster.ag.health_check_timeout metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgHealthCheckTimeout, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint adds a data point to sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgRequiredSyncSecondaries, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint adds a data point to sqlserver.failover_cluster.replica.database.queue_size metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string, replicaQueueKindAttributeValue AttributeReplicaQueueKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaDatabaseQueueSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, dbNamespaceAttributeValue, replicaQueueKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint adds a data point to sqlserver.failover_cluster.replica.database.redo.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts pcommon.Timestamp, val float64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string) {
+	mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, dbNamespaceAttributeValue)
+}
+
+// RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint adds a data point to sqlserver.failover_cluster.replica.flow_control_time metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverFailoverClusterReplicaFlowControlTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverFailoverClusterReplicaRoleDataPoint adds a data point to sqlserver.failover_cluster.replica.role metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaRoleAttributeValue AttributeReplicaRole) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaRole, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaRole.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, replicaRoleAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint adds a data point to sqlserver.failover_cluster.replica.synchronization_health metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaSyncHealthAttributeValue AttributeReplicaSyncHealth) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaSynchronizationHealth, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, replicaSyncHealthAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverIndexSearchRateDataPoint adds a data point to sqlserver.index.search.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverIndexSearchRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverIndexSearchRate.recordDataPoint(mb.startTime, ts, val)
@@ -6440,6 +9843,26 @@ func (mb *MetricsBuilder) RecordSqlserverLatchWaitTimeAvgDataPoint(ts pcommon.Ti
 // RecordSqlserverLatchWaitTimeTotalDataPoint adds a data point to sqlserver.latch.wait_time.total metric.
 func (mb *MetricsBuilder) RecordSqlserverLatchWaitTimeTotalDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverLatchWaitTimeTotal.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverLockByModeCountDataPoint adds a data point to sqlserver.lock.by_mode.count metric.
+func (mb *MetricsBuilder) RecordSqlserverLockByModeCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, lockModeAttributeValue AttributeLockMode) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverLockByModeCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverLockByModeCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, lockModeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverLockByResourceCountDataPoint adds a data point to sqlserver.lock.by_resource.count metric.
+func (mb *MetricsBuilder) RecordSqlserverLockByResourceCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, lockResourceAttributeValue AttributeLockResource) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverLockByResourceCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverLockByResourceCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, lockResourceAttributeValue.String())
+	return nil
 }
 
 // RecordSqlserverLockTimeoutRateDataPoint adds a data point to sqlserver.lock.timeout.rate metric.
@@ -6687,9 +10110,94 @@ func (mb *MetricsBuilder) RecordSqlserverTableCountDataPoint(ts pcommon.Timestam
 	mb.metricSqlserverTableCount.recordDataPoint(mb.startTime, ts, val, tableStateAttributeValue.String(), tableStatusAttributeValue.String())
 }
 
+// RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint adds a data point to sqlserver.tempdb.allocation.wait_time.total metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts pcommon.Timestamp, val float64, allocationPageTypeAttributeValue AttributeAllocationPageType) {
+	mb.metricSqlserverTempdbAllocationWaitTimeTotal.recordDataPoint(mb.startTime, ts, val, allocationPageTypeAttributeValue.String())
+}
+
+// RecordSqlserverTempdbContentionWaitersCountDataPoint adds a data point to sqlserver.tempdb.contention.waiters.count metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbContentionWaitersCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbContentionWaitersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbContentionWaitersCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverTempdbDataFilesCountDataPoint adds a data point to sqlserver.tempdb.data_files.count metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbDataFilesCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbDataFilesCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbDataFilesCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverTempdbFileSizeDataPoint adds a data point to sqlserver.tempdb.file.size metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbFileSizeDataPoint(ts pcommon.Timestamp, inputVal string, fileTypeAttributeValue string, tempdbFileIDAttributeValue int64) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbFileSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbFileSize.recordDataPoint(mb.startTime, ts, val, fileTypeAttributeValue, tempdbFileIDAttributeValue)
+	return nil
+}
+
+// RecordSqlserverTempdbSpaceUsageDataPoint adds a data point to sqlserver.tempdb.space.usage metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbSpaceUsageDataPoint(ts pcommon.Timestamp, inputVal string, tempdbSpaceKindAttributeValue AttributeTempdbSpaceKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbSpaceUsage, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbSpaceUsage.recordDataPoint(mb.startTime, ts, val, tempdbSpaceKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolTasksCountDataPoint adds a data point to sqlserver.thread_pool.tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolTasksCountDataPoint(ts pcommon.Timestamp, inputVal string, taskStateAttributeValue AttributeTaskState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolTasksCount.recordDataPoint(mb.startTime, ts, val, taskStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersCountDataPoint adds a data point to sqlserver.thread_pool.workers.count metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersCountDataPoint(ts pcommon.Timestamp, inputVal string, workerStateAttributeValue AttributeWorkerState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolWorkersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolWorkersCount.recordDataPoint(mb.startTime, ts, val, workerStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersMaxDataPoint adds a data point to sqlserver.thread_pool.workers.max metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersMaxDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolWorkersMax, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolWorkersMax.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersUtilizationDataPoint adds a data point to sqlserver.thread_pool.workers.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverThreadPoolWorkersUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordSqlserverTransactionDelayDataPoint adds a data point to sqlserver.transaction.delay metric.
 func (mb *MetricsBuilder) RecordSqlserverTransactionDelayDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverTransactionDelay.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionLongestRunningTimeDataPoint adds a data point to sqlserver.transaction.longest_running_time metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionLongestRunningTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionLongestRunningTime.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionMirrorWriteRateDataPoint adds a data point to sqlserver.transaction.mirror_write.rate metric.
@@ -6700,6 +10208,16 @@ func (mb *MetricsBuilder) RecordSqlserverTransactionMirrorWriteRateDataPoint(ts 
 // RecordSqlserverTransactionRateDataPoint adds a data point to sqlserver.transaction.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverTransactionRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverTransactionRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionVersionCleanupRateDataPoint adds a data point to sqlserver.transaction.version_cleanup.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionVersionCleanupRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionVersionCleanupRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionVersionGenerationRateDataPoint adds a data point to sqlserver.transaction.version_generation.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionVersionGenerationRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionVersionGenerationRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionWriteRateDataPoint adds a data point to sqlserver.transaction.write.rate metric.

--- a/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nrsqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -73,10 +73,28 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.database.latency"] = mb.metricSqlserverDatabaseLatency.config.AggregationStrategy
 			aggMap["sqlserver.database.operations"] = mb.metricSqlserverDatabaseOperations.config.AggregationStrategy
 			aggMap["sqlserver.database.page_file.size"] = mb.metricSqlserverDatabasePageFileSize.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.count"] = mb.metricSqlserverDatabasePrincipalsCount.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.old"] = mb.metricSqlserverDatabasePrincipalsOld.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.orphaned_users"] = mb.metricSqlserverDatabasePrincipalsOrphanedUsers.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.recently_created"] = mb.metricSqlserverDatabasePrincipalsRecentlyCreated.config.AggregationStrategy
+			aggMap["sqlserver.database.role.members.count"] = mb.metricSqlserverDatabaseRoleMembersCount.config.AggregationStrategy
+			aggMap["sqlserver.database.role.memberships.count"] = mb.metricSqlserverDatabaseRoleMembershipsCount.config.AggregationStrategy
+			aggMap["sqlserver.database.role.permission.risk_level"] = mb.metricSqlserverDatabaseRolePermissionRiskLevel.config.AggregationStrategy
+			aggMap["sqlserver.database.role.roles.count"] = mb.metricSqlserverDatabaseRoleRolesCount.config.AggregationStrategy
 			aggMap["sqlserver.database.security.role_membership.count"] = mb.metricSqlserverDatabaseSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.database.tempdb.space"] = mb.metricSqlserverDatabaseTempdbSpace.config.AggregationStrategy
 			aggMap["sqlserver.database.transactions.active"] = mb.metricSqlserverDatabaseTransactionsActive.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.cluster_type"] = mb.metricSqlserverFailoverClusterAgClusterType.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.failure_condition_level"] = mb.metricSqlserverFailoverClusterAgFailureConditionLevel.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.health_check_timeout"] = mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.required_sync_secondaries"] = mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.database.queue_size"] = mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.database.redo.rate"] = mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.role"] = mb.metricSqlserverFailoverClusterReplicaRole.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.synchronization_health"] = mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.config.AggregationStrategy
 			aggMap["sqlserver.latch.superlatch.transition.rate"] = mb.metricSqlserverLatchSuperlatchTransitionRate.config.AggregationStrategy
+			aggMap["sqlserver.lock.by_mode.count"] = mb.metricSqlserverLockByModeCount.config.AggregationStrategy
+			aggMap["sqlserver.lock.by_resource.count"] = mb.metricSqlserverLockByResourceCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.area"] = mb.metricSqlserverMemoryArea.config.AggregationStrategy
 			aggMap["sqlserver.memory.cache.object.count"] = mb.metricSqlserverMemoryCacheObjectCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.page.count"] = mb.metricSqlserverMemoryPageCount.config.AggregationStrategy
@@ -92,6 +110,11 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.server.security.role_membership.count"] = mb.metricSqlserverServerSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.table.count"] = mb.metricSqlserverTableCount.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.allocation.wait_time.total"] = mb.metricSqlserverTempdbAllocationWaitTimeTotal.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.file.size"] = mb.metricSqlserverTempdbFileSize.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.space.usage"] = mb.metricSqlserverTempdbSpaceUsage.config.AggregationStrategy
+			aggMap["sqlserver.thread_pool.tasks.count"] = mb.metricSqlserverThreadPoolTasksCount.config.AggregationStrategy
+			aggMap["sqlserver.thread_pool.workers.count"] = mb.metricSqlserverThreadPoolWorkersCount.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet != testDataSetReag {
@@ -171,6 +194,54 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsCountDataPoint(ts, "1", "db.namespace-val", AttributePrincipalTypeSQLUser)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsCountDataPoint(ts, "3", "db.namespace-val-2", AttributePrincipalTypeWindowsUser)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsOldDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsOldDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(ts, "1", "db.namespace-val", AttributeMemberKindAppRole)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(ts, "3", "db.namespace-val-2", AttributeMemberKindCrossRole)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts, "1", "db.namespace-val", AttributeMembershipKindActive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts, "3", "db.namespace-val-2", AttributeMembershipKindCustom)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts, "1", "db.namespace-val", "role-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(ts, "1", "db.namespace-val", AttributeRoleStateEmpty)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(ts, "3", "db.namespace-val-2", AttributeRoleStateWithMembers)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "1", "db.namespace-val", "role-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
@@ -195,6 +266,57 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverDeadlockRateDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts, "1", "ag.name-val", AttributeAgClusterTypeWsfc)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts, "3", "ag.name-val-2", AttributeAgClusterTypeExternal)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", "db.namespace-val", AttributeReplicaQueueKindLogSend)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", "db.namespace-val-2", AttributeReplicaQueueKindRedo)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts, 1, "ag.name-val", "replica.server_name-val", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts, 3, "ag.name-val-2", "replica.server_name-val-2", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", AttributeReplicaRolePrimary)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", AttributeReplicaRoleSecondary)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", AttributeReplicaSyncHealthHealthy)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", AttributeReplicaSyncHealthPartiallyHealthy)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverIndexSearchRateDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -217,6 +339,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordSqlserverLatchWaitTimeTotalDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverLockByModeCountDataPoint(ts, "1", "db.namespace-val", AttributeLockModeShared)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverLockByModeCountDataPoint(ts, "3", "db.namespace-val-2", AttributeLockModeExclusive)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverLockByResourceCountDataPoint(ts, "1", "db.namespace-val", AttributeLockResourceKey)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverLockByResourceCountDataPoint(ts, "3", "db.namespace-val-2", AttributeLockResourcePage)
+			}
 
 			allMetricsCount++
 			mb.RecordSqlserverLockTimeoutRateDataPoint(ts, 1)
@@ -378,13 +512,64 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts, 1, AttributeAllocationPageTypeGam)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts, 3, AttributeAllocationPageTypeSgam)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbContentionWaitersCountDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbDataFilesCountDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbFileSizeDataPoint(ts, "1", "file_type-val", 14)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbFileSizeDataPoint(ts, "3", "file_type-val-2", 15)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbSpaceUsageDataPoint(ts, "1", AttributeTempdbSpaceKindUserObjects)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbSpaceUsageDataPoint(ts, "3", AttributeTempdbSpaceKindInternalObjects)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolTasksCountDataPoint(ts, "1", AttributeTaskStateCurrent)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverThreadPoolTasksCountDataPoint(ts, "3", AttributeTaskStateQueued)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersCountDataPoint(ts, "1", AttributeWorkerStateRunning)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverThreadPoolWorkersCountDataPoint(ts, "3", AttributeWorkerStateSuspendedOrSleeping)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersMaxDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordSqlserverTransactionDelayDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionLongestRunningTimeDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverTransactionMirrorWriteRateDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverTransactionRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionVersionCleanupRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionVersionGenerationRateDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverTransactionWriteRateDataPoint(ts, 1)
@@ -429,10 +614,28 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverDatabaseLatency.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabasePageFileSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsOld.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsOrphanedUsers.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsRecentlyCreated.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleMembersCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleMembershipsCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRolePermissionRiskLevel.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleRolesCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTempdbSpace.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTransactionsActive.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgClusterType.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgFailureConditionLevel.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaRole.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverLatchSuperlatchTransitionRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverLockByModeCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverLockByResourceCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryArea.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryCacheObjectCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryPageCount.aggDataPoints)
@@ -448,6 +651,11 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverServerSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverTableCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbAllocationWaitTimeTotal.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbFileSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbSpaceUsage.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverThreadPoolTasksCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverThreadPoolWorkersCount.aggDataPoints)
 			}
 
 			if tt.expectEmpty {
@@ -914,6 +1122,351 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("page_file.state")
 						assert.False(t, ok)
 					}
+				case "sqlserver.database.principals.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.count"], "Found a duplicate in the metrics slice: sqlserver.database.principals.count")
+						validatedMetrics["sqlserver.database.principals.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database security principals broken down by type.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						principalTypeAttrVal, ok := dp.Attributes().Get("principal.type")
+						assert.True(t, ok)
+						assert.Equal(t, "sql_user", principalTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.count"], "Found a duplicate in the metrics slice: sqlserver.database.principals.count")
+						validatedMetrics["sqlserver.database.principals.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database security principals broken down by type.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("principal.type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.old":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.old"], "Found a duplicate in the metrics slice: sqlserver.database.principals.old")
+						validatedMetrics["sqlserver.database.principals.old"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created more than one year ago.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.old"], "Found a duplicate in the metrics slice: sqlserver.database.principals.old")
+						validatedMetrics["sqlserver.database.principals.old"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created more than one year ago.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.old"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.orphaned_users":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.orphaned_users"], "Found a duplicate in the metrics slice: sqlserver.database.principals.orphaned_users")
+						validatedMetrics["sqlserver.database.principals.orphaned_users"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL users in the database that have no matching server login.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.orphaned_users"], "Found a duplicate in the metrics slice: sqlserver.database.principals.orphaned_users")
+						validatedMetrics["sqlserver.database.principals.orphaned_users"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL users in the database that have no matching server login.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.orphaned_users"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.recently_created":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.recently_created"], "Found a duplicate in the metrics slice: sqlserver.database.principals.recently_created")
+						validatedMetrics["sqlserver.database.principals.recently_created"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created in the last 30 days.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.recently_created"], "Found a duplicate in the metrics slice: sqlserver.database.principals.recently_created")
+						validatedMetrics["sqlserver.database.principals.recently_created"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created in the last 30 days.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.recently_created"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.members.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.members.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.members.count")
+						validatedMetrics["sqlserver.database.role.members.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role members broken down by member kind.", mi.Description())
+						assert.Equal(t, "{members}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						memberKindAttrVal, ok := dp.Attributes().Get("member.kind")
+						assert.True(t, ok)
+						assert.Equal(t, "app_role", memberKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.members.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.members.count")
+						validatedMetrics["sqlserver.database.role.members.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role members broken down by member kind.", mi.Description())
+						assert.Equal(t, "{members}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.members.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("member.kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.memberships.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.memberships.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.memberships.count")
+						validatedMetrics["sqlserver.database.role.memberships.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role memberships broken down by kind.", mi.Description())
+						assert.Equal(t, "{memberships}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						membershipKindAttrVal, ok := dp.Attributes().Get("membership.kind")
+						assert.True(t, ok)
+						assert.Equal(t, "active", membershipKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.memberships.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.memberships.count")
+						validatedMetrics["sqlserver.database.role.memberships.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role memberships broken down by kind.", mi.Description())
+						assert.Equal(t, "{memberships}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.memberships.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("membership.kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.permission.risk_level":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.permission.risk_level"], "Found a duplicate in the metrics slice: sqlserver.database.role.permission.risk_level")
+						validatedMetrics["sqlserver.database.role.permission.risk_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Risk level assigned to each database role (1=low, 4=high).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						roleAttrVal, ok := dp.Attributes().Get("role")
+						assert.True(t, ok)
+						assert.Equal(t, "role-val", roleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.permission.risk_level"], "Found a duplicate in the metrics slice: sqlserver.database.role.permission.risk_level")
+						validatedMetrics["sqlserver.database.role.permission.risk_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Risk level assigned to each database role (1=low, 4=high).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.permission.risk_level"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("role")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.roles.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.roles.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.roles.count")
+						validatedMetrics["sqlserver.database.role.roles.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database roles broken down by usage state.", mi.Description())
+						assert.Equal(t, "{roles}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						roleStateAttrVal, ok := dp.Attributes().Get("role.state")
+						assert.True(t, ok)
+						assert.Equal(t, "empty", roleStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.roles.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.roles.count")
+						validatedMetrics["sqlserver.database.role.roles.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database roles broken down by usage state.", mi.Description())
+						assert.Equal(t, "{roles}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.roles.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("role.state")
+						assert.False(t, ok)
+					}
 				case "sqlserver.database.security.role_membership.count":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.database.security.role_membership.count"], "Found a duplicate in the metrics slice: sqlserver.database.security.role_membership.count")
@@ -1067,6 +1620,388 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.failover_cluster.ag.cluster_type":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.cluster_type")
+						validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cluster type of the Always-On Availability Group.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						agClusterTypeAttrVal, ok := dp.Attributes().Get("ag.cluster_type")
+						assert.True(t, ok)
+						assert.Equal(t, "wsfc", agClusterTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.cluster_type")
+						validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cluster type of the Always-On Availability Group.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.cluster_type"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("ag.cluster_type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.failure_condition_level":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.failure_condition_level")
+						validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Failure condition level configured for the Availability Group (1-5).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.failure_condition_level")
+						validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Failure condition level configured for the Availability Group (1-5).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.failure_condition_level"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.health_check_timeout":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.health_check_timeout")
+						validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Health-check timeout configured for the Availability Group.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.health_check_timeout")
+						validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Health-check timeout configured for the Availability Group.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.health_check_timeout"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.required_sync_secondaries":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.required_sync_secondaries")
+						validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of synchronized secondary replicas required to commit on the Availability Group.", mi.Description())
+						assert.Equal(t, "{secondaries}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.required_sync_secondaries")
+						validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of synchronized secondary replicas required to commit on the Availability Group.", mi.Description())
+						assert.Equal(t, "{secondaries}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.required_sync_secondaries"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.database.queue_size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.queue_size")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of the log-send or redo queue for an AG database replica.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						replicaQueueKindAttrVal, ok := dp.Attributes().Get("replica.queue_kind")
+						assert.True(t, ok)
+						assert.Equal(t, "log_send", replicaQueueKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.queue_size")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of the log-send or redo queue for an AG database replica.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.database.queue_size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.queue_kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.database.redo.rate":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.redo.rate")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Redo rate for an AG database replica.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.redo.rate")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Redo rate for an AG database replica.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.database.redo.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.flow_control_time":
+					assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.flow_control_time"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.flow_control_time")
+					validatedMetrics["sqlserver.failover_cluster.replica.flow_control_time"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Cumulative time spent in AG flow control, in milliseconds per second observed.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.failover_cluster.replica.role":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.role"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.role")
+						validatedMetrics["sqlserver.failover_cluster.replica.role"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Role of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						replicaRoleAttrVal, ok := dp.Attributes().Get("replica.role")
+						assert.True(t, ok)
+						assert.Equal(t, "primary", replicaRoleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.role"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.role")
+						validatedMetrics["sqlserver.failover_cluster.replica.role"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Role of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.role"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.role")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.synchronization_health":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.synchronization_health")
+						validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Synchronization health of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						replicaSyncHealthAttrVal, ok := dp.Attributes().Get("replica.sync_health")
+						assert.True(t, ok)
+						assert.Equal(t, "healthy", replicaSyncHealthAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.synchronization_health")
+						validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Synchronization health of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.synchronization_health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.sync_health")
+						assert.False(t, ok)
+					}
 				case "sqlserver.index.search.rate":
 					assert.False(t, validatedMetrics["sqlserver.index.search.rate"], "Found a duplicate in the metrics slice: sqlserver.index.search.rate")
 					validatedMetrics["sqlserver.index.search.rate"] = true
@@ -1181,6 +2116,96 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.lock.by_mode.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_mode.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_mode.count")
+						validatedMetrics["sqlserver.lock.by_mode.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by lock mode.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						lockModeAttrVal, ok := dp.Attributes().Get("lock.mode")
+						assert.True(t, ok)
+						assert.Equal(t, "shared", lockModeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_mode.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_mode.count")
+						validatedMetrics["sqlserver.lock.by_mode.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by lock mode.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.lock.by_mode.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("lock.mode")
+						assert.False(t, ok)
+					}
+				case "sqlserver.lock.by_resource.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_resource.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_resource.count")
+						validatedMetrics["sqlserver.lock.by_resource.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by resource type.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						lockResourceAttrVal, ok := dp.Attributes().Get("lock.resource")
+						assert.True(t, ok)
+						assert.Equal(t, "key", lockResourceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_resource.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_resource.count")
+						validatedMetrics["sqlserver.lock.by_resource.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by resource type.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.lock.by_resource.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("lock.resource")
+						assert.False(t, ok)
+					}
 				case "sqlserver.lock.timeout.rate":
 					assert.False(t, validatedMetrics["sqlserver.lock.timeout.rate"], "Found a duplicate in the metrics slice: sqlserver.lock.timeout.rate")
 					validatedMetrics["sqlserver.lock.timeout.rate"] = true
@@ -2090,6 +3115,263 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("table.status")
 						assert.False(t, ok)
 					}
+				case "sqlserver.tempdb.allocation.wait_time.total":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"], "Found a duplicate in the metrics slice: sqlserver.tempdb.allocation.wait_time.total")
+						validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative wait time on tempdb allocation pages, broken down by page type.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						allocationPageTypeAttrVal, ok := dp.Attributes().Get("allocation.page_type")
+						assert.True(t, ok)
+						assert.Equal(t, "gam", allocationPageTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"], "Found a duplicate in the metrics slice: sqlserver.tempdb.allocation.wait_time.total")
+						validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative wait time on tempdb allocation pages, broken down by page type.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.allocation.wait_time.total"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("allocation.page_type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.tempdb.contention.waiters.count":
+					assert.False(t, validatedMetrics["sqlserver.tempdb.contention.waiters.count"], "Found a duplicate in the metrics slice: sqlserver.tempdb.contention.waiters.count")
+					validatedMetrics["sqlserver.tempdb.contention.waiters.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of tempdb pagelatch wait types with at least one active waiter.", mi.Description())
+					assert.Equal(t, "{waiters}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.tempdb.data_files.count":
+					assert.False(t, validatedMetrics["sqlserver.tempdb.data_files.count"], "Found a duplicate in the metrics slice: sqlserver.tempdb.data_files.count")
+					validatedMetrics["sqlserver.tempdb.data_files.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of tempdb data files configured on the instance.", mi.Description())
+					assert.Equal(t, "{files}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.tempdb.file.size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.file.size"], "Found a duplicate in the metrics slice: sqlserver.tempdb.file.size")
+						validatedMetrics["sqlserver.tempdb.file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of each tempdb data or log file.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						fileTypeAttrVal, ok := dp.Attributes().Get("file_type")
+						assert.True(t, ok)
+						assert.Equal(t, "file_type-val", fileTypeAttrVal.Str())
+						tempdbFileIDAttrVal, ok := dp.Attributes().Get("tempdb.file.id")
+						assert.True(t, ok)
+						assert.EqualValues(t, 14, tempdbFileIDAttrVal.Int())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.file.size"], "Found a duplicate in the metrics slice: sqlserver.tempdb.file.size")
+						validatedMetrics["sqlserver.tempdb.file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of each tempdb data or log file.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.file.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("file_type")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("tempdb.file.id")
+						assert.False(t, ok)
+					}
+				case "sqlserver.tempdb.space.usage":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.space.usage"], "Found a duplicate in the metrics slice: sqlserver.tempdb.space.usage")
+						validatedMetrics["sqlserver.tempdb.space.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Space used by tempdb, broken down by allocation category.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						tempdbSpaceKindAttrVal, ok := dp.Attributes().Get("tempdb.space_kind")
+						assert.True(t, ok)
+						assert.Equal(t, "user_objects", tempdbSpaceKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.space.usage"], "Found a duplicate in the metrics slice: sqlserver.tempdb.space.usage")
+						validatedMetrics["sqlserver.tempdb.space.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Space used by tempdb, broken down by allocation category.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.space.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("tempdb.space_kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.tasks.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.tasks.count")
+						validatedMetrics["sqlserver.thread_pool.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server tasks broken down by state.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						taskStateAttrVal, ok := dp.Attributes().Get("task.state")
+						assert.True(t, ok)
+						assert.Equal(t, "current", taskStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.tasks.count")
+						validatedMetrics["sqlserver.thread_pool.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server tasks broken down by state.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.thread_pool.tasks.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("task.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.workers.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.count")
+						validatedMetrics["sqlserver.thread_pool.workers.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server worker threads broken down by state.", mi.Description())
+						assert.Equal(t, "{workers}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						workerStateAttrVal, ok := dp.Attributes().Get("worker.state")
+						assert.True(t, ok)
+						assert.Equal(t, "running", workerStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.count")
+						validatedMetrics["sqlserver.thread_pool.workers.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server worker threads broken down by state.", mi.Description())
+						assert.Equal(t, "{workers}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.thread_pool.workers.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("worker.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.workers.max":
+					assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.max"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.max")
+					validatedMetrics["sqlserver.thread_pool.workers.max"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Maximum number of SQL Server worker threads configured on the instance.", mi.Description())
+					assert.Equal(t, "{workers}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.thread_pool.workers.utilization":
+					assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.utilization"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.utilization")
+					validatedMetrics["sqlserver.thread_pool.workers.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Fraction of configured SQL Server worker threads currently running.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "sqlserver.transaction.delay":
 					assert.False(t, validatedMetrics["sqlserver.transaction.delay"], "Found a duplicate in the metrics slice: sqlserver.transaction.delay")
 					validatedMetrics["sqlserver.transaction.delay"] = true
@@ -2100,6 +3382,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.False(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.longest_running_time":
+					assert.False(t, validatedMetrics["sqlserver.transaction.longest_running_time"], "Found a duplicate in the metrics slice: sqlserver.transaction.longest_running_time")
+					validatedMetrics["sqlserver.transaction.longest_running_time"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Age in seconds of the longest currently-open transaction on the server.", mi.Description())
+					assert.Equal(t, "s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
@@ -2124,6 +3418,34 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, "Number of transactions started for the database (not including XTP-only transactions).", mi.Description())
 					assert.Equal(t, "{transactions}/s", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.version_cleanup.rate":
+					assert.False(t, validatedMetrics["sqlserver.transaction.version_cleanup.rate"], "Found a duplicate in the metrics slice: sqlserver.transaction.version_cleanup.rate")
+					validatedMetrics["sqlserver.transaction.version_cleanup.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Cumulative bytes cleaned from the tempdb version store.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.version_generation.rate":
+					assert.False(t, validatedMetrics["sqlserver.transaction.version_generation.rate"], "Found a duplicate in the metrics slice: sqlserver.transaction.version_generation.rate")
+					validatedMetrics["sqlserver.transaction.version_generation.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Cumulative bytes of row versions written to the tempdb version store.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())

--- a/receiver/nrsqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/nrsqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -41,6 +41,30 @@ all_set:
     sqlserver.database.page_file.size:
       enabled: true
       attributes: ["db.namespace","page_file.state"]
+    sqlserver.database.principals.count:
+      enabled: true
+      attributes: ["db.namespace","principal.type"]
+    sqlserver.database.principals.old:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.orphaned_users:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.recently_created:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.role.members.count:
+      enabled: true
+      attributes: ["db.namespace","member.kind"]
+    sqlserver.database.role.memberships.count:
+      enabled: true
+      attributes: ["db.namespace","membership.kind"]
+    sqlserver.database.role.permission.risk_level:
+      enabled: true
+      attributes: ["db.namespace","role"]
+    sqlserver.database.role.roles.count:
+      enabled: true
+      attributes: ["db.namespace","role.state"]
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: ["db.namespace","role"]
@@ -54,6 +78,32 @@ all_set:
       attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: true
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: true
+      attributes: ["ag.name","ag.cluster_type"]
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","db.namespace","replica.queue_kind"]
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","db.namespace"]
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: true
+    sqlserver.failover_cluster.replica.role:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","replica.role"]
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","replica.sync_health"]
     sqlserver.index.search.rate:
       enabled: true
     sqlserver.kill_connection.error.rate:
@@ -69,6 +119,12 @@ all_set:
       enabled: true
     sqlserver.latch.wait_time.total:
       enabled: true
+    sqlserver.lock.by_mode.count:
+      enabled: true
+      attributes: ["db.namespace","lock.mode"]
+    sqlserver.lock.by_resource.count:
+      enabled: true
+      attributes: ["db.namespace","lock.resource"]
     sqlserver.lock.timeout.rate:
       enabled: true
     sqlserver.lock.wait.count:
@@ -160,11 +216,40 @@ all_set:
     sqlserver.table.count:
       enabled: true
       attributes: ["table.state","table.status"]
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: true
+      attributes: ["allocation.page_type"]
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: true
+    sqlserver.tempdb.data_files.count:
+      enabled: true
+    sqlserver.tempdb.file.size:
+      enabled: true
+      attributes: ["file_type","tempdb.file.id"]
+    sqlserver.tempdb.space.usage:
+      enabled: true
+      attributes: ["tempdb.space_kind"]
+    sqlserver.thread_pool.tasks.count:
+      enabled: true
+      attributes: ["task.state"]
+    sqlserver.thread_pool.workers.count:
+      enabled: true
+      attributes: ["worker.state"]
+    sqlserver.thread_pool.workers.max:
+      enabled: true
+    sqlserver.thread_pool.workers.utilization:
+      enabled: true
     sqlserver.transaction.delay:
+      enabled: true
+    sqlserver.transaction.longest_running_time:
       enabled: true
     sqlserver.transaction.mirror_write.rate:
       enabled: true
     sqlserver.transaction.rate:
+      enabled: true
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: true
+    sqlserver.transaction.version_generation.rate:
       enabled: true
     sqlserver.transaction.write.rate:
       enabled: true
@@ -248,6 +333,30 @@ reaggregate_set:
     sqlserver.database.page_file.size:
       enabled: true
       attributes: []
+    sqlserver.database.principals.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.old:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.orphaned_users:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.recently_created:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.members.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.memberships.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.permission.risk_level:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.roles.count:
+      enabled: true
+      attributes: []
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: []
@@ -261,6 +370,32 @@ reaggregate_set:
       attributes: []
     sqlserver.deadlock.rate:
       enabled: true
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: true
+    sqlserver.failover_cluster.replica.role:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: true
+      attributes: []
     sqlserver.index.search.rate:
       enabled: true
     sqlserver.kill_connection.error.rate:
@@ -276,6 +411,12 @@ reaggregate_set:
       enabled: true
     sqlserver.latch.wait_time.total:
       enabled: true
+    sqlserver.lock.by_mode.count:
+      enabled: true
+      attributes: []
+    sqlserver.lock.by_resource.count:
+      enabled: true
+      attributes: []
     sqlserver.lock.timeout.rate:
       enabled: true
     sqlserver.lock.wait.count:
@@ -367,11 +508,40 @@ reaggregate_set:
     sqlserver.table.count:
       enabled: true
       attributes: []
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: true
+      attributes: []
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: true
+    sqlserver.tempdb.data_files.count:
+      enabled: true
+    sqlserver.tempdb.file.size:
+      enabled: true
+      attributes: []
+    sqlserver.tempdb.space.usage:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.tasks.count:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.workers.count:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.workers.max:
+      enabled: true
+    sqlserver.thread_pool.workers.utilization:
+      enabled: true
     sqlserver.transaction.delay:
+      enabled: true
+    sqlserver.transaction.longest_running_time:
       enabled: true
     sqlserver.transaction.mirror_write.rate:
       enabled: true
     sqlserver.transaction.rate:
+      enabled: true
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: true
+    sqlserver.transaction.version_generation.rate:
       enabled: true
     sqlserver.transaction.write.rate:
       enabled: true
@@ -455,6 +625,30 @@ none_set:
     sqlserver.database.page_file.size:
       enabled: false
       attributes: ["db.namespace","page_file.state"]
+    sqlserver.database.principals.count:
+      enabled: false
+      attributes: ["db.namespace","principal.type"]
+    sqlserver.database.principals.old:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.orphaned_users:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.recently_created:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.role.members.count:
+      enabled: false
+      attributes: ["db.namespace","member.kind"]
+    sqlserver.database.role.memberships.count:
+      enabled: false
+      attributes: ["db.namespace","membership.kind"]
+    sqlserver.database.role.permission.risk_level:
+      enabled: false
+      attributes: ["db.namespace","role"]
+    sqlserver.database.role.roles.count:
+      enabled: false
+      attributes: ["db.namespace","role.state"]
     sqlserver.database.security.role_membership.count:
       enabled: false
       attributes: ["db.namespace","role"]
@@ -468,6 +662,32 @@ none_set:
       attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: false
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: false
+      attributes: ["ag.name","ag.cluster_type"]
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","db.namespace","replica.queue_kind"]
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","db.namespace"]
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: false
+    sqlserver.failover_cluster.replica.role:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","replica.role"]
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","replica.sync_health"]
     sqlserver.index.search.rate:
       enabled: false
     sqlserver.kill_connection.error.rate:
@@ -483,6 +703,12 @@ none_set:
       enabled: false
     sqlserver.latch.wait_time.total:
       enabled: false
+    sqlserver.lock.by_mode.count:
+      enabled: false
+      attributes: ["db.namespace","lock.mode"]
+    sqlserver.lock.by_resource.count:
+      enabled: false
+      attributes: ["db.namespace","lock.resource"]
     sqlserver.lock.timeout.rate:
       enabled: false
     sqlserver.lock.wait.count:
@@ -574,11 +800,40 @@ none_set:
     sqlserver.table.count:
       enabled: false
       attributes: ["table.state","table.status"]
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: false
+      attributes: ["allocation.page_type"]
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: false
+    sqlserver.tempdb.data_files.count:
+      enabled: false
+    sqlserver.tempdb.file.size:
+      enabled: false
+      attributes: ["file_type","tempdb.file.id"]
+    sqlserver.tempdb.space.usage:
+      enabled: false
+      attributes: ["tempdb.space_kind"]
+    sqlserver.thread_pool.tasks.count:
+      enabled: false
+      attributes: ["task.state"]
+    sqlserver.thread_pool.workers.count:
+      enabled: false
+      attributes: ["worker.state"]
+    sqlserver.thread_pool.workers.max:
+      enabled: false
+    sqlserver.thread_pool.workers.utilization:
+      enabled: false
     sqlserver.transaction.delay:
+      enabled: false
+    sqlserver.transaction.longest_running_time:
       enabled: false
     sqlserver.transaction.mirror_write.rate:
       enabled: false
     sqlserver.transaction.rate:
+      enabled: false
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: false
+    sqlserver.transaction.version_generation.rate:
       enabled: false
     sqlserver.transaction.write.rate:
       enabled: false

--- a/receiver/nrsqlserverreceiver/metadata.yaml
+++ b/receiver/nrsqlserverreceiver/metadata.yaml
@@ -60,6 +60,20 @@ resource_attributes:
 
 attributes:
   # attributes for metrics
+  ag.cluster_type:
+    description: Cluster type of the Always-On Availability Group.
+    type: string
+    requirement_level: recommended
+    enum: [wsfc, external, none, unknown]
+  ag.name:
+    description: Name of the Always-On Availability Group.
+    type: string
+    requirement_level: recommended
+  allocation.page_type:
+    description: TempDB allocation-page wait type.
+    type: string
+    requirement_level: recommended
+    enum: [gam, sgam, pfs, other]
   cache.state:
     description: The state of the cache objects.
     type: string
@@ -112,10 +126,30 @@ attributes:
     description: The type of file being monitored.
     type: string
     requirement_level: recommended
+  lock.mode:
+    description: SQL Server lock request mode.
+    type: string
+    requirement_level: recommended
+    enum: [shared, exclusive, update, intent, schema, bulk_update, shared_intent_exclusive]
+  lock.resource:
+    description: SQL Server lock resource type.
+    type: string
+    requirement_level: recommended
+    enum: [key, page, row, table, extent, file, hobt, metadata, application, allocation_unit, database_level]
   logical_filename:
     description: The logical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  member.kind:
+    description: Role-membership member breakdown bucket.
+    type: string
+    requirement_level: recommended
+    enum: [app_role, cross_role, high_privilege, unique]
+  membership.kind:
+    description: Role-membership grouping bucket.
+    type: string
+    requirement_level: recommended
+    enum: [active, custom, nested, users]
   memory.pool:
     description: The functional area of SQL Server memory.
     type: string
@@ -158,6 +192,11 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  principal.type:
+    description: Database security principal type.
+    type: string
+    requirement_level: recommended
+    enum: [sql_user, windows_user, role, application_role, certificate_mapped_user, asymmetric_key_mapped_user]
   process.status:
     description: The status of the SQL Server process/session.
     type: string
@@ -168,10 +207,34 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [transmit, receive]
+  replica.queue_kind:
+    description: Type of AG database-replica queue.
+    type: string
+    requirement_level: recommended
+    enum: [log_send, redo]
+  replica.role:
+    description: Availability replica role.
+    type: string
+    requirement_level: recommended
+    enum: [primary, secondary, resolving, unknown]
+  replica.server_name:
+    description: Server name of the availability replica.
+    type: string
+    requirement_level: recommended
+  replica.sync_health:
+    description: Synchronization health of the availability replica.
+    type: string
+    requirement_level: recommended
+    enum: [healthy, partially_healthy, not_healthy, unknown]
   role:
     description: The name of the database or server role.
     type: string
     requirement_level: recommended
+  role.state:
+    description: Database role usage state.
+    type: string
+    requirement_level: recommended
+    enum: [empty, with_members]
   server.address:
     description: The network address of the server hosting the database.
     type: string
@@ -378,6 +441,20 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [temporary, permanent]
+  task.state:
+    description: SQL Server task state for thread-pool diagnostics.
+    type: string
+    requirement_level: recommended
+    enum: [current, queued, waiting_for_threadpool]
+  tempdb.file.id:
+    description: Numeric file_id within tempdb (sys.master_files.file_id).
+    type: int
+    requirement_level: recommended
+  tempdb.space_kind:
+    description: TempDB space usage category.
+    type: string
+    requirement_level: recommended
+    enum: [user_objects, internal_objects, version_store, free]
   tempdb.state:
     description: The status of the tempdb space usage.
     type: string
@@ -401,6 +478,11 @@ attributes:
     description: Type of the wait, view [WaitTypes documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql?view=sql-server-ver16#WaitTypes) for more information.
     type: string
     requirement_level: recommended
+  worker.state:
+    description: SQL Server worker state.
+    type: string
+    requirement_level: recommended
+    enum: [running, suspended_or_sleeping]
   # attributes for events
   ## common
 events:
@@ -635,6 +717,86 @@ metrics:
       input_type: string
     attributes: [db.namespace, page_file.state]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.count:
+    enabled: false
+    description: Number of database security principals broken down by type.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, principal.type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.old:
+    enabled: false
+    description: Number of database principals created more than one year ago.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.orphaned_users:
+    enabled: false
+    description: Number of SQL users in the database that have no matching server login.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.recently_created:
+    enabled: false
+    description: Number of database principals created in the last 30 days.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.members.count:
+    enabled: false
+    description: Number of database role members broken down by member kind.
+    stability: development
+    unit: "{members}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, member.kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.memberships.count:
+    enabled: false
+    description: Number of database role memberships broken down by kind.
+    stability: development
+    unit: "{memberships}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, membership.kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.permission.risk_level:
+    enabled: false
+    description: Risk level assigned to each database role (1=low, 4=high).
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, role]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.roles.count:
+    enabled: false
+    description: Number of database roles broken down by usage state.
+    stability: development
+    unit: "{roles}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, role.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -681,6 +843,94 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.failover_cluster.ag.cluster_type:
+    enabled: false
+    description: Cluster type of the Always-On Availability Group.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, ag.cluster_type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.failure_condition_level:
+    enabled: false
+    description: Failure condition level configured for the Availability Group (1-5).
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.health_check_timeout:
+    enabled: false
+    description: Health-check timeout configured for the Availability Group.
+    stability: development
+    unit: "ms"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.required_sync_secondaries:
+    enabled: false
+    description: Number of synchronized secondary replicas required to commit on the Availability Group.
+    stability: development
+    unit: "{secondaries}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.database.queue_size:
+    enabled: false
+    description: Size of the log-send or redo queue for an AG database replica.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.database.redo.rate:
+    enabled: false
+    description: Redo rate for an AG database replica.
+    stability: development
+    unit: By/s
+    gauge:
+      value_type: double
+    attributes: [ag.name, replica.server_name, db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.flow_control_time:
+    enabled: false
+    description: Cumulative time spent in AG flow control, in milliseconds per second observed.
+    stability: development
+    unit: ms
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.role:
+    enabled: false
+    description: Role of the availability replica.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, replica.role]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.synchronization_health:
+    enabled: false
+    description: Synchronization health of the availability replica.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, replica.sync_health]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.index.search.rate:
     enabled: false
     description: Total number of index searches.
@@ -744,6 +994,26 @@ metrics:
       aggregation_temporality: cumulative
       value_type: double
     attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.lock.by_mode.count:
+    enabled: false
+    description: Number of currently active locks held in the database, grouped by lock mode.
+    stability: development
+    unit: "{locks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, lock.mode]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.lock.by_resource.count:
+    enabled: false
+    description: Number of currently active locks held in the database, grouped by resource type.
+    stability: development
+    unit: "{locks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, lock.resource]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.lock.timeout.rate:
     enabled: false
@@ -1088,6 +1358,96 @@ metrics:
       monotonic: false
       value_type: int
     attributes: [table.state, table.status]
+  sqlserver.tempdb.allocation.wait_time.total:
+    enabled: false
+    description: Cumulative wait time on tempdb allocation pages, broken down by page type.
+    stability: development
+    unit: s
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: [allocation.page_type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.contention.waiters.count:
+    enabled: false
+    description: Number of tempdb pagelatch wait types with at least one active waiter.
+    stability: development
+    unit: "{waiters}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.data_files.count:
+    enabled: false
+    description: Number of tempdb data files configured on the instance.
+    stability: development
+    unit: "{files}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.file.size:
+    enabled: false
+    description: Size of each tempdb data or log file.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [file_type, tempdb.file.id]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.space.usage:
+    enabled: false
+    description: Space used by tempdb, broken down by allocation category.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [tempdb.space_kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.tasks.count:
+    enabled: false
+    description: Number of SQL Server tasks broken down by state.
+    stability: development
+    unit: "{tasks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [task.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.count:
+    enabled: false
+    description: Number of SQL Server worker threads broken down by state.
+    stability: development
+    unit: "{workers}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [worker.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.max:
+    enabled: false
+    description: Maximum number of SQL Server worker threads configured on the instance.
+    stability: development
+    unit: "{workers}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.utilization:
+    enabled: false
+    description: Fraction of configured SQL Server worker threads currently running.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.delay:
     enabled: false
     description: Time consumed in transaction delays.
@@ -1098,6 +1458,15 @@ metrics:
       monotonic: false
       value_type: double
     attributes: []
+  sqlserver.transaction.longest_running_time:
+    enabled: false
+    description: Age in seconds of the longest currently-open transaction on the server.
+    stability: development
+    unit: s
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.mirror_write.rate:
     enabled: false
     description: Total number of mirror write transactions.
@@ -1114,6 +1483,28 @@ metrics:
     gauge:
       value_type: double
     extended_documentation: This metric is only available when running on Windows.
+  sqlserver.transaction.version_cleanup.rate:
+    enabled: false
+    description: Cumulative bytes cleaned from the tempdb version store.
+    stability: development
+    unit: By
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.transaction.version_generation.rate:
+    enabled: false
+    description: Cumulative bytes of row versions written to the tempdb version store.
+    stability: development
+    unit: By
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.write.rate:
     enabled: true
     description: Number of transactions that wrote to the database and committed.

--- a/receiver/nrsqlserverreceiver/metadata.yaml
+++ b/receiver/nrsqlserverreceiver/metadata.yaml
@@ -141,7 +141,7 @@ attributes:
     type: string
     requirement_level: recommended
   member.kind:
-    description: Role-membership member breakdown bucket.
+    description: Role-membership member breakdown bucket. `high_privilege` covers db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin.
     type: string
     requirement_level: recommended
     enum: [app_role, cross_role, high_privilege, unique]

--- a/receiver/nrsqlserverreceiver/queries.go
+++ b/receiver/nrsqlserverreceiver/queries.go
@@ -1915,7 +1915,6 @@ INNER JOIN sys.dm_tran_session_transactions AS st WITH (NOLOCK) ON tat.transacti
 INNER JOIN sys.dm_exec_sessions             AS sess WITH (NOLOCK) ON st.session_id = sess.session_id
 WHERE tat.transaction_type IN (1,2,4)
   AND tat.transaction_state IN (2,3)
-  AND sess.session_id > 50
   AND sess.is_user_process = 1
 {filter_instance_name};
 `

--- a/receiver/nrsqlserverreceiver/queries.go
+++ b/receiver/nrsqlserverreceiver/queries.go
@@ -161,6 +161,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'
@@ -1456,4 +1458,474 @@ func getSQLServerDatabasePageFileQuery(instanceName string) string {
 
 	r := strings.NewReplacer("{filter_instance_name}", "")
 	return r.Replace(sqlServerDatabasePageFileQuery)
+}
+
+// One row per database with active locks; mode + resource buckets in a single row.
+const sqlServerLockQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.lock.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_lock' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	DB_NAME(tl.resource_database_id) AS [db_name],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('S','IS')              THEN 1 ELSE 0 END) AS BIGINT) AS [mode_shared],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('X','IX')              THEN 1 ELSE 0 END) AS BIGINT) AS [mode_exclusive],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('U','IU','SIU','UIX')  THEN 1 ELSE 0 END) AS BIGINT) AS [mode_update],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('IS','IX','IU','SIU','SIX','UIX') THEN 1 ELSE 0 END) AS BIGINT) AS [mode_intent],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('Sch-S','Sch-M')        THEN 1 ELSE 0 END) AS BIGINT) AS [mode_schema],
+	CAST(SUM(CASE WHEN tl.request_mode = 'BU'                      THEN 1 ELSE 0 END) AS BIGINT) AS [mode_bulk_update],
+	CAST(SUM(CASE WHEN tl.request_mode = 'SIX'                     THEN 1 ELSE 0 END) AS BIGINT) AS [mode_shared_intent_exclusive],
+	CAST(SUM(CASE WHEN tl.resource_type = 'KEY'             THEN 1 ELSE 0 END) AS BIGINT) AS [resource_key],
+	CAST(SUM(CASE WHEN tl.resource_type = 'PAGE'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_page],
+	CAST(SUM(CASE WHEN tl.resource_type = 'RID'             THEN 1 ELSE 0 END) AS BIGINT) AS [resource_row],
+	CAST(SUM(CASE WHEN tl.resource_type = 'OBJECT'          THEN 1 ELSE 0 END) AS BIGINT) AS [resource_table],
+	CAST(SUM(CASE WHEN tl.resource_type = 'EXTENT'          THEN 1 ELSE 0 END) AS BIGINT) AS [resource_extent],
+	CAST(SUM(CASE WHEN tl.resource_type = 'FILE'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_file],
+	CAST(SUM(CASE WHEN tl.resource_type = 'HOBT'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_hobt],
+	CAST(SUM(CASE WHEN tl.resource_type = 'METADATA'        THEN 1 ELSE 0 END) AS BIGINT) AS [resource_metadata],
+	CAST(SUM(CASE WHEN tl.resource_type = 'APPLICATION'     THEN 1 ELSE 0 END) AS BIGINT) AS [resource_application],
+	CAST(SUM(CASE WHEN tl.resource_type = 'ALLOCATION_UNIT' THEN 1 ELSE 0 END) AS BIGINT) AS [resource_allocation_unit],
+	CAST(SUM(CASE WHEN tl.resource_type = 'DATABASE'        THEN 1 ELSE 0 END) AS BIGINT) AS [resource_database_level]
+FROM sys.dm_tran_locks tl WITH (NOLOCK)
+WHERE tl.resource_database_id > 0
+{filter_instance_name}
+GROUP BY tl.resource_database_id
+HAVING COUNT(*) > 0;
+`
+
+func getSQLServerLockQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerLockQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerLockQuery)
+}
+
+// Single-row snapshot of worker / task / scheduler state for thread-pool diagnostics.
+const sqlServerThreadPoolQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.thread_pool.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+;
+WITH
+waits AS (
+	SELECT COUNT(*) AS waiting_for_threadpool
+	FROM sys.dm_os_waiting_tasks WITH (NOLOCK)
+	WHERE wait_type = 'THREADPOOL'
+),
+sched AS (
+	SELECT
+		ISNULL(SUM(work_queue_count),0) AS work_queue,
+		ISNULL(SUM(current_tasks_count),0) AS current_tasks
+	FROM sys.dm_os_schedulers WITH (NOLOCK)
+	WHERE scheduler_id < 255 AND status = 'VISIBLE ONLINE'
+),
+workers AS (
+	SELECT
+		SUM(CASE WHEN state = 'RUNNING' THEN 1 ELSE 0 END) AS running,
+		SUM(CASE WHEN state NOT IN ('RUNNING','RUNNABLE') THEN 1 ELSE 0 END) AS suspended_or_sleeping
+	FROM sys.dm_os_workers WITH (NOLOCK)
+),
+cfg AS (
+	SELECT max_workers_count AS max_workers FROM sys.dm_os_sys_info
+)
+SELECT
+	'sqlserver_thread_pool' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(workers.running AS BIGINT)                AS [workers_running],
+	CAST(workers.suspended_or_sleeping AS BIGINT)  AS [workers_suspended_or_sleeping],
+	CAST(cfg.max_workers AS BIGINT)                AS [workers_max],
+	CAST(CAST(workers.running AS float) / NULLIF(CAST(cfg.max_workers AS float), 0) AS float) AS [workers_utilization],
+	CAST(sched.current_tasks AS BIGINT)            AS [tasks_current],
+	CAST(sched.work_queue AS BIGINT)               AS [tasks_queued],
+	CAST(waits.waiting_for_threadpool AS BIGINT)   AS [tasks_waiting_for_threadpool]
+FROM waits, sched, workers, cfg
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerThreadPoolQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerThreadPoolQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerThreadPoolQuery)
+}
+
+// Single-row tempdb diagnostics covering space usage, data-file count, pagelatch waiters, and allocation-page wait time.
+const sqlServerTempDBQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.tempdb.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+;
+WITH
+file_space AS (
+	SELECT
+		CAST(SUM(user_object_reserved_page_count)     AS BIGINT) * 8 * 1024 AS bytes_user_objects,
+		CAST(SUM(internal_object_reserved_page_count) AS BIGINT) * 8 * 1024 AS bytes_internal_objects,
+		CAST(SUM(version_store_reserved_page_count)   AS BIGINT) * 8 * 1024 AS bytes_version_store,
+		CAST(SUM(unallocated_extent_page_count)       AS BIGINT) * 8 * 1024 AS bytes_free
+	FROM tempdb.sys.dm_db_file_space_usage WITH (NOLOCK)
+),
+files AS (
+	SELECT CAST(COUNT(*) AS BIGINT) AS data_file_count
+	FROM sys.master_files WITH (NOLOCK)
+	WHERE database_id = 2 AND type = 0
+),
+contention AS (
+	SELECT CAST(COUNT(*) AS BIGINT) AS pagelatch_waiters
+	FROM sys.dm_os_wait_stats WITH (NOLOCK)
+	WHERE wait_type IN ('PAGELATCH_IO','PAGELATCH_SH','PAGELATCH_EX','PAGELATCH_UP')
+	  AND waiting_tasks_count > 0
+),
+alloc AS (
+	SELECT
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%GAM%'  AND wait_type NOT LIKE '%SGAM%'), 0) AS gam_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%SGAM%'), 0) AS sgam_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%PFS%'),  0) AS pfs_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK)
+		        WHERE wait_type LIKE '%ALLOCATION%'
+		          AND wait_type NOT LIKE '%GAM%'
+		          AND wait_type NOT LIKE '%SGAM%'
+		          AND wait_type NOT LIKE '%PFS%'), 0) AS other_ms
+)
+SELECT
+	'sqlserver_tempdb' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	file_space.bytes_user_objects,
+	file_space.bytes_internal_objects,
+	file_space.bytes_version_store,
+	file_space.bytes_free,
+	files.data_file_count,
+	contention.pagelatch_waiters,
+	alloc.gam_ms,
+	alloc.sgam_ms,
+	alloc.pfs_ms,
+	alloc.other_ms
+FROM file_space, files, contention, alloc
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerTempDBQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerTempDBQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerTempDBQuery)
+}
+
+// One row per tempdb data/log file.
+const sqlServerTempDBFileQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.tempdb.file.size.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_tempdb_file' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(file_id AS BIGINT) AS [file_id],
+	CASE type WHEN 0 THEN 'data' WHEN 1 THEN 'log' ELSE 'other' END AS [file_type],
+	CAST(size AS BIGINT) * 8 * 1024 AS [size_bytes]
+FROM sys.master_files WITH (NOLOCK)
+WHERE database_id = 2 AND type IN (0, 1)
+{filter_instance_name};
+`
+
+func getSQLServerTempDBFileQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerTempDBFileQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerTempDBFileQuery)
+}
+
+// One row per Availability Group on this instance. Returns zero rows if Always-On is not configured.
+const sqlServerFailoverClusterAGQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.ag.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_ag' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	LOWER(ISNULL(ag.cluster_type_desc, 'UNKNOWN')) AS [cluster_type],
+	CAST(ISNULL(ag.failure_condition_level, 0) AS BIGINT) AS [failure_condition_level],
+	CAST(ISNULL(ag.health_check_timeout, 0) AS BIGINT) AS [health_check_timeout],
+	CAST(ISNULL(ag.required_synchronized_secondaries_to_commit, 0) AS BIGINT) AS [required_sync_secondaries]
+FROM sys.availability_groups AS ag WITH (NOLOCK)
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterAGQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterAGQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterAGQuery)
+}
+
+// One row per availability replica.
+const sqlServerFailoverClusterReplicaQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.replica.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_replica' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	ISNULL(ar.replica_server_name, 'UNKNOWN') AS [replica_server_name],
+	LOWER(ISNULL(ars.role_desc, 'UNKNOWN')) AS [role],
+	LOWER(REPLACE(ISNULL(ars.synchronization_health_desc, 'UNKNOWN'), '_', '_')) AS [sync_health]
+FROM sys.dm_hadr_availability_replica_states AS ars WITH (NOLOCK)
+INNER JOIN sys.availability_replicas AS ar WITH (NOLOCK) ON ars.replica_id = ar.replica_id
+INNER JOIN sys.availability_groups   AS ag WITH (NOLOCK) ON ar.group_id   = ag.group_id
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterReplicaQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterReplicaQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterReplicaQuery)
+}
+
+// One row per AG database replica.
+const sqlServerFailoverClusterReplicaDatabaseQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.replica.database.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_replica_database' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	ISNULL(ar.replica_server_name, 'UNKNOWN') AS [replica_server_name],
+	ISNULL(d.name, 'UNKNOWN') AS [db_name],
+	CAST(ISNULL(drs.log_send_queue_size, 0) AS BIGINT) * 1024 AS [log_send_queue_bytes],
+	CAST(ISNULL(drs.redo_queue_size, 0) AS BIGINT)     * 1024 AS [redo_queue_bytes],
+	CAST(ISNULL(drs.redo_rate, 0) AS float)            * 1024 AS [redo_rate_bytes_per_sec]
+FROM sys.dm_hadr_database_replica_states AS drs WITH (NOLOCK)
+INNER JOIN sys.availability_replicas AS ar WITH (NOLOCK) ON drs.replica_id = ar.replica_id
+INNER JOIN sys.availability_groups   AS ag WITH (NOLOCK) ON ar.group_id    = ag.group_id
+INNER JOIN sys.databases             AS d  WITH (NOLOCK) ON drs.database_id = d.database_id
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterReplicaDatabaseQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterReplicaDatabaseQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterReplicaDatabaseQuery)
+}
+
+// One row per user database with principal counts (typed and lifecycle).
+// Dynamic SQL with UNION ALL so the entire result set is one rowset.
+const sqlServerDatabasePrincipalsQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.principals.* metrics (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''S'' THEN 1 ELSE 0 END) AS BIGINT) AS [sql_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''U'' THEN 1 ELSE 0 END) AS BIGINT) AS [windows_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''R'' THEN 1 ELSE 0 END) AS BIGINT) AS [role], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''A'' THEN 1 ELSE 0 END) AS BIGINT) AS [application_role], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''C'' THEN 1 ELSE 0 END) AS BIGINT) AS [certificate_mapped_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''K'' THEN 1 ELSE 0 END) AS BIGINT) AS [asymmetric_key_mapped_user], ' +
+	N'CAST(SUM(CASE WHEN p.create_date >= DATEADD(day, -30, GETDATE()) THEN 1 ELSE 0 END) AS BIGINT) AS [recently_created], ' +
+	N'CAST(SUM(CASE WHEN p.create_date <  DATEADD(year, -1,  GETDATE()) THEN 1 ELSE 0 END) AS BIGINT) AS [old], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_principals dp WHERE dp.type = ''S'' AND dp.is_fixed_role = 0 AND dp.name <> ''dbo'' AND dp.principal_id > 4 AND NOT EXISTS (SELECT 1 FROM sys.server_principals sp WHERE sp.name = dp.name AND sp.type = ''S'')) AS BIGINT) AS [orphaned_users] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.database_principals p ' +
+	N'WHERE p.is_fixed_role = 0 AND p.type <> ''X'' AND p.name NOT IN (''guest'', ''INFORMATION_SCHEMA'', ''sys'')'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabasePrincipalsQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabasePrincipalsQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabasePrincipalsQuery)
+}
+
+// One row per user database with role-membership aggregates.
+const sqlServerDatabaseRoleMembershipQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.role.* metrics (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	-- members.* (4 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.type = ''A'') AS BIGINT) AS [members_app_role], ' +
+	N'CAST((SELECT COUNT(DISTINCT drm1.member_principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm1 WHERE EXISTS (SELECT 1 FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm2 WHERE drm2.member_principal_id = drm1.member_principal_id AND drm2.role_principal_id <> drm1.role_principal_id)) AS BIGINT) AS [members_cross_role], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.name IN (''db_owner'',''db_securityadmin'',''db_accessadmin'',''db_backupoperator'',''db_ddladmin'')) AS BIGINT) AS [members_high_privilege], ' +
+	N'CAST((SELECT COUNT(DISTINCT member_principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_role_members) AS BIGINT) AS [members_unique], ' +
+	-- memberships.* (4 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members) AS BIGINT) AS [memberships_active], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.is_fixed_role = 0) AS BIGINT) AS [memberships_custom], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals m ON drm.member_principal_id = m.principal_id WHERE m.type = ''R'') AS BIGINT) AS [memberships_nested], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals m ON drm.member_principal_id = m.principal_id WHERE m.type IN (''S'',''U'',''G'')) AS BIGINT) AS [memberships_users], ' +
+	-- roles.* (2 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_principals r WHERE r.type IN (''R'',''A'') AND NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm WHERE drm.role_principal_id = r.principal_id)) AS BIGINT) AS [roles_empty], ' +
+	N'CAST((SELECT COUNT(DISTINCT r.principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_principals r JOIN ' + QUOTENAME(name) + N'.sys.database_role_members drm ON drm.role_principal_id = r.principal_id WHERE r.type IN (''R'',''A'')) AS BIGINT) AS [roles_with_members]'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabaseRoleMembershipQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabaseRoleMembershipQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabaseRoleMembershipQuery)
+}
+
+// One row per user database, per role, with a static risk-level mapping.
+const sqlServerDatabaseRoleRiskLevelQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.role.permission.risk_level (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], r.name AS [role_name], ' +
+	N'CAST(CASE WHEN r.name = ''db_owner'' THEN 4 ' +
+	N'          WHEN r.name IN (''db_securityadmin'',''db_accessadmin'') THEN 3 ' +
+	N'          WHEN r.name IN (''db_ddladmin'',''db_backupoperator'') THEN 2 ' +
+	N'          ELSE 1 END AS BIGINT) AS [risk_level] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.database_principals r WHERE r.type IN (''R'',''A'')'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabaseRoleRiskLevelQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabaseRoleRiskLevelQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabaseRoleRiskLevelQuery)
+}
+
+// Returns the age (in seconds) of the longest currently-open transaction.
+// Returns 0 if no user transactions are open.
+const sqlServerLongestRunningTransactionQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.transaction.longest_running_time.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_longest_running_transaction' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(MAX(DATEDIFF(SECOND, tat.transaction_begin_time, GETDATE())), 0) AS [longest_running_seconds]
+FROM sys.dm_tran_active_transactions   AS tat WITH (NOLOCK)
+INNER JOIN sys.dm_tran_session_transactions AS st WITH (NOLOCK) ON tat.transaction_id = st.transaction_id
+INNER JOIN sys.dm_exec_sessions             AS sess WITH (NOLOCK) ON st.session_id = sess.session_id
+WHERE tat.transaction_type IN (1,2,4)
+  AND tat.transaction_state IN (2,3)
+  AND sess.session_id > 50
+  AND sess.is_user_process = 1
+{filter_instance_name};
+`
+
+func getSQLServerLongestRunningTransactionQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerLongestRunningTransactionQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerLongestRunningTransactionQuery)
 }

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -145,6 +145,28 @@ func (s *sqlServerScraperHelper) ScrapeMetrics(ctx context.Context) (pmetric.Met
 		err = s.recordProcessCountMetrics(ctx)
 	case getSQLServerDatabasePageFileQuery(s.config.InstanceName):
 		err = s.recordDatabasePageFileMetrics(ctx)
+	case getSQLServerLockQuery(s.config.InstanceName):
+		err = s.recordLockMetrics(ctx)
+	case getSQLServerThreadPoolQuery(s.config.InstanceName):
+		err = s.recordThreadPoolMetrics(ctx)
+	case getSQLServerTempDBQuery(s.config.InstanceName):
+		err = s.recordTempDBMetrics(ctx)
+	case getSQLServerTempDBFileQuery(s.config.InstanceName):
+		err = s.recordTempDBFileMetrics(ctx)
+	case getSQLServerFailoverClusterAGQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterAGMetrics(ctx)
+	case getSQLServerFailoverClusterReplicaQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterReplicaMetrics(ctx)
+	case getSQLServerFailoverClusterReplicaDatabaseQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterReplicaDatabaseMetrics(ctx)
+	case getSQLServerDatabasePrincipalsQuery(s.config.InstanceName):
+		err = s.recordDatabasePrincipalsMetrics(ctx)
+	case getSQLServerDatabaseRoleMembershipQuery(s.config.InstanceName):
+		err = s.recordDatabaseRoleMembershipMetrics(ctx)
+	case getSQLServerDatabaseRoleRiskLevelQuery(s.config.InstanceName):
+		err = s.recordDatabaseRoleRiskLevelMetrics(ctx)
+	case getSQLServerLongestRunningTransactionQuery(s.config.InstanceName):
+		err = s.recordLongestRunningTransactionMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -441,6 +463,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const bufferCacheHitRatio = "Buffer cache hit ratio"
 	const bytesReceivedFromReplicaPerSec = "Bytes Received from Replica/sec"
 	const bytesSentForReplicaPerSec = "Bytes Sent to Replica/sec"
+	const flowControlTimePerSec = "Flow Control Time (ms/sec)"
 	const diskReadIOSec = "Disk Read IO/sec"
 	const diskReadIOThrottled = "Disk Read IO Throttled/sec"
 	const diskWriteIOSec = "Disk Write IO/sec"
@@ -477,6 +500,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const userConnCount = "User Connections"
 	const usedMemory = "Used memory (KB)"
 	const versionStoreSize = "Version Store Size (KB)"
+	const versionGenerationRate = "Version Generation rate (KB/s)"
+	const versionCleanupRate = "Version Cleanup rate (KB/s)"
 	const sqlCacheMemory = "SQL Cache Memory (KB)"
 	const optimizerMemory = "Optimizer Memory (KB)"
 	const connectionMemory = "Connection Memory (KB)"
@@ -587,6 +612,31 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionTransmit)
+			}
+		case flowControlTimePerSec:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, flowControlTimePerSec)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(now, val.(float64))
+			}
+		case versionGenerationRate:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, versionGenerationRate)
+				errs = append(errs, err)
+			} else {
+				// Convert KB/s to By/s.
+				s.mb.RecordSqlserverTransactionVersionGenerationRateDataPoint(now, val.(float64)*1024)
+			}
+		case versionCleanupRate:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, versionCleanupRate)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverTransactionVersionCleanupRateDataPoint(now, val.(float64)*1024)
 			}
 		case diskReadIOSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -1385,6 +1435,505 @@ func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Conte
 		if totalErr == nil && freeErr == nil {
 			usedBytes := max(totalVal.(int64)-freeVal.(int64), 0)
 			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, fmt.Sprintf("%d", usedBytes), row[databaseName], metadata.AttributePageFileStateUsed))
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordLockMetrics(ctx context.Context) error {
+	const databaseName = "db_name"
+	lockModeCols := []struct {
+		col   string
+		value metadata.AttributeLockMode
+	}{
+		{"mode_shared", metadata.AttributeLockModeShared},
+		{"mode_exclusive", metadata.AttributeLockModeExclusive},
+		{"mode_update", metadata.AttributeLockModeUpdate},
+		{"mode_intent", metadata.AttributeLockModeIntent},
+		{"mode_schema", metadata.AttributeLockModeSchema},
+		{"mode_bulk_update", metadata.AttributeLockModeBulkUpdate},
+		{"mode_shared_intent_exclusive", metadata.AttributeLockModeSharedIntentExclusive},
+	}
+	lockResourceCols := []struct {
+		col   string
+		value metadata.AttributeLockResource
+	}{
+		{"resource_key", metadata.AttributeLockResourceKey},
+		{"resource_page", metadata.AttributeLockResourcePage},
+		{"resource_row", metadata.AttributeLockResourceRow},
+		{"resource_table", metadata.AttributeLockResourceTable},
+		{"resource_extent", metadata.AttributeLockResourceExtent},
+		{"resource_file", metadata.AttributeLockResourceFile},
+		{"resource_hobt", metadata.AttributeLockResourceHobt},
+		{"resource_metadata", metadata.AttributeLockResourceMetadata},
+		{"resource_application", metadata.AttributeLockResourceApplication},
+		{"resource_allocation_unit", metadata.AttributeLockResourceAllocationUnit},
+		{"resource_database_level", metadata.AttributeLockResourceDatabaseLevel},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range lockModeCols {
+			errs = append(errs, s.mb.RecordSqlserverLockByModeCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range lockResourceCols {
+			errs = append(errs, s.mb.RecordSqlserverLockByResourceCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordThreadPoolMetrics(ctx context.Context) error {
+	const (
+		workersRunning             = "workers_running"
+		workersSuspendedOrSleeping = "workers_suspended_or_sleeping"
+		workersMax                 = "workers_max"
+		workersUtilization         = "workers_utilization"
+		tasksCurrent               = "tasks_current"
+		tasksQueued                = "tasks_queued"
+		tasksWaitingForThreadpool  = "tasks_waiting_for_threadpool"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverThreadPoolWorkersCountDataPoint(now, row[workersRunning], metadata.AttributeWorkerStateRunning),
+			s.mb.RecordSqlserverThreadPoolWorkersCountDataPoint(now, row[workersSuspendedOrSleeping], metadata.AttributeWorkerStateSuspendedOrSleeping),
+			s.mb.RecordSqlserverThreadPoolWorkersMaxDataPoint(now, row[workersMax]),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksCurrent], metadata.AttributeTaskStateCurrent),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksQueued], metadata.AttributeTaskStateQueued),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksWaitingForThreadpool], metadata.AttributeTaskStateWaitingForThreadpool),
+		)
+
+		if utilStr := row[workersUtilization]; utilStr != "" {
+			val, parseErr := retrieveFloat(row, workersUtilization)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s: %w", workersUtilization, parseErr))
+			} else {
+				s.mb.RecordSqlserverThreadPoolWorkersUtilizationDataPoint(now, val.(float64))
+			}
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordTempDBMetrics(ctx context.Context) error {
+	const (
+		bytesUserObjects     = "bytes_user_objects"
+		bytesInternalObjects = "bytes_internal_objects"
+		bytesVersionStore    = "bytes_version_store"
+		bytesFree            = "bytes_free"
+		dataFileCount        = "data_file_count"
+		pagelatchWaiters     = "pagelatch_waiters"
+		gamMs                = "gam_ms"
+		sgamMs               = "sgam_ms"
+		pfsMs                = "pfs_ms"
+		otherMs              = "other_ms"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesUserObjects], metadata.AttributeTempdbSpaceKindUserObjects),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesInternalObjects], metadata.AttributeTempdbSpaceKindInternalObjects),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesVersionStore], metadata.AttributeTempdbSpaceKindVersionStore),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesFree], metadata.AttributeTempdbSpaceKindFree),
+			s.mb.RecordSqlserverTempdbDataFilesCountDataPoint(now, row[dataFileCount]),
+			s.mb.RecordSqlserverTempdbContentionWaitersCountDataPoint(now, row[pagelatchWaiters]),
+		)
+
+		for _, w := range []struct {
+			col   string
+			value metadata.AttributeAllocationPageType
+		}{
+			{gamMs, metadata.AttributeAllocationPageTypeGam},
+			{sgamMs, metadata.AttributeAllocationPageTypeSgam},
+			{pfsMs, metadata.AttributeAllocationPageTypePfs},
+			{otherMs, metadata.AttributeAllocationPageTypeOther},
+		} {
+			val, parseErr := retrieveFloat(row, w.col)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", w.col, i, parseErr))
+				continue
+			}
+			s.mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(now, val.(float64)/1e3, w.value)
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordTempDBFileMetrics(ctx context.Context) error {
+	const (
+		fileID    = "file_id"
+		fileType  = "file_type"
+		sizeBytes = "size_bytes"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		idVal, parseErr := retrieveInt(row, fileID)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", fileID, i, parseErr))
+			continue
+		}
+		errs = append(errs, s.mb.RecordSqlserverTempdbFileSizeDataPoint(now, row[sizeBytes], row[fileType], idVal.(int64)))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+var failoverClusterAGClusterTypeMap = map[string]metadata.AttributeAgClusterType{
+	"wsfc":     metadata.AttributeAgClusterTypeWsfc,
+	"external": metadata.AttributeAgClusterTypeExternal,
+	"none":     metadata.AttributeAgClusterTypeNone,
+}
+
+var failoverClusterReplicaRoleMap = map[string]metadata.AttributeReplicaRole{
+	"primary":   metadata.AttributeReplicaRolePrimary,
+	"secondary": metadata.AttributeReplicaRoleSecondary,
+	"resolving": metadata.AttributeReplicaRoleResolving,
+}
+
+var failoverClusterReplicaSyncHealthMap = map[string]metadata.AttributeReplicaSyncHealth{
+	"healthy":           metadata.AttributeReplicaSyncHealthHealthy,
+	"partially_healthy": metadata.AttributeReplicaSyncHealthPartiallyHealthy,
+	"not_healthy":       metadata.AttributeReplicaSyncHealthNotHealthy,
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterAGMetrics(ctx context.Context) error {
+	const (
+		agName                  = "ag_name"
+		clusterType             = "cluster_type"
+		failureConditionLevel   = "failure_condition_level"
+		healthCheckTimeout      = "health_check_timeout"
+		requiredSyncSecondaries = "required_sync_secondaries"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		ct, ok := failoverClusterAGClusterTypeMap[row[clusterType]]
+		if !ok {
+			ct = metadata.AttributeAgClusterTypeUnknown
+		}
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(now, "1", row[agName], ct),
+			s.mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(now, row[failureConditionLevel], row[agName]),
+			s.mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(now, row[healthCheckTimeout], row[agName]),
+			s.mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(now, row[requiredSyncSecondaries], row[agName]),
+		)
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterReplicaMetrics(ctx context.Context) error {
+	const (
+		agName            = "ag_name"
+		replicaServerName = "replica_server_name"
+		role              = "role"
+		syncHealth        = "sync_health"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		r, ok := failoverClusterReplicaRoleMap[row[role]]
+		if !ok {
+			r = metadata.AttributeReplicaRoleUnknown
+		}
+		sh, ok := failoverClusterReplicaSyncHealthMap[row[syncHealth]]
+		if !ok {
+			sh = metadata.AttributeReplicaSyncHealthUnknown
+		}
+
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(now, "1", row[agName], row[replicaServerName], r),
+			s.mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(now, "1", row[agName], row[replicaServerName], sh),
+		)
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterReplicaDatabaseMetrics(ctx context.Context) error {
+	const (
+		agName              = "ag_name"
+		replicaServerName   = "replica_server_name"
+		databaseName        = "db_name"
+		logSendQueueBytes   = "log_send_queue_bytes"
+		redoQueueBytes      = "redo_queue_bytes"
+		redoRateBytesPerSec = "redo_rate_bytes_per_sec"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(now, row[logSendQueueBytes], row[agName], row[replicaServerName], row[databaseName], metadata.AttributeReplicaQueueKindLogSend),
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(now, row[redoQueueBytes], row[agName], row[replicaServerName], row[databaseName], metadata.AttributeReplicaQueueKindRedo),
+		)
+
+		rateVal, parseErr := retrieveFloat(row, redoRateBytesPerSec)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", redoRateBytesPerSec, i, parseErr))
+		} else {
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(now, rateVal.(float64), row[agName], row[replicaServerName], row[databaseName])
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabasePrincipalsMetrics(ctx context.Context) error {
+	const (
+		databaseName            = "db_name"
+		sqlUser                 = "sql_user"
+		windowsUser             = "windows_user"
+		roleCol                 = "role"
+		applicationRole         = "application_role"
+		certificateMappedUser   = "certificate_mapped_user"
+		asymmetricKeyMappedUser = "asymmetric_key_mapped_user"
+		recentlyCreated         = "recently_created"
+		old                     = "old"
+		orphanedUsers           = "orphaned_users"
+	)
+	principalTypeCols := []struct {
+		col   string
+		value metadata.AttributePrincipalType
+	}{
+		{sqlUser, metadata.AttributePrincipalTypeSQLUser},
+		{windowsUser, metadata.AttributePrincipalTypeWindowsUser},
+		{roleCol, metadata.AttributePrincipalTypeRole},
+		{applicationRole, metadata.AttributePrincipalTypeApplicationRole},
+		{certificateMappedUser, metadata.AttributePrincipalTypeCertificateMappedUser},
+		{asymmetricKeyMappedUser, metadata.AttributePrincipalTypeAsymmetricKeyMappedUser},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range principalTypeCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePrincipalsCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		errs = append(errs,
+			s.mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(now, row[recentlyCreated], row[databaseName]),
+			s.mb.RecordSqlserverDatabasePrincipalsOldDataPoint(now, row[old], row[databaseName]),
+			s.mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(now, row[orphanedUsers], row[databaseName]),
+		)
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabaseRoleMembershipMetrics(ctx context.Context) error {
+	const databaseName = "db_name"
+	memberCols := []struct {
+		col   string
+		value metadata.AttributeMemberKind
+	}{
+		{"members_app_role", metadata.AttributeMemberKindAppRole},
+		{"members_cross_role", metadata.AttributeMemberKindCrossRole},
+		{"members_high_privilege", metadata.AttributeMemberKindHighPrivilege},
+		{"members_unique", metadata.AttributeMemberKindUnique},
+	}
+	membershipCols := []struct {
+		col   string
+		value metadata.AttributeMembershipKind
+	}{
+		{"memberships_active", metadata.AttributeMembershipKindActive},
+		{"memberships_custom", metadata.AttributeMembershipKindCustom},
+		{"memberships_nested", metadata.AttributeMembershipKindNested},
+		{"memberships_users", metadata.AttributeMembershipKindUsers},
+	}
+	roleCols := []struct {
+		col   string
+		value metadata.AttributeRoleState
+	}{
+		{"roles_empty", metadata.AttributeRoleStateEmpty},
+		{"roles_with_members", metadata.AttributeRoleStateWithMembers},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range memberCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range membershipCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range roleCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabaseRoleRiskLevelMetrics(ctx context.Context) error {
+	const (
+		databaseName = "db_name"
+		roleName     = "role_name"
+		riskLevel    = "risk_level"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		errs = append(errs, s.mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(now, row[riskLevel], row[databaseName], row[roleName]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordLongestRunningTransactionMetrics(ctx context.Context) error {
+	const longestSeconds = "longest_running_seconds"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		val, parseErr := retrieveFloat(row, longestSeconds)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", longestSeconds, i, parseErr))
+		} else {
+			s.mb.RecordSqlserverTransactionLongestRunningTimeDataPoint(now, val.(float64))
 		}
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/nrsqlserverreceiver/testdata/perfCounterQueryWithInstanceName.txt
+++ b/receiver/nrsqlserverreceiver/testdata/perfCounterQueryWithInstanceName.txt
@@ -77,6 +77,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'

--- a/receiver/nrsqlserverreceiver/testdata/perfCounterQueryWithoutInstanceName.txt
+++ b/receiver/nrsqlserverreceiver/testdata/perfCounterQueryWithoutInstanceName.txt
@@ -77,6 +77,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -395,6 +395,139 @@ This metric is only available when the receiver is configured to directly connec
 | db.namespace | The database name. | Any Str | Recommended | - |
 | page_file.state | The state of the database page file (reserved space) allocation. | Str: ``used``, ``free``, ``total`` | Recommended | - |
 
+### sqlserver.database.principals.count
+
+Number of database security principals broken down by type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| principal.type | Database security principal type. | Str: ``sql_user``, ``windows_user``, ``role``, ``application_role``, ``certificate_mapped_user``, ``asymmetric_key_mapped_user`` | Recommended | - |
+
+### sqlserver.database.principals.old
+
+Number of database principals created more than one year ago.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.principals.orphaned_users
+
+Number of SQL users in the database that have no matching server login.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.principals.recently_created
+
+Number of database principals created in the last 30 days.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {principals} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.database.role.members.count
+
+Number of database role members broken down by member kind.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {members} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| member.kind | Role-membership member breakdown bucket. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
+
+### sqlserver.database.role.memberships.count
+
+Number of database role memberships broken down by kind.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {memberships} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| membership.kind | Role-membership grouping bucket. | Str: ``active``, ``custom``, ``nested``, ``users`` | Recommended | - |
+
+### sqlserver.database.role.permission.risk_level
+
+Risk level assigned to each database role (1=low, 4=high).
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| role | The name of the database or server role. | Any Str | Recommended | - |
+
+### sqlserver.database.role.roles.count
+
+Number of database roles broken down by usage state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {roles} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| role.state | Database role usage state. | Str: ``empty``, ``with_members`` | Recommended | - |
+
 ### sqlserver.database.security.role_membership.count
 
 Number of members in a database role.
@@ -457,6 +590,154 @@ Total number of deadlocks.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {deadlocks}/s | Gauge | Double | Development |
+
+### sqlserver.failover_cluster.ag.cluster_type
+
+Cluster type of the Always-On Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| ag.cluster_type | Cluster type of the Always-On Availability Group. | Str: ``wsfc``, ``external``, ``none``, ``unknown`` | Recommended | - |
+
+### sqlserver.failover_cluster.ag.failure_condition_level
+
+Failure condition level configured for the Availability Group (1-5).
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.ag.health_check_timeout
+
+Health-check timeout configured for the Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.ag.required_sync_secondaries
+
+Number of synchronized secondary replicas required to commit on the Availability Group.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {secondaries} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.replica.database.queue_size
+
+Size of the log-send or redo queue for an AG database replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| replica.queue_kind | Type of AG database-replica queue. | Str: ``log_send``, ``redo`` | Recommended | - |
+
+### sqlserver.failover_cluster.replica.database.redo.rate
+
+Redo rate for an AG database replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| db.namespace | The database name. | Any Str | Recommended | - |
+
+### sqlserver.failover_cluster.replica.flow_control_time
+
+Cumulative time spent in AG flow control, in milliseconds per second observed.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Double | Development |
+
+### sqlserver.failover_cluster.replica.role
+
+Role of the availability replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| replica.role | Availability replica role. | Str: ``primary``, ``secondary``, ``resolving``, ``unknown`` | Recommended | - |
+
+### sqlserver.failover_cluster.replica.synchronization_health
+
+Synchronization health of the availability replica.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| ag.name | Name of the Always-On Availability Group. | Any Str | Recommended | - |
+| replica.server_name | Server name of the availability replica. | Any Str | Recommended | - |
+| replica.sync_health | Synchronization health of the availability replica. | Str: ``healthy``, ``partially_healthy``, ``not_healthy``, ``unknown`` | Recommended | - |
 
 ### sqlserver.index.search.rate
 
@@ -531,6 +812,40 @@ This metric is only available when the receiver is configured to directly connec
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | s | Sum | Double | Cumulative | true | Development |
+
+### sqlserver.lock.by_mode.count
+
+Number of currently active locks held in the database, grouped by lock mode.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| lock.mode | SQL Server lock request mode. | Str: ``shared``, ``exclusive``, ``update``, ``intent``, ``schema``, ``bulk_update``, ``shared_intent_exclusive`` | Recommended | - |
+
+### sqlserver.lock.by_resource.count
+
+Number of currently active locks held in the database, grouped by resource type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| db.namespace | The database name. | Any Str | Recommended | - |
+| lock.resource | SQL Server lock resource type. | Str: ``key``, ``page``, ``row``, ``table``, ``extent``, ``file``, ``hobt``, ``metadata``, ``application``, ``allocation_unit``, ``database_level`` | Recommended | - |
 
 ### sqlserver.lock.timeout.rate
 
@@ -889,6 +1204,127 @@ The number of tables.
 | table.state | The state of the table. | Str: ``active``, ``inactive`` | Recommended | - |
 | table.status | The status of the table. | Str: ``temporary``, ``permanent`` | Recommended | - |
 
+### sqlserver.tempdb.allocation.wait_time.total
+
+Cumulative wait time on tempdb allocation pages, broken down by page type.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| allocation.page_type | TempDB allocation-page wait type. | Str: ``gam``, ``sgam``, ``pfs``, ``other`` | Recommended | - |
+
+### sqlserver.tempdb.contention.waiters.count
+
+Number of tempdb pagelatch wait types with at least one active waiter.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {waiters} | Gauge | Int | Development |
+
+### sqlserver.tempdb.data_files.count
+
+Number of tempdb data files configured on the instance.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {files} | Gauge | Int | Development |
+
+### sqlserver.tempdb.file.size
+
+Size of each tempdb data or log file.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| file_type | The type of file being monitored. | Any Str | Recommended | - |
+| tempdb.file.id | Numeric file_id within tempdb (sys.master_files.file_id). | Any Int | Recommended | - |
+
+### sqlserver.tempdb.space.usage
+
+Space used by tempdb, broken down by allocation category.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| tempdb.space_kind | TempDB space usage category. | Str: ``user_objects``, ``internal_objects``, ``version_store``, ``free`` | Recommended | - |
+
+### sqlserver.thread_pool.tasks.count
+
+Number of SQL Server tasks broken down by state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tasks} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| task.state | SQL Server task state for thread-pool diagnostics. | Str: ``current``, ``queued``, ``waiting_for_threadpool`` | Recommended | - |
+
+### sqlserver.thread_pool.workers.count
+
+Number of SQL Server worker threads broken down by state.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {workers} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| worker.state | SQL Server worker state. | Str: ``running``, ``suspended_or_sleeping`` | Recommended | - |
+
+### sqlserver.thread_pool.workers.max
+
+Maximum number of SQL Server worker threads configured on the instance.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {workers} | Gauge | Int | Development |
+
+### sqlserver.thread_pool.workers.utilization
+
+Fraction of configured SQL Server worker threads currently running.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | Development |
+
 ### sqlserver.transaction.delay
 
 Time consumed in transaction delays.
@@ -897,6 +1333,16 @@ Time consumed in transaction delays.
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | ms | Sum | Double | Cumulative | false | Development |
 
+### sqlserver.transaction.longest_running_time
+
+Age in seconds of the longest currently-open transaction on the server.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
 ### sqlserver.transaction.mirror_write.rate
 
 Total number of mirror write transactions.
@@ -904,6 +1350,26 @@ Total number of mirror write transactions.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {transactions}/s | Gauge | Double | Development |
+
+### sqlserver.transaction.version_cleanup.rate
+
+Cumulative bytes cleaned from the tempdb version store.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Double | Cumulative | true | Development |
+
+### sqlserver.transaction.version_generation.rate
+
+Cumulative bytes of row versions written to the tempdb version store.
+
+This metric is only available when the receiver is configured to directly connect to SQL Server.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Double | Cumulative | true | Development |
 
 ## Default Events
 

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -475,7 +475,7 @@ This metric is only available when the receiver is configured to directly connec
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | db.namespace | The database name. | Any Str | Recommended | - |
-| member.kind | Role-membership member breakdown bucket. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
+| member.kind | Role-membership member breakdown bucket. `high_privilege` covers db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin. | Str: ``app_role``, ``cross_role``, ``high_privilege``, ``unique`` | Recommended | - |
 
 ### sqlserver.database.role.memberships.count
 

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -123,7 +123,116 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabasePageFileQuery(cfg.InstanceName))
 	}
 
+	if cfg.Metrics.SqlserverLockByModeCount.Enabled || cfg.Metrics.SqlserverLockByResourceCount.Enabled {
+		queries = append(queries, getSQLServerLockQuery(cfg.InstanceName))
+	}
+
+	if isThreadPoolQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerThreadPoolQuery(cfg.InstanceName))
+	}
+
+	if isTempDBQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerTempDBQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverTempdbFileSize.Enabled {
+		queries = append(queries, getSQLServerTempDBFileQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterAGQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterAGQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterReplicaQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterReplicaQuery(cfg.InstanceName))
+	}
+
+	if isFailoverClusterReplicaDatabaseQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerFailoverClusterReplicaDatabaseQuery(cfg.InstanceName))
+	}
+
+	if isDatabasePrincipalsQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerDatabasePrincipalsQuery(cfg.InstanceName))
+	}
+
+	if isDatabaseRoleMembershipQueryEnabled(&cfg.Metrics) {
+		queries = append(queries, getSQLServerDatabaseRoleMembershipQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverDatabaseRolePermissionRiskLevel.Enabled {
+		queries = append(queries, getSQLServerDatabaseRoleRiskLevelQuery(cfg.InstanceName))
+	}
+
+	if cfg.Metrics.SqlserverTransactionLongestRunningTime.Enabled {
+		queries = append(queries, getSQLServerLongestRunningTransactionQuery(cfg.InstanceName))
+	}
+
 	return queries
+}
+
+func isDatabasePrincipalsQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverDatabasePrincipalsCount.Enabled ||
+		metrics.SqlserverDatabasePrincipalsOld.Enabled ||
+		metrics.SqlserverDatabasePrincipalsOrphanedUsers.Enabled ||
+		metrics.SqlserverDatabasePrincipalsRecentlyCreated.Enabled
+}
+
+func isDatabaseRoleMembershipQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverDatabaseRoleMembersCount.Enabled ||
+		metrics.SqlserverDatabaseRoleMembershipsCount.Enabled ||
+		metrics.SqlserverDatabaseRoleRolesCount.Enabled
+}
+
+func isFailoverClusterAGQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterAgClusterType.Enabled ||
+		metrics.SqlserverFailoverClusterAgFailureConditionLevel.Enabled ||
+		metrics.SqlserverFailoverClusterAgHealthCheckTimeout.Enabled ||
+		metrics.SqlserverFailoverClusterAgRequiredSyncSecondaries.Enabled
+}
+
+func isFailoverClusterReplicaQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterReplicaRole.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaSynchronizationHealth.Enabled
+}
+
+func isFailoverClusterReplicaDatabaseQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverFailoverClusterReplicaDatabaseQueueSize.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaDatabaseRedoRate.Enabled
+}
+
+func isThreadPoolQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverThreadPoolWorkersCount.Enabled ||
+		metrics.SqlserverThreadPoolWorkersMax.Enabled ||
+		metrics.SqlserverThreadPoolWorkersUtilization.Enabled ||
+		metrics.SqlserverThreadPoolTasksCount.Enabled
+}
+
+func isTempDBQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+	return metrics.SqlserverTempdbAllocationWaitTimeTotal.Enabled ||
+		metrics.SqlserverTempdbContentionWaitersCount.Enabled ||
+		metrics.SqlserverTempdbDataFilesCount.Enabled ||
+		metrics.SqlserverTempdbSpaceUsage.Enabled
 }
 
 func setupLogQueries(cfg *Config) []string {
@@ -334,6 +443,9 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		metrics.SqlserverPageBufferCacheHitRatio.Enabled ||
 		metrics.SqlserverPageLookupRate.Enabled ||
 		metrics.SqlserverProcessesBlocked.Enabled ||
+		metrics.SqlserverFailoverClusterReplicaFlowControlTime.Enabled ||
+		metrics.SqlserverTransactionVersionCleanupRate.Enabled ||
+		metrics.SqlserverTransactionVersionGenerationRate.Enabled ||
 		metrics.SqlserverReplicaDataRate.Enabled ||
 		metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
 		metrics.SqlserverResourcePoolDiskOperations.Enabled ||

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -263,7 +263,7 @@ func TestSetupQueries(t *testing.T) {
 
 	metricsMetadata, ok := metadata["metrics"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, metricsMetadata, 78, "Every time metrics are added or removed, the function `setupQueries` must "+
+	require.Len(t, metricsMetadata, 109, "Every time metrics are added or removed, the function `setupQueries` must "+
 		"be modified to properly account for the change. Please update `setupQueries` and then, "+
 		"and only then, update the expected metric count here.")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config.go
@@ -529,6 +529,395 @@ func (ms *SqlserverDatabasePageFileSizeMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverDatabasePrincipalsCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.count metric.
+type SqlserverDatabasePrincipalsCountMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace   SqlserverDatabasePrincipalsCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType SqlserverDatabasePrincipalsCountMetricAttributeKey = "principal.type"
+)
+
+// SqlserverDatabasePrincipalsCountMetricConfig provides config for the sqlserver.database.principals.count metric.
+type SqlserverDatabasePrincipalsCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.count doesn't have an attribute %v, valid attributes: [db.namespace, principal.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsOldMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.old metric.
+type SqlserverDatabasePrincipalsOldMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsOldMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsOldMetricConfig provides config for the sqlserver.database.principals.old metric.
+type SqlserverDatabasePrincipalsOldMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsOldMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsOldMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsOldMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.old doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.orphaned_users metric.
+type SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsOrphanedUsersMetricConfig provides config for the sqlserver.database.principals.orphaned_users metric.
+type SqlserverDatabasePrincipalsOrphanedUsersMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.orphaned_users doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey specifies the key of an attribute for the sqlserver.database.principals.recently_created metric.
+type SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey string
+
+const (
+	SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig provides config for the sqlserver.database.principals.recently_created metric.
+type SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                         `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.database.principals.recently_created doesn't have an attribute %v, valid attributes: [db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleMembersCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.members.count metric.
+type SqlserverDatabaseRoleMembersCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace SqlserverDatabaseRoleMembersCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind  SqlserverDatabaseRoleMembersCountMetricAttributeKey = "member.kind"
+)
+
+// SqlserverDatabaseRoleMembersCountMetricConfig provides config for the sqlserver.database.role.members.count metric.
+type SqlserverDatabaseRoleMembersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleMembersCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleMembersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleMembersCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.members.count doesn't have an attribute %v, valid attributes: [db.namespace, member.kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleMembershipsCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.memberships.count metric.
+type SqlserverDatabaseRoleMembershipsCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace    SqlserverDatabaseRoleMembershipsCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind SqlserverDatabaseRoleMembershipsCountMetricAttributeKey = "membership.kind"
+)
+
+// SqlserverDatabaseRoleMembershipsCountMetricConfig provides config for the sqlserver.database.role.memberships.count metric.
+type SqlserverDatabaseRoleMembershipsCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleMembershipsCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleMembershipsCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.memberships.count doesn't have an attribute %v, valid attributes: [db.namespace, membership.kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.permission.risk_level metric.
+type SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole        SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey = "role"
+)
+
+// SqlserverDatabaseRolePermissionRiskLevelMetricConfig provides config for the sqlserver.database.role.permission.risk_level metric.
+type SqlserverDatabaseRolePermissionRiskLevelMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRolePermissionRiskLevelMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRolePermissionRiskLevelMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.permission.risk_level doesn't have an attribute %v, valid attributes: [db.namespace, role]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverDatabaseRoleRolesCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.role.roles.count metric.
+type SqlserverDatabaseRoleRolesCountMetricAttributeKey string
+
+const (
+	SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace SqlserverDatabaseRoleRolesCountMetricAttributeKey = "db.namespace"
+	SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState   SqlserverDatabaseRoleRolesCountMetricAttributeKey = "role.state"
+)
+
+// SqlserverDatabaseRoleRolesCountMetricConfig provides config for the sqlserver.database.role.roles.count metric.
+type SqlserverDatabaseRoleRolesCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverDatabaseRoleRolesCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverDatabaseRoleRolesCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverDatabaseRoleRolesCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState:
+		default:
+			return fmt.Errorf("metric sqlserver.database.role.roles.count doesn't have an attribute %v, valid attributes: [db.namespace, role.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey specifies the key of an attribute for the sqlserver.database.security.role_membership.count metric.
 type SqlserverDatabaseSecurityRoleMembershipCountMetricAttributeKey string
 
@@ -714,6 +1103,420 @@ func (ms *SqlserverDeadlockRateMetricConfig) Unmarshal(parser *confmap.Conf) err
 	return nil
 }
 
+// SqlserverFailoverClusterAgClusterTypeMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.cluster_type metric.
+type SqlserverFailoverClusterAgClusterTypeMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName        SqlserverFailoverClusterAgClusterTypeMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType SqlserverFailoverClusterAgClusterTypeMetricAttributeKey = "ag.cluster_type"
+)
+
+// SqlserverFailoverClusterAgClusterTypeMetricConfig provides config for the sqlserver.failover_cluster.ag.cluster_type metric.
+type SqlserverFailoverClusterAgClusterTypeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgClusterTypeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgClusterTypeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.cluster_type doesn't have an attribute %v, valid attributes: [ag.name, ag.cluster_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.failure_condition_level metric.
+type SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgFailureConditionLevelMetricConfig provides config for the sqlserver.failover_cluster.ag.failure_condition_level metric.
+type SqlserverFailoverClusterAgFailureConditionLevelMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.failure_condition_level doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.health_check_timeout metric.
+type SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig provides config for the sqlserver.failover_cluster.ag.health_check_timeout metric.
+type SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.health_check_timeout doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+type SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey = "ag.name"
+)
+
+// SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig provides config for the sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+type SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.ag.required_sync_secondaries doesn't have an attribute %v, valid attributes: [ag.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.database.queue_size metric.
+type SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace       SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "db.namespace"
+	SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind  SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey = "replica.queue_kind"
+)
+
+// SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig provides config for the sqlserver.failover_cluster.replica.database.queue_size metric.
+type SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.database.queue_size doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.database.redo.rate metric.
+type SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace       SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey = "db.namespace"
+)
+
+// SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig provides config for the sqlserver.failover_cluster.replica.database.redo.rate metric.
+type SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.database.redo.rate doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, db.namespace]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig provides config for the sqlserver.failover_cluster.replica.flow_control_time metric.
+type SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaRoleMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.role metric.
+type SqlserverFailoverClusterReplicaRoleMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole       SqlserverFailoverClusterReplicaRoleMetricAttributeKey = "replica.role"
+)
+
+// SqlserverFailoverClusterReplicaRoleMetricConfig provides config for the sqlserver.failover_cluster.replica.role metric.
+type SqlserverFailoverClusterReplicaRoleMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                  `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaRoleMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaRoleMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.role doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, replica.role]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey specifies the key of an attribute for the sqlserver.failover_cluster.replica.synchronization_health metric.
+type SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey string
+
+const (
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName            SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "ag.name"
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "replica.server_name"
+	SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey = "replica.sync_health"
+)
+
+// SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig provides config for the sqlserver.failover_cluster.replica.synchronization_health metric.
+type SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth:
+		default:
+			return fmt.Errorf("metric sqlserver.failover_cluster.replica.synchronization_health doesn't have an attribute %v, valid attributes: [ag.name, replica.server_name, replica.sync_health]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // SqlserverIndexSearchRateMetricConfig provides config for the sqlserver.index.search.rate metric.
 type SqlserverIndexSearchRateMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -879,6 +1682,104 @@ func (ms *SqlserverLatchWaitTimeTotalMetricConfig) Unmarshal(parser *confmap.Con
 	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverLockByModeCountMetricAttributeKey specifies the key of an attribute for the sqlserver.lock.by_mode.count metric.
+type SqlserverLockByModeCountMetricAttributeKey string
+
+const (
+	SqlserverLockByModeCountMetricAttributeKeyDbNamespace SqlserverLockByModeCountMetricAttributeKey = "db.namespace"
+	SqlserverLockByModeCountMetricAttributeKeyLockMode    SqlserverLockByModeCountMetricAttributeKey = "lock.mode"
+)
+
+// SqlserverLockByModeCountMetricConfig provides config for the sqlserver.lock.by_mode.count metric.
+type SqlserverLockByModeCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverLockByModeCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverLockByModeCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverLockByModeCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode:
+		default:
+			return fmt.Errorf("metric sqlserver.lock.by_mode.count doesn't have an attribute %v, valid attributes: [db.namespace, lock.mode]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverLockByResourceCountMetricAttributeKey specifies the key of an attribute for the sqlserver.lock.by_resource.count metric.
+type SqlserverLockByResourceCountMetricAttributeKey string
+
+const (
+	SqlserverLockByResourceCountMetricAttributeKeyDbNamespace  SqlserverLockByResourceCountMetricAttributeKey = "db.namespace"
+	SqlserverLockByResourceCountMetricAttributeKeyLockResource SqlserverLockByResourceCountMetricAttributeKey = "lock.resource"
+)
+
+// SqlserverLockByResourceCountMetricConfig provides config for the sqlserver.lock.by_resource.count metric.
+type SqlserverLockByResourceCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverLockByResourceCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverLockByResourceCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverLockByResourceCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource:
+		default:
+			return fmt.Errorf("metric sqlserver.lock.by_resource.count doesn't have an attribute %v, valid attributes: [db.namespace, lock.resource]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
 	return nil
 }
 
@@ -2065,6 +2966,327 @@ func (ms *SqlserverTableCountMetricConfig) Validate() error {
 	return nil
 }
 
+// SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.allocation.wait_time.total metric.
+type SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey string
+
+const (
+	SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey = "allocation.page_type"
+)
+
+// SqlserverTempdbAllocationWaitTimeTotalMetricConfig provides config for the sqlserver.tempdb.allocation.wait_time.total metric.
+type SqlserverTempdbAllocationWaitTimeTotalMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                                     `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbAllocationWaitTimeTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbAllocationWaitTimeTotalMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.allocation.wait_time.total doesn't have an attribute %v, valid attributes: [allocation.page_type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverTempdbContentionWaitersCountMetricConfig provides config for the sqlserver.tempdb.contention.waiters.count metric.
+type SqlserverTempdbContentionWaitersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTempdbContentionWaitersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTempdbDataFilesCountMetricConfig provides config for the sqlserver.tempdb.data_files.count metric.
+type SqlserverTempdbDataFilesCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTempdbDataFilesCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTempdbFileSizeMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.file.size metric.
+type SqlserverTempdbFileSizeMetricAttributeKey string
+
+const (
+	SqlserverTempdbFileSizeMetricAttributeKeyFileType     SqlserverTempdbFileSizeMetricAttributeKey = "file_type"
+	SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID SqlserverTempdbFileSizeMetricAttributeKey = "tempdb.file.id"
+)
+
+// SqlserverTempdbFileSizeMetricConfig provides config for the sqlserver.tempdb.file.size metric.
+type SqlserverTempdbFileSizeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                      `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbFileSizeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbFileSizeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbFileSizeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.file.size doesn't have an attribute %v, valid attributes: [file_type, tempdb.file.id]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverTempdbSpaceUsageMetricAttributeKey specifies the key of an attribute for the sqlserver.tempdb.space.usage metric.
+type SqlserverTempdbSpaceUsageMetricAttributeKey string
+
+const (
+	SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind SqlserverTempdbSpaceUsageMetricAttributeKey = "tempdb.space_kind"
+)
+
+// SqlserverTempdbSpaceUsageMetricConfig provides config for the sqlserver.tempdb.space.usage metric.
+type SqlserverTempdbSpaceUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverTempdbSpaceUsageMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverTempdbSpaceUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverTempdbSpaceUsageMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind:
+		default:
+			return fmt.Errorf("metric sqlserver.tempdb.space.usage doesn't have an attribute %v, valid attributes: [tempdb.space_kind]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolTasksCountMetricAttributeKey specifies the key of an attribute for the sqlserver.thread_pool.tasks.count metric.
+type SqlserverThreadPoolTasksCountMetricAttributeKey string
+
+const (
+	SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState SqlserverThreadPoolTasksCountMetricAttributeKey = "task.state"
+)
+
+// SqlserverThreadPoolTasksCountMetricConfig provides config for the sqlserver.thread_pool.tasks.count metric.
+type SqlserverThreadPoolTasksCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                            `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverThreadPoolTasksCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverThreadPoolTasksCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverThreadPoolTasksCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState:
+		default:
+			return fmt.Errorf("metric sqlserver.thread_pool.tasks.count doesn't have an attribute %v, valid attributes: [task.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolWorkersCountMetricAttributeKey specifies the key of an attribute for the sqlserver.thread_pool.workers.count metric.
+type SqlserverThreadPoolWorkersCountMetricAttributeKey string
+
+const (
+	SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState SqlserverThreadPoolWorkersCountMetricAttributeKey = "worker.state"
+)
+
+// SqlserverThreadPoolWorkersCountMetricConfig provides config for the sqlserver.thread_pool.workers.count metric.
+type SqlserverThreadPoolWorkersCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                              `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []SqlserverThreadPoolWorkersCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *SqlserverThreadPoolWorkersCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *SqlserverThreadPoolWorkersCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState:
+		default:
+			return fmt.Errorf("metric sqlserver.thread_pool.workers.count doesn't have an attribute %v, valid attributes: [worker.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// SqlserverThreadPoolWorkersMaxMetricConfig provides config for the sqlserver.thread_pool.workers.max metric.
+type SqlserverThreadPoolWorkersMaxMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverThreadPoolWorkersMaxMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverThreadPoolWorkersUtilizationMetricConfig provides config for the sqlserver.thread_pool.workers.utilization metric.
+type SqlserverThreadPoolWorkersUtilizationMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverThreadPoolWorkersUtilizationMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // SqlserverTransactionDelayMetricConfig provides config for the sqlserver.transaction.delay metric.
 type SqlserverTransactionDelayMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -2072,6 +3294,26 @@ type SqlserverTransactionDelayMetricConfig struct {
 }
 
 func (ms *SqlserverTransactionDelayMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionLongestRunningTimeMetricConfig provides config for the sqlserver.transaction.longest_running_time metric.
+type SqlserverTransactionLongestRunningTimeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionLongestRunningTimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -2112,6 +3354,46 @@ type SqlserverTransactionRateMetricConfig struct {
 }
 
 func (ms *SqlserverTransactionRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionVersionCleanupRateMetricConfig provides config for the sqlserver.transaction.version_cleanup.rate metric.
+type SqlserverTransactionVersionCleanupRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionVersionCleanupRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// SqlserverTransactionVersionGenerationRateMetricConfig provides config for the sqlserver.transaction.version_generation.rate metric.
+type SqlserverTransactionVersionGenerationRateMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *SqlserverTransactionVersionGenerationRateMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -2287,84 +3569,115 @@ func (ms *SqlserverUserConnectionCountMetricConfig) Unmarshal(parser *confmap.Co
 
 // MetricsConfig provides config for sqlserver metrics.
 type MetricsConfig struct {
-	SqlserverAttentionRate                       SqlserverAttentionRateMetricConfig                       `mapstructure:"sqlserver.attention.rate"`
-	SqlserverBatchCompilationUtilization         SqlserverBatchCompilationUtilizationMetricConfig         `mapstructure:"sqlserver.batch.compilation.utilization"`
-	SqlserverBatchPageSplitUtilization           SqlserverBatchPageSplitUtilizationMetricConfig           `mapstructure:"sqlserver.batch.page_split.utilization"`
-	SqlserverBatchRequestRate                    SqlserverBatchRequestRateMetricConfig                    `mapstructure:"sqlserver.batch.request.rate"`
-	SqlserverBatchSQLCompilationRate             SqlserverBatchSQLCompilationRateMetricConfig             `mapstructure:"sqlserver.batch.sql_compilation.rate"`
-	SqlserverBatchSQLRecompilationRate           SqlserverBatchSQLRecompilationRateMetricConfig           `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
-	SqlserverComputerUptime                      SqlserverComputerUptimeMetricConfig                      `mapstructure:"sqlserver.computer.uptime"`
-	SqlserverCPUCount                            SqlserverCPUCountMetricConfig                            `mapstructure:"sqlserver.cpu.count"`
-	SqlserverDatabaseBackupOrRestoreRate         SqlserverDatabaseBackupOrRestoreRateMetricConfig         `mapstructure:"sqlserver.database.backup_or_restore.rate"`
-	SqlserverDatabaseCount                       SqlserverDatabaseCountMetricConfig                       `mapstructure:"sqlserver.database.count"`
-	SqlserverDatabaseExecutionErrors             SqlserverDatabaseExecutionErrorsMetricConfig             `mapstructure:"sqlserver.database.execution.errors"`
-	SqlserverDatabaseFileSize                    SqlserverDatabaseFileSizeMetricConfig                    `mapstructure:"sqlserver.database.file.size"`
-	SqlserverDatabaseFullScanRate                SqlserverDatabaseFullScanRateMetricConfig                `mapstructure:"sqlserver.database.full_scan.rate"`
-	SqlserverDatabaseIo                          SqlserverDatabaseIoMetricConfig                          `mapstructure:"sqlserver.database.io"`
-	SqlserverDatabaseLatency                     SqlserverDatabaseLatencyMetricConfig                     `mapstructure:"sqlserver.database.latency"`
-	SqlserverDatabaseOperations                  SqlserverDatabaseOperationsMetricConfig                  `mapstructure:"sqlserver.database.operations"`
-	SqlserverDatabasePageFileSize                SqlserverDatabasePageFileSizeMetricConfig                `mapstructure:"sqlserver.database.page_file.size"`
-	SqlserverDatabaseSecurityRoleMembershipCount SqlserverDatabaseSecurityRoleMembershipCountMetricConfig `mapstructure:"sqlserver.database.security.role_membership.count"`
-	SqlserverDatabaseTempdbSpace                 SqlserverDatabaseTempdbSpaceMetricConfig                 `mapstructure:"sqlserver.database.tempdb.space"`
-	SqlserverDatabaseTempdbVersionStoreSize      SqlserverDatabaseTempdbVersionStoreSizeMetricConfig      `mapstructure:"sqlserver.database.tempdb.version_store.size"`
-	SqlserverDatabaseTransactionsActive          SqlserverDatabaseTransactionsActiveMetricConfig          `mapstructure:"sqlserver.database.transactions.active"`
-	SqlserverDeadlockRate                        SqlserverDeadlockRateMetricConfig                        `mapstructure:"sqlserver.deadlock.rate"`
-	SqlserverIndexSearchRate                     SqlserverIndexSearchRateMetricConfig                     `mapstructure:"sqlserver.index.search.rate"`
-	SqlserverKillConnectionErrorRate             SqlserverKillConnectionErrorRateMetricConfig             `mapstructure:"sqlserver.kill_connection.error.rate"`
-	SqlserverLatchSuperlatchCount                SqlserverLatchSuperlatchCountMetricConfig                `mapstructure:"sqlserver.latch.superlatch.count"`
-	SqlserverLatchSuperlatchTransitionRate       SqlserverLatchSuperlatchTransitionRateMetricConfig       `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
-	SqlserverLatchWaitRate                       SqlserverLatchWaitRateMetricConfig                       `mapstructure:"sqlserver.latch.wait.rate"`
-	SqlserverLatchWaitTimeAvg                    SqlserverLatchWaitTimeAvgMetricConfig                    `mapstructure:"sqlserver.latch.wait_time.avg"`
-	SqlserverLatchWaitTimeTotal                  SqlserverLatchWaitTimeTotalMetricConfig                  `mapstructure:"sqlserver.latch.wait_time.total"`
-	SqlserverLockTimeoutRate                     SqlserverLockTimeoutRateMetricConfig                     `mapstructure:"sqlserver.lock.timeout.rate"`
-	SqlserverLockWaitCount                       SqlserverLockWaitCountMetricConfig                       `mapstructure:"sqlserver.lock.wait.count"`
-	SqlserverLockWaitRate                        SqlserverLockWaitRateMetricConfig                        `mapstructure:"sqlserver.lock.wait.rate"`
-	SqlserverLockWaitTimeAvg                     SqlserverLockWaitTimeAvgMetricConfig                     `mapstructure:"sqlserver.lock.wait_time.avg"`
-	SqlserverLoginRate                           SqlserverLoginRateMetricConfig                           `mapstructure:"sqlserver.login.rate"`
-	SqlserverLogoutRate                          SqlserverLogoutRateMetricConfig                          `mapstructure:"sqlserver.logout.rate"`
-	SqlserverMemoryArea                          SqlserverMemoryAreaMetricConfig                          `mapstructure:"sqlserver.memory.area"`
-	SqlserverMemoryCacheObjectCount              SqlserverMemoryCacheObjectCountMetricConfig              `mapstructure:"sqlserver.memory.cache.object.count"`
-	SqlserverMemoryGrantsPendingCount            SqlserverMemoryGrantsPendingCountMetricConfig            `mapstructure:"sqlserver.memory.grants.pending.count"`
-	SqlserverMemoryPageCount                     SqlserverMemoryPageCountMetricConfig                     `mapstructure:"sqlserver.memory.page.count"`
-	SqlserverMemoryTarget                        SqlserverMemoryTargetMetricConfig                        `mapstructure:"sqlserver.memory.target"`
-	SqlserverMemoryUsage                         SqlserverMemoryUsageMetricConfig                         `mapstructure:"sqlserver.memory.usage"`
-	SqlserverOsDiskSize                          SqlserverOsDiskSizeMetricConfig                          `mapstructure:"sqlserver.os.disk.size"`
-	SqlserverOsMemoryUsage                       SqlserverOsMemoryUsageMetricConfig                       `mapstructure:"sqlserver.os.memory.usage"`
-	SqlserverOsMemoryUtilization                 SqlserverOsMemoryUtilizationMetricConfig                 `mapstructure:"sqlserver.os.memory.utilization"`
-	SqlserverOsSchedulerRunnableTasksCount       SqlserverOsSchedulerRunnableTasksCountMetricConfig       `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
-	SqlserverOsWaitDuration                      SqlserverOsWaitDurationMetricConfig                      `mapstructure:"sqlserver.os.wait.duration"`
-	SqlserverOsWaitTasksCount                    SqlserverOsWaitTasksCountMetricConfig                    `mapstructure:"sqlserver.os.wait.tasks.count"`
-	SqlserverPageBufferCacheFreeListStallsRate   SqlserverPageBufferCacheFreeListStallsRateMetricConfig   `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
-	SqlserverPageBufferCacheHitRatio             SqlserverPageBufferCacheHitRatioMetricConfig             `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
-	SqlserverPageCheckpointFlushRate             SqlserverPageCheckpointFlushRateMetricConfig             `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
-	SqlserverPageLazyWriteRate                   SqlserverPageLazyWriteRateMetricConfig                   `mapstructure:"sqlserver.page.lazy_write.rate"`
-	SqlserverPageLifeExpectancy                  SqlserverPageLifeExpectancyMetricConfig                  `mapstructure:"sqlserver.page.life_expectancy"`
-	SqlserverPageLookupRate                      SqlserverPageLookupRateMetricConfig                      `mapstructure:"sqlserver.page.lookup.rate"`
-	SqlserverPageOperationRate                   SqlserverPageOperationRateMetricConfig                   `mapstructure:"sqlserver.page.operation.rate"`
-	SqlserverPageSplitRate                       SqlserverPageSplitRateMetricConfig                       `mapstructure:"sqlserver.page.split.rate"`
-	SqlserverParameterizationRate                SqlserverParameterizationRateMetricConfig                `mapstructure:"sqlserver.parameterization.rate"`
-	SqlserverPlanExecutionRate                   SqlserverPlanExecutionRateMetricConfig                   `mapstructure:"sqlserver.plan.execution.rate"`
-	SqlserverProcessCount                        SqlserverProcessCountMetricConfig                        `mapstructure:"sqlserver.process.count"`
-	SqlserverProcessesBlocked                    SqlserverProcessesBlockedMetricConfig                    `mapstructure:"sqlserver.processes.blocked"`
-	SqlserverRecompilationRatio                  SqlserverRecompilationRatioMetricConfig                  `mapstructure:"sqlserver.recompilation.ratio"`
-	SqlserverReplicaDataRate                     SqlserverReplicaDataRateMetricConfig                     `mapstructure:"sqlserver.replica.data.rate"`
-	SqlserverResourcePoolDiskOperations          SqlserverResourcePoolDiskOperationsMetricConfig          `mapstructure:"sqlserver.resource_pool.disk.operations"`
-	SqlserverResourcePoolDiskThrottledReadRate   SqlserverResourcePoolDiskThrottledReadRateMetricConfig   `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
-	SqlserverResourcePoolDiskThrottledWriteRate  SqlserverResourcePoolDiskThrottledWriteRateMetricConfig  `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
-	SqlserverServerSecurityPrincipalCount        SqlserverServerSecurityPrincipalCountMetricConfig        `mapstructure:"sqlserver.server.security.principal.count"`
-	SqlserverServerSecurityRoleMembershipCount   SqlserverServerSecurityRoleMembershipCountMetricConfig   `mapstructure:"sqlserver.server.security.role_membership.count"`
-	SqlserverTableCount                          SqlserverTableCountMetricConfig                          `mapstructure:"sqlserver.table.count"`
-	SqlserverTransactionDelay                    SqlserverTransactionDelayMetricConfig                    `mapstructure:"sqlserver.transaction.delay"`
-	SqlserverTransactionMirrorWriteRate          SqlserverTransactionMirrorWriteRateMetricConfig          `mapstructure:"sqlserver.transaction.mirror_write.rate"`
-	SqlserverTransactionRate                     SqlserverTransactionRateMetricConfig                     `mapstructure:"sqlserver.transaction.rate"`
-	SqlserverTransactionWriteRate                SqlserverTransactionWriteRateMetricConfig                `mapstructure:"sqlserver.transaction.write.rate"`
-	SqlserverTransactionLogFlushDataRate         SqlserverTransactionLogFlushDataRateMetricConfig         `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
-	SqlserverTransactionLogFlushRate             SqlserverTransactionLogFlushRateMetricConfig             `mapstructure:"sqlserver.transaction_log.flush.rate"`
-	SqlserverTransactionLogFlushWaitRate         SqlserverTransactionLogFlushWaitRateMetricConfig         `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
-	SqlserverTransactionLogGrowthCount           SqlserverTransactionLogGrowthCountMetricConfig           `mapstructure:"sqlserver.transaction_log.growth.count"`
-	SqlserverTransactionLogShrinkCount           SqlserverTransactionLogShrinkCountMetricConfig           `mapstructure:"sqlserver.transaction_log.shrink.count"`
-	SqlserverTransactionLogUsage                 SqlserverTransactionLogUsageMetricConfig                 `mapstructure:"sqlserver.transaction_log.usage"`
-	SqlserverUserConnectionCount                 SqlserverUserConnectionCountMetricConfig                 `mapstructure:"sqlserver.user.connection.count"`
+	SqlserverAttentionRate                               SqlserverAttentionRateMetricConfig                               `mapstructure:"sqlserver.attention.rate"`
+	SqlserverBatchCompilationUtilization                 SqlserverBatchCompilationUtilizationMetricConfig                 `mapstructure:"sqlserver.batch.compilation.utilization"`
+	SqlserverBatchPageSplitUtilization                   SqlserverBatchPageSplitUtilizationMetricConfig                   `mapstructure:"sqlserver.batch.page_split.utilization"`
+	SqlserverBatchRequestRate                            SqlserverBatchRequestRateMetricConfig                            `mapstructure:"sqlserver.batch.request.rate"`
+	SqlserverBatchSQLCompilationRate                     SqlserverBatchSQLCompilationRateMetricConfig                     `mapstructure:"sqlserver.batch.sql_compilation.rate"`
+	SqlserverBatchSQLRecompilationRate                   SqlserverBatchSQLRecompilationRateMetricConfig                   `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
+	SqlserverComputerUptime                              SqlserverComputerUptimeMetricConfig                              `mapstructure:"sqlserver.computer.uptime"`
+	SqlserverCPUCount                                    SqlserverCPUCountMetricConfig                                    `mapstructure:"sqlserver.cpu.count"`
+	SqlserverDatabaseBackupOrRestoreRate                 SqlserverDatabaseBackupOrRestoreRateMetricConfig                 `mapstructure:"sqlserver.database.backup_or_restore.rate"`
+	SqlserverDatabaseCount                               SqlserverDatabaseCountMetricConfig                               `mapstructure:"sqlserver.database.count"`
+	SqlserverDatabaseExecutionErrors                     SqlserverDatabaseExecutionErrorsMetricConfig                     `mapstructure:"sqlserver.database.execution.errors"`
+	SqlserverDatabaseFileSize                            SqlserverDatabaseFileSizeMetricConfig                            `mapstructure:"sqlserver.database.file.size"`
+	SqlserverDatabaseFullScanRate                        SqlserverDatabaseFullScanRateMetricConfig                        `mapstructure:"sqlserver.database.full_scan.rate"`
+	SqlserverDatabaseIo                                  SqlserverDatabaseIoMetricConfig                                  `mapstructure:"sqlserver.database.io"`
+	SqlserverDatabaseLatency                             SqlserverDatabaseLatencyMetricConfig                             `mapstructure:"sqlserver.database.latency"`
+	SqlserverDatabaseOperations                          SqlserverDatabaseOperationsMetricConfig                          `mapstructure:"sqlserver.database.operations"`
+	SqlserverDatabasePageFileSize                        SqlserverDatabasePageFileSizeMetricConfig                        `mapstructure:"sqlserver.database.page_file.size"`
+	SqlserverDatabasePrincipalsCount                     SqlserverDatabasePrincipalsCountMetricConfig                     `mapstructure:"sqlserver.database.principals.count"`
+	SqlserverDatabasePrincipalsOld                       SqlserverDatabasePrincipalsOldMetricConfig                       `mapstructure:"sqlserver.database.principals.old"`
+	SqlserverDatabasePrincipalsOrphanedUsers             SqlserverDatabasePrincipalsOrphanedUsersMetricConfig             `mapstructure:"sqlserver.database.principals.orphaned_users"`
+	SqlserverDatabasePrincipalsRecentlyCreated           SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig           `mapstructure:"sqlserver.database.principals.recently_created"`
+	SqlserverDatabaseRoleMembersCount                    SqlserverDatabaseRoleMembersCountMetricConfig                    `mapstructure:"sqlserver.database.role.members.count"`
+	SqlserverDatabaseRoleMembershipsCount                SqlserverDatabaseRoleMembershipsCountMetricConfig                `mapstructure:"sqlserver.database.role.memberships.count"`
+	SqlserverDatabaseRolePermissionRiskLevel             SqlserverDatabaseRolePermissionRiskLevelMetricConfig             `mapstructure:"sqlserver.database.role.permission.risk_level"`
+	SqlserverDatabaseRoleRolesCount                      SqlserverDatabaseRoleRolesCountMetricConfig                      `mapstructure:"sqlserver.database.role.roles.count"`
+	SqlserverDatabaseSecurityRoleMembershipCount         SqlserverDatabaseSecurityRoleMembershipCountMetricConfig         `mapstructure:"sqlserver.database.security.role_membership.count"`
+	SqlserverDatabaseTempdbSpace                         SqlserverDatabaseTempdbSpaceMetricConfig                         `mapstructure:"sqlserver.database.tempdb.space"`
+	SqlserverDatabaseTempdbVersionStoreSize              SqlserverDatabaseTempdbVersionStoreSizeMetricConfig              `mapstructure:"sqlserver.database.tempdb.version_store.size"`
+	SqlserverDatabaseTransactionsActive                  SqlserverDatabaseTransactionsActiveMetricConfig                  `mapstructure:"sqlserver.database.transactions.active"`
+	SqlserverDeadlockRate                                SqlserverDeadlockRateMetricConfig                                `mapstructure:"sqlserver.deadlock.rate"`
+	SqlserverFailoverClusterAgClusterType                SqlserverFailoverClusterAgClusterTypeMetricConfig                `mapstructure:"sqlserver.failover_cluster.ag.cluster_type"`
+	SqlserverFailoverClusterAgFailureConditionLevel      SqlserverFailoverClusterAgFailureConditionLevelMetricConfig      `mapstructure:"sqlserver.failover_cluster.ag.failure_condition_level"`
+	SqlserverFailoverClusterAgHealthCheckTimeout         SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig         `mapstructure:"sqlserver.failover_cluster.ag.health_check_timeout"`
+	SqlserverFailoverClusterAgRequiredSyncSecondaries    SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig    `mapstructure:"sqlserver.failover_cluster.ag.required_sync_secondaries"`
+	SqlserverFailoverClusterReplicaDatabaseQueueSize     SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig     `mapstructure:"sqlserver.failover_cluster.replica.database.queue_size"`
+	SqlserverFailoverClusterReplicaDatabaseRedoRate      SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig      `mapstructure:"sqlserver.failover_cluster.replica.database.redo.rate"`
+	SqlserverFailoverClusterReplicaFlowControlTime       SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig       `mapstructure:"sqlserver.failover_cluster.replica.flow_control_time"`
+	SqlserverFailoverClusterReplicaRole                  SqlserverFailoverClusterReplicaRoleMetricConfig                  `mapstructure:"sqlserver.failover_cluster.replica.role"`
+	SqlserverFailoverClusterReplicaSynchronizationHealth SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig `mapstructure:"sqlserver.failover_cluster.replica.synchronization_health"`
+	SqlserverIndexSearchRate                             SqlserverIndexSearchRateMetricConfig                             `mapstructure:"sqlserver.index.search.rate"`
+	SqlserverKillConnectionErrorRate                     SqlserverKillConnectionErrorRateMetricConfig                     `mapstructure:"sqlserver.kill_connection.error.rate"`
+	SqlserverLatchSuperlatchCount                        SqlserverLatchSuperlatchCountMetricConfig                        `mapstructure:"sqlserver.latch.superlatch.count"`
+	SqlserverLatchSuperlatchTransitionRate               SqlserverLatchSuperlatchTransitionRateMetricConfig               `mapstructure:"sqlserver.latch.superlatch.transition.rate"`
+	SqlserverLatchWaitRate                               SqlserverLatchWaitRateMetricConfig                               `mapstructure:"sqlserver.latch.wait.rate"`
+	SqlserverLatchWaitTimeAvg                            SqlserverLatchWaitTimeAvgMetricConfig                            `mapstructure:"sqlserver.latch.wait_time.avg"`
+	SqlserverLatchWaitTimeTotal                          SqlserverLatchWaitTimeTotalMetricConfig                          `mapstructure:"sqlserver.latch.wait_time.total"`
+	SqlserverLockByModeCount                             SqlserverLockByModeCountMetricConfig                             `mapstructure:"sqlserver.lock.by_mode.count"`
+	SqlserverLockByResourceCount                         SqlserverLockByResourceCountMetricConfig                         `mapstructure:"sqlserver.lock.by_resource.count"`
+	SqlserverLockTimeoutRate                             SqlserverLockTimeoutRateMetricConfig                             `mapstructure:"sqlserver.lock.timeout.rate"`
+	SqlserverLockWaitCount                               SqlserverLockWaitCountMetricConfig                               `mapstructure:"sqlserver.lock.wait.count"`
+	SqlserverLockWaitRate                                SqlserverLockWaitRateMetricConfig                                `mapstructure:"sqlserver.lock.wait.rate"`
+	SqlserverLockWaitTimeAvg                             SqlserverLockWaitTimeAvgMetricConfig                             `mapstructure:"sqlserver.lock.wait_time.avg"`
+	SqlserverLoginRate                                   SqlserverLoginRateMetricConfig                                   `mapstructure:"sqlserver.login.rate"`
+	SqlserverLogoutRate                                  SqlserverLogoutRateMetricConfig                                  `mapstructure:"sqlserver.logout.rate"`
+	SqlserverMemoryArea                                  SqlserverMemoryAreaMetricConfig                                  `mapstructure:"sqlserver.memory.area"`
+	SqlserverMemoryCacheObjectCount                      SqlserverMemoryCacheObjectCountMetricConfig                      `mapstructure:"sqlserver.memory.cache.object.count"`
+	SqlserverMemoryGrantsPendingCount                    SqlserverMemoryGrantsPendingCountMetricConfig                    `mapstructure:"sqlserver.memory.grants.pending.count"`
+	SqlserverMemoryPageCount                             SqlserverMemoryPageCountMetricConfig                             `mapstructure:"sqlserver.memory.page.count"`
+	SqlserverMemoryTarget                                SqlserverMemoryTargetMetricConfig                                `mapstructure:"sqlserver.memory.target"`
+	SqlserverMemoryUsage                                 SqlserverMemoryUsageMetricConfig                                 `mapstructure:"sqlserver.memory.usage"`
+	SqlserverOsDiskSize                                  SqlserverOsDiskSizeMetricConfig                                  `mapstructure:"sqlserver.os.disk.size"`
+	SqlserverOsMemoryUsage                               SqlserverOsMemoryUsageMetricConfig                               `mapstructure:"sqlserver.os.memory.usage"`
+	SqlserverOsMemoryUtilization                         SqlserverOsMemoryUtilizationMetricConfig                         `mapstructure:"sqlserver.os.memory.utilization"`
+	SqlserverOsSchedulerRunnableTasksCount               SqlserverOsSchedulerRunnableTasksCountMetricConfig               `mapstructure:"sqlserver.os.scheduler.runnable_tasks.count"`
+	SqlserverOsWaitDuration                              SqlserverOsWaitDurationMetricConfig                              `mapstructure:"sqlserver.os.wait.duration"`
+	SqlserverOsWaitTasksCount                            SqlserverOsWaitTasksCountMetricConfig                            `mapstructure:"sqlserver.os.wait.tasks.count"`
+	SqlserverPageBufferCacheFreeListStallsRate           SqlserverPageBufferCacheFreeListStallsRateMetricConfig           `mapstructure:"sqlserver.page.buffer_cache.free_list.stalls.rate"`
+	SqlserverPageBufferCacheHitRatio                     SqlserverPageBufferCacheHitRatioMetricConfig                     `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
+	SqlserverPageCheckpointFlushRate                     SqlserverPageCheckpointFlushRateMetricConfig                     `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
+	SqlserverPageLazyWriteRate                           SqlserverPageLazyWriteRateMetricConfig                           `mapstructure:"sqlserver.page.lazy_write.rate"`
+	SqlserverPageLifeExpectancy                          SqlserverPageLifeExpectancyMetricConfig                          `mapstructure:"sqlserver.page.life_expectancy"`
+	SqlserverPageLookupRate                              SqlserverPageLookupRateMetricConfig                              `mapstructure:"sqlserver.page.lookup.rate"`
+	SqlserverPageOperationRate                           SqlserverPageOperationRateMetricConfig                           `mapstructure:"sqlserver.page.operation.rate"`
+	SqlserverPageSplitRate                               SqlserverPageSplitRateMetricConfig                               `mapstructure:"sqlserver.page.split.rate"`
+	SqlserverParameterizationRate                        SqlserverParameterizationRateMetricConfig                        `mapstructure:"sqlserver.parameterization.rate"`
+	SqlserverPlanExecutionRate                           SqlserverPlanExecutionRateMetricConfig                           `mapstructure:"sqlserver.plan.execution.rate"`
+	SqlserverProcessCount                                SqlserverProcessCountMetricConfig                                `mapstructure:"sqlserver.process.count"`
+	SqlserverProcessesBlocked                            SqlserverProcessesBlockedMetricConfig                            `mapstructure:"sqlserver.processes.blocked"`
+	SqlserverRecompilationRatio                          SqlserverRecompilationRatioMetricConfig                          `mapstructure:"sqlserver.recompilation.ratio"`
+	SqlserverReplicaDataRate                             SqlserverReplicaDataRateMetricConfig                             `mapstructure:"sqlserver.replica.data.rate"`
+	SqlserverResourcePoolDiskOperations                  SqlserverResourcePoolDiskOperationsMetricConfig                  `mapstructure:"sqlserver.resource_pool.disk.operations"`
+	SqlserverResourcePoolDiskThrottledReadRate           SqlserverResourcePoolDiskThrottledReadRateMetricConfig           `mapstructure:"sqlserver.resource_pool.disk.throttled.read.rate"`
+	SqlserverResourcePoolDiskThrottledWriteRate          SqlserverResourcePoolDiskThrottledWriteRateMetricConfig          `mapstructure:"sqlserver.resource_pool.disk.throttled.write.rate"`
+	SqlserverServerSecurityPrincipalCount                SqlserverServerSecurityPrincipalCountMetricConfig                `mapstructure:"sqlserver.server.security.principal.count"`
+	SqlserverServerSecurityRoleMembershipCount           SqlserverServerSecurityRoleMembershipCountMetricConfig           `mapstructure:"sqlserver.server.security.role_membership.count"`
+	SqlserverTableCount                                  SqlserverTableCountMetricConfig                                  `mapstructure:"sqlserver.table.count"`
+	SqlserverTempdbAllocationWaitTimeTotal               SqlserverTempdbAllocationWaitTimeTotalMetricConfig               `mapstructure:"sqlserver.tempdb.allocation.wait_time.total"`
+	SqlserverTempdbContentionWaitersCount                SqlserverTempdbContentionWaitersCountMetricConfig                `mapstructure:"sqlserver.tempdb.contention.waiters.count"`
+	SqlserverTempdbDataFilesCount                        SqlserverTempdbDataFilesCountMetricConfig                        `mapstructure:"sqlserver.tempdb.data_files.count"`
+	SqlserverTempdbFileSize                              SqlserverTempdbFileSizeMetricConfig                              `mapstructure:"sqlserver.tempdb.file.size"`
+	SqlserverTempdbSpaceUsage                            SqlserverTempdbSpaceUsageMetricConfig                            `mapstructure:"sqlserver.tempdb.space.usage"`
+	SqlserverThreadPoolTasksCount                        SqlserverThreadPoolTasksCountMetricConfig                        `mapstructure:"sqlserver.thread_pool.tasks.count"`
+	SqlserverThreadPoolWorkersCount                      SqlserverThreadPoolWorkersCountMetricConfig                      `mapstructure:"sqlserver.thread_pool.workers.count"`
+	SqlserverThreadPoolWorkersMax                        SqlserverThreadPoolWorkersMaxMetricConfig                        `mapstructure:"sqlserver.thread_pool.workers.max"`
+	SqlserverThreadPoolWorkersUtilization                SqlserverThreadPoolWorkersUtilizationMetricConfig                `mapstructure:"sqlserver.thread_pool.workers.utilization"`
+	SqlserverTransactionDelay                            SqlserverTransactionDelayMetricConfig                            `mapstructure:"sqlserver.transaction.delay"`
+	SqlserverTransactionLongestRunningTime               SqlserverTransactionLongestRunningTimeMetricConfig               `mapstructure:"sqlserver.transaction.longest_running_time"`
+	SqlserverTransactionMirrorWriteRate                  SqlserverTransactionMirrorWriteRateMetricConfig                  `mapstructure:"sqlserver.transaction.mirror_write.rate"`
+	SqlserverTransactionRate                             SqlserverTransactionRateMetricConfig                             `mapstructure:"sqlserver.transaction.rate"`
+	SqlserverTransactionVersionCleanupRate               SqlserverTransactionVersionCleanupRateMetricConfig               `mapstructure:"sqlserver.transaction.version_cleanup.rate"`
+	SqlserverTransactionVersionGenerationRate            SqlserverTransactionVersionGenerationRateMetricConfig            `mapstructure:"sqlserver.transaction.version_generation.rate"`
+	SqlserverTransactionWriteRate                        SqlserverTransactionWriteRateMetricConfig                        `mapstructure:"sqlserver.transaction.write.rate"`
+	SqlserverTransactionLogFlushDataRate                 SqlserverTransactionLogFlushDataRateMetricConfig                 `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
+	SqlserverTransactionLogFlushRate                     SqlserverTransactionLogFlushRateMetricConfig                     `mapstructure:"sqlserver.transaction_log.flush.rate"`
+	SqlserverTransactionLogFlushWaitRate                 SqlserverTransactionLogFlushWaitRateMetricConfig                 `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
+	SqlserverTransactionLogGrowthCount                   SqlserverTransactionLogGrowthCountMetricConfig                   `mapstructure:"sqlserver.transaction_log.growth.count"`
+	SqlserverTransactionLogShrinkCount                   SqlserverTransactionLogShrinkCountMetricConfig                   `mapstructure:"sqlserver.transaction_log.shrink.count"`
+	SqlserverTransactionLogUsage                         SqlserverTransactionLogUsageMetricConfig                         `mapstructure:"sqlserver.transaction_log.usage"`
+	SqlserverUserConnectionCount                         SqlserverUserConnectionCountMetricConfig                         `mapstructure:"sqlserver.user.connection.count"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -2432,6 +3745,46 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 		},
+		SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+		},
+		SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+		},
+		SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+		},
+		SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+		},
+		SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+		},
+		SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+		},
 		SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
@@ -2452,6 +3805,49 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 			Enabled: false,
+		},
+		SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+		},
+		SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+		},
+		SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+		},
+		SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+		},
+		SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+			Enabled: false,
+		},
+		SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+		},
+		SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 		},
 		SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 			Enabled: false,
@@ -2475,6 +3871,16 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 			Enabled: false,
+		},
+		SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+		},
+		SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 		},
 		SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 			Enabled: false,
@@ -2620,7 +4026,47 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 		},
+		SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+		},
+		SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+		},
+		SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+		},
+		SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+		},
+		SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+		},
+		SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+			Enabled: false,
+		},
+		SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+			Enabled: false,
+		},
 		SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 			Enabled: false,
 		},
 		SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
@@ -2628,6 +4074,12 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
 			Enabled: true,
+		},
+		SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+			Enabled: false,
+		},
+		SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
+			Enabled: false,
 		},
 		SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
 			Enabled: true,

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config_test.go
@@ -90,6 +90,46 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 					},
+					SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+					},
+					SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+					},
+					SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+					},
+					SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+					},
+					SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -110,6 +150,49 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: true,
+					},
+					SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+					},
+					SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+					},
+					SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+					},
+					SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+						Enabled: true,
+					},
+					SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+					},
+					SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 						Enabled: true,
@@ -133,6 +216,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 						Enabled: true,
+					},
+					SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+					},
+					SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 					},
 					SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 						Enabled: true,
@@ -278,13 +371,59 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 					},
+					SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+					},
+					SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+					},
+					SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+					},
+					SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+					},
+					SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+					},
+					SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+						Enabled: true,
+					},
+					SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+						Enabled: true,
+					},
 					SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+						Enabled: true,
+					},
+					SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
 						Enabled: true,
 					},
 					SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
@@ -392,6 +531,46 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []SqlserverDatabasePageFileSizeMetricAttributeKey{SqlserverDatabasePageFileSizeMetricAttributeKeyDbNamespace, SqlserverDatabasePageFileSizeMetricAttributeKeyPageFileState},
 					},
+					SqlserverDatabasePrincipalsCount: SqlserverDatabasePrincipalsCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsCountMetricAttributeKey{SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType},
+					},
+					SqlserverDatabasePrincipalsOld: SqlserverDatabasePrincipalsOldMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOldMetricAttributeKey{SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsOrphanedUsers: SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabasePrincipalsRecentlyCreated: SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace},
+					},
+					SqlserverDatabaseRoleMembersCount: SqlserverDatabaseRoleMembersCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembersCountMetricAttributeKey{SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind},
+					},
+					SqlserverDatabaseRoleMembershipsCount: SqlserverDatabaseRoleMembershipsCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind},
+					},
+					SqlserverDatabaseRolePermissionRiskLevel: SqlserverDatabaseRolePermissionRiskLevelMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole},
+					},
+					SqlserverDatabaseRoleRolesCount: SqlserverDatabaseRoleRolesCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverDatabaseRoleRolesCountMetricAttributeKey{SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState},
+					},
 					SqlserverDatabaseSecurityRoleMembershipCount: SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -412,6 +591,49 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverDeadlockRate: SqlserverDeadlockRateMetricConfig{
 						Enabled: false,
+					},
+					SqlserverFailoverClusterAgClusterType: SqlserverFailoverClusterAgClusterTypeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType},
+					},
+					SqlserverFailoverClusterAgFailureConditionLevel: SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgHealthCheckTimeout: SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterAgRequiredSyncSecondaries: SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName},
+					},
+					SqlserverFailoverClusterReplicaDatabaseQueueSize: SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind},
+					},
+					SqlserverFailoverClusterReplicaDatabaseRedoRate: SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace},
+					},
+					SqlserverFailoverClusterReplicaFlowControlTime: SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{
+						Enabled: false,
+					},
+					SqlserverFailoverClusterReplicaRole: SqlserverFailoverClusterReplicaRoleMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole},
+					},
+					SqlserverFailoverClusterReplicaSynchronizationHealth: SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth},
 					},
 					SqlserverIndexSearchRate: SqlserverIndexSearchRateMetricConfig{
 						Enabled: false,
@@ -435,6 +657,16 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					SqlserverLatchWaitTimeTotal: SqlserverLatchWaitTimeTotalMetricConfig{
 						Enabled: false,
+					},
+					SqlserverLockByModeCount: SqlserverLockByModeCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByModeCountMetricAttributeKey{SqlserverLockByModeCountMetricAttributeKeyDbNamespace, SqlserverLockByModeCountMetricAttributeKeyLockMode},
+					},
+					SqlserverLockByResourceCount: SqlserverLockByResourceCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverLockByResourceCountMetricAttributeKey{SqlserverLockByResourceCountMetricAttributeKeyDbNamespace, SqlserverLockByResourceCountMetricAttributeKeyLockResource},
 					},
 					SqlserverLockTimeoutRate: SqlserverLockTimeoutRateMetricConfig{
 						Enabled: false,
@@ -580,13 +812,59 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []SqlserverTableCountMetricAttributeKey{SqlserverTableCountMetricAttributeKeyTableState, SqlserverTableCountMetricAttributeKeyTableStatus},
 					},
+					SqlserverTempdbAllocationWaitTimeTotal: SqlserverTempdbAllocationWaitTimeTotalMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType},
+					},
+					SqlserverTempdbContentionWaitersCount: SqlserverTempdbContentionWaitersCountMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTempdbDataFilesCount: SqlserverTempdbDataFilesCountMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTempdbFileSize: SqlserverTempdbFileSizeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbFileSizeMetricAttributeKey{SqlserverTempdbFileSizeMetricAttributeKeyFileType, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID},
+					},
+					SqlserverTempdbSpaceUsage: SqlserverTempdbSpaceUsageMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverTempdbSpaceUsageMetricAttributeKey{SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind},
+					},
+					SqlserverThreadPoolTasksCount: SqlserverThreadPoolTasksCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolTasksCountMetricAttributeKey{SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState},
+					},
+					SqlserverThreadPoolWorkersCount: SqlserverThreadPoolWorkersCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []SqlserverThreadPoolWorkersCountMetricAttributeKey{SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState},
+					},
+					SqlserverThreadPoolWorkersMax: SqlserverThreadPoolWorkersMaxMetricConfig{
+						Enabled: false,
+					},
+					SqlserverThreadPoolWorkersUtilization: SqlserverThreadPoolWorkersUtilizationMetricConfig{
+						Enabled: false,
+					},
 					SqlserverTransactionDelay: SqlserverTransactionDelayMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionLongestRunningTime: SqlserverTransactionLongestRunningTimeMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionMirrorWriteRate: SqlserverTransactionMirrorWriteRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionRate: SqlserverTransactionRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionVersionCleanupRate: SqlserverTransactionVersionCleanupRateMetricConfig{
+						Enabled: false,
+					},
+					SqlserverTransactionVersionGenerationRate: SqlserverTransactionVersionGenerationRateMetricConfig{
 						Enabled: false,
 					},
 					SqlserverTransactionWriteRate: SqlserverTransactionWriteRateMetricConfig{
@@ -631,7 +909,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(SqlserverAttentionRateMetricConfig{}, SqlserverBatchCompilationUtilizationMetricConfig{}, SqlserverBatchPageSplitUtilizationMetricConfig{}, SqlserverBatchRequestRateMetricConfig{}, SqlserverBatchSQLCompilationRateMetricConfig{}, SqlserverBatchSQLRecompilationRateMetricConfig{}, SqlserverComputerUptimeMetricConfig{}, SqlserverCPUCountMetricConfig{}, SqlserverDatabaseBackupOrRestoreRateMetricConfig{}, SqlserverDatabaseCountMetricConfig{}, SqlserverDatabaseExecutionErrorsMetricConfig{}, SqlserverDatabaseFileSizeMetricConfig{}, SqlserverDatabaseFullScanRateMetricConfig{}, SqlserverDatabaseIoMetricConfig{}, SqlserverDatabaseLatencyMetricConfig{}, SqlserverDatabaseOperationsMetricConfig{}, SqlserverDatabasePageFileSizeMetricConfig{}, SqlserverDatabasePrincipalsCountMetricConfig{}, SqlserverDatabasePrincipalsOldMetricConfig{}, SqlserverDatabasePrincipalsOrphanedUsersMetricConfig{}, SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig{}, SqlserverDatabaseRoleMembersCountMetricConfig{}, SqlserverDatabaseRoleMembershipsCountMetricConfig{}, SqlserverDatabaseRolePermissionRiskLevelMetricConfig{}, SqlserverDatabaseRoleRolesCountMetricConfig{}, SqlserverDatabaseSecurityRoleMembershipCountMetricConfig{}, SqlserverDatabaseTempdbSpaceMetricConfig{}, SqlserverDatabaseTempdbVersionStoreSizeMetricConfig{}, SqlserverDatabaseTransactionsActiveMetricConfig{}, SqlserverDeadlockRateMetricConfig{}, SqlserverFailoverClusterAgClusterTypeMetricConfig{}, SqlserverFailoverClusterAgFailureConditionLevelMetricConfig{}, SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig{}, SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig{}, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig{}, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig{}, SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig{}, SqlserverFailoverClusterReplicaRoleMetricConfig{}, SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig{}, SqlserverIndexSearchRateMetricConfig{}, SqlserverKillConnectionErrorRateMetricConfig{}, SqlserverLatchSuperlatchCountMetricConfig{}, SqlserverLatchSuperlatchTransitionRateMetricConfig{}, SqlserverLatchWaitRateMetricConfig{}, SqlserverLatchWaitTimeAvgMetricConfig{}, SqlserverLatchWaitTimeTotalMetricConfig{}, SqlserverLockByModeCountMetricConfig{}, SqlserverLockByResourceCountMetricConfig{}, SqlserverLockTimeoutRateMetricConfig{}, SqlserverLockWaitCountMetricConfig{}, SqlserverLockWaitRateMetricConfig{}, SqlserverLockWaitTimeAvgMetricConfig{}, SqlserverLoginRateMetricConfig{}, SqlserverLogoutRateMetricConfig{}, SqlserverMemoryAreaMetricConfig{}, SqlserverMemoryCacheObjectCountMetricConfig{}, SqlserverMemoryGrantsPendingCountMetricConfig{}, SqlserverMemoryPageCountMetricConfig{}, SqlserverMemoryTargetMetricConfig{}, SqlserverMemoryUsageMetricConfig{}, SqlserverOsDiskSizeMetricConfig{}, SqlserverOsMemoryUsageMetricConfig{}, SqlserverOsMemoryUtilizationMetricConfig{}, SqlserverOsSchedulerRunnableTasksCountMetricConfig{}, SqlserverOsWaitDurationMetricConfig{}, SqlserverOsWaitTasksCountMetricConfig{}, SqlserverPageBufferCacheFreeListStallsRateMetricConfig{}, SqlserverPageBufferCacheHitRatioMetricConfig{}, SqlserverPageCheckpointFlushRateMetricConfig{}, SqlserverPageLazyWriteRateMetricConfig{}, SqlserverPageLifeExpectancyMetricConfig{}, SqlserverPageLookupRateMetricConfig{}, SqlserverPageOperationRateMetricConfig{}, SqlserverPageSplitRateMetricConfig{}, SqlserverParameterizationRateMetricConfig{}, SqlserverPlanExecutionRateMetricConfig{}, SqlserverProcessCountMetricConfig{}, SqlserverProcessesBlockedMetricConfig{}, SqlserverRecompilationRatioMetricConfig{}, SqlserverReplicaDataRateMetricConfig{}, SqlserverResourcePoolDiskOperationsMetricConfig{}, SqlserverResourcePoolDiskThrottledReadRateMetricConfig{}, SqlserverResourcePoolDiskThrottledWriteRateMetricConfig{}, SqlserverServerSecurityPrincipalCountMetricConfig{}, SqlserverServerSecurityRoleMembershipCountMetricConfig{}, SqlserverTableCountMetricConfig{}, SqlserverTempdbAllocationWaitTimeTotalMetricConfig{}, SqlserverTempdbContentionWaitersCountMetricConfig{}, SqlserverTempdbDataFilesCountMetricConfig{}, SqlserverTempdbFileSizeMetricConfig{}, SqlserverTempdbSpaceUsageMetricConfig{}, SqlserverThreadPoolTasksCountMetricConfig{}, SqlserverThreadPoolWorkersCountMetricConfig{}, SqlserverThreadPoolWorkersMaxMetricConfig{}, SqlserverThreadPoolWorkersUtilizationMetricConfig{}, SqlserverTransactionDelayMetricConfig{}, SqlserverTransactionLongestRunningTimeMetricConfig{}, SqlserverTransactionMirrorWriteRateMetricConfig{}, SqlserverTransactionRateMetricConfig{}, SqlserverTransactionVersionCleanupRateMetricConfig{}, SqlserverTransactionVersionGenerationRateMetricConfig{}, SqlserverTransactionWriteRateMetricConfig{}, SqlserverTransactionLogFlushDataRateMetricConfig{}, SqlserverTransactionLogFlushRateMetricConfig{}, SqlserverTransactionLogFlushWaitRateMetricConfig{}, SqlserverTransactionLogGrowthCountMetricConfig{}, SqlserverTransactionLogShrinkCountMetricConfig{}, SqlserverTransactionLogUsageMetricConfig{}, SqlserverUserConnectionCountMetricConfig{}, HostNameResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}, SqlserverComputerNameResourceAttributeConfig{}, SqlserverDatabaseNameResourceAttributeConfig{}, SqlserverInstanceNameResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -709,6 +987,102 @@ func TestSqlserverDatabasePageFileSizeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverDatabasePrincipalsCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.count doesn't have an attribute invalid, valid attributes: [db.namespace, principal.type]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsOldMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsOld
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsOldMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.old doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsOld
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsOrphanedUsersMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsOrphanedUsers
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.orphaned_users doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsOrphanedUsers
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabasePrincipalsRecentlyCreatedMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabasePrincipalsRecentlyCreated
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.principals.recently_created doesn't have an attribute invalid, valid attributes: [db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabasePrincipalsRecentlyCreated
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleMembersCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleMembersCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleMembersCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.members.count doesn't have an attribute invalid, valid attributes: [db.namespace, member.kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleMembersCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleMembershipsCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleMembershipsCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleMembershipsCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.memberships.count doesn't have an attribute invalid, valid attributes: [db.namespace, membership.kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleMembershipsCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRolePermissionRiskLevelMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRolePermissionRiskLevel
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.permission.risk_level doesn't have an attribute invalid, valid attributes: [db.namespace, role]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRolePermissionRiskLevel
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverDatabaseRoleRolesCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverDatabaseRoleRolesCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverDatabaseRoleRolesCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.database.role.roles.count doesn't have an attribute invalid, valid attributes: [db.namespace, role.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverDatabaseRoleRolesCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverDatabaseSecurityRoleMembershipCountMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverDatabaseSecurityRoleMembershipCount
 	require.NoError(t, cfg.Validate())
@@ -745,6 +1119,102 @@ func TestSqlserverDatabaseTransactionsActiveMetricsConfig_Validate(t *testing.T)
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
+func TestSqlserverFailoverClusterAgClusterTypeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgClusterType
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgClusterTypeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.cluster_type doesn't have an attribute invalid, valid attributes: [ag.name, ag.cluster_type]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgClusterType
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgFailureConditionLevelMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgFailureConditionLevel
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.failure_condition_level doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgFailureConditionLevel
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgHealthCheckTimeoutMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgHealthCheckTimeout
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.health_check_timeout doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgHealthCheckTimeout
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterAgRequiredSyncSecondariesMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterAgRequiredSyncSecondaries
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.ag.required_sync_secondaries doesn't have an attribute invalid, valid attributes: [ag.name]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterAgRequiredSyncSecondaries
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaDatabaseQueueSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseQueueSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.database.queue_size doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseQueueSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaDatabaseRedoRateMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseRedoRate
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.database.redo.rate doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, db.namespace]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaDatabaseRedoRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaRoleMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaRole
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaRoleMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.role doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, replica.role]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaRole
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverFailoverClusterReplicaSynchronizationHealthMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverFailoverClusterReplicaSynchronizationHealth
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.failover_cluster.replica.synchronization_health doesn't have an attribute invalid, valid attributes: [ag.name, replica.server_name, replica.sync_health]")
+
+	cfg = DefaultMetricsConfig().SqlserverFailoverClusterReplicaSynchronizationHealth
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestSqlserverLatchSuperlatchTransitionRateMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().SqlserverLatchSuperlatchTransitionRate
 	require.NoError(t, cfg.Validate())
@@ -753,6 +1223,30 @@ func TestSqlserverLatchSuperlatchTransitionRateMetricsConfig_Validate(t *testing
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.latch.superlatch.transition.rate doesn't have an attribute invalid, valid attributes: [transition.direction]")
 
 	cfg = DefaultMetricsConfig().SqlserverLatchSuperlatchTransitionRate
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverLockByModeCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverLockByModeCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverLockByModeCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.lock.by_mode.count doesn't have an attribute invalid, valid attributes: [db.namespace, lock.mode]")
+
+	cfg = DefaultMetricsConfig().SqlserverLockByModeCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverLockByResourceCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverLockByResourceCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverLockByResourceCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.lock.by_resource.count doesn't have an attribute invalid, valid attributes: [db.namespace, lock.resource]")
+
+	cfg = DefaultMetricsConfig().SqlserverLockByResourceCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -933,6 +1427,66 @@ func TestSqlserverTableCountMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.table.count doesn't have an attribute invalid, valid attributes: [table.state, table.status]")
 
 	cfg = DefaultMetricsConfig().SqlserverTableCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbAllocationWaitTimeTotalMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbAllocationWaitTimeTotal
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.allocation.wait_time.total doesn't have an attribute invalid, valid attributes: [allocation.page_type]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbAllocationWaitTimeTotal
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbFileSizeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbFileSize
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbFileSizeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.file.size doesn't have an attribute invalid, valid attributes: [file_type, tempdb.file.id]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbFileSize
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverTempdbSpaceUsageMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverTempdbSpaceUsage
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverTempdbSpaceUsageMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.tempdb.space.usage doesn't have an attribute invalid, valid attributes: [tempdb.space_kind]")
+
+	cfg = DefaultMetricsConfig().SqlserverTempdbSpaceUsage
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverThreadPoolTasksCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverThreadPoolTasksCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverThreadPoolTasksCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.thread_pool.tasks.count doesn't have an attribute invalid, valid attributes: [task.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverThreadPoolTasksCount
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestSqlserverThreadPoolWorkersCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().SqlserverThreadPoolWorkersCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []SqlserverThreadPoolWorkersCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric sqlserver.thread_pool.workers.count doesn't have an attribute invalid, valid attributes: [worker.state]")
+
+	cfg = DefaultMetricsConfig().SqlserverThreadPoolWorkersCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -22,6 +22,74 @@ const (
 	AggregationStrategyMax = "max"
 )
 
+// AttributeAgClusterType specifies the value ag.cluster_type attribute.
+type AttributeAgClusterType int
+
+const (
+	_ AttributeAgClusterType = iota
+	AttributeAgClusterTypeWsfc
+	AttributeAgClusterTypeExternal
+	AttributeAgClusterTypeNone
+	AttributeAgClusterTypeUnknown
+)
+
+// String returns the string representation of the AttributeAgClusterType.
+func (av AttributeAgClusterType) String() string {
+	switch av {
+	case AttributeAgClusterTypeWsfc:
+		return "wsfc"
+	case AttributeAgClusterTypeExternal:
+		return "external"
+	case AttributeAgClusterTypeNone:
+		return "none"
+	case AttributeAgClusterTypeUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeAgClusterType is a helper map of string to AttributeAgClusterType attribute value.
+var MapAttributeAgClusterType = map[string]AttributeAgClusterType{
+	"wsfc":     AttributeAgClusterTypeWsfc,
+	"external": AttributeAgClusterTypeExternal,
+	"none":     AttributeAgClusterTypeNone,
+	"unknown":  AttributeAgClusterTypeUnknown,
+}
+
+// AttributeAllocationPageType specifies the value allocation.page_type attribute.
+type AttributeAllocationPageType int
+
+const (
+	_ AttributeAllocationPageType = iota
+	AttributeAllocationPageTypeGam
+	AttributeAllocationPageTypeSgam
+	AttributeAllocationPageTypePfs
+	AttributeAllocationPageTypeOther
+)
+
+// String returns the string representation of the AttributeAllocationPageType.
+func (av AttributeAllocationPageType) String() string {
+	switch av {
+	case AttributeAllocationPageTypeGam:
+		return "gam"
+	case AttributeAllocationPageTypeSgam:
+		return "sgam"
+	case AttributeAllocationPageTypePfs:
+		return "pfs"
+	case AttributeAllocationPageTypeOther:
+		return "other"
+	}
+	return ""
+}
+
+// MapAttributeAllocationPageType is a helper map of string to AttributeAllocationPageType attribute value.
+var MapAttributeAllocationPageType = map[string]AttributeAllocationPageType{
+	"gam":   AttributeAllocationPageTypeGam,
+	"sgam":  AttributeAllocationPageTypeSgam,
+	"pfs":   AttributeAllocationPageTypePfs,
+	"other": AttributeAllocationPageTypeOther,
+}
+
 // AttributeCacheState specifies the value cache.state attribute.
 type AttributeCacheState int
 
@@ -114,6 +182,182 @@ func (av AttributeDirection) String() string {
 var MapAttributeDirection = map[string]AttributeDirection{
 	"read":  AttributeDirectionRead,
 	"write": AttributeDirectionWrite,
+}
+
+// AttributeLockMode specifies the value lock.mode attribute.
+type AttributeLockMode int
+
+const (
+	_ AttributeLockMode = iota
+	AttributeLockModeShared
+	AttributeLockModeExclusive
+	AttributeLockModeUpdate
+	AttributeLockModeIntent
+	AttributeLockModeSchema
+	AttributeLockModeBulkUpdate
+	AttributeLockModeSharedIntentExclusive
+)
+
+// String returns the string representation of the AttributeLockMode.
+func (av AttributeLockMode) String() string {
+	switch av {
+	case AttributeLockModeShared:
+		return "shared"
+	case AttributeLockModeExclusive:
+		return "exclusive"
+	case AttributeLockModeUpdate:
+		return "update"
+	case AttributeLockModeIntent:
+		return "intent"
+	case AttributeLockModeSchema:
+		return "schema"
+	case AttributeLockModeBulkUpdate:
+		return "bulk_update"
+	case AttributeLockModeSharedIntentExclusive:
+		return "shared_intent_exclusive"
+	}
+	return ""
+}
+
+// MapAttributeLockMode is a helper map of string to AttributeLockMode attribute value.
+var MapAttributeLockMode = map[string]AttributeLockMode{
+	"shared":                  AttributeLockModeShared,
+	"exclusive":               AttributeLockModeExclusive,
+	"update":                  AttributeLockModeUpdate,
+	"intent":                  AttributeLockModeIntent,
+	"schema":                  AttributeLockModeSchema,
+	"bulk_update":             AttributeLockModeBulkUpdate,
+	"shared_intent_exclusive": AttributeLockModeSharedIntentExclusive,
+}
+
+// AttributeLockResource specifies the value lock.resource attribute.
+type AttributeLockResource int
+
+const (
+	_ AttributeLockResource = iota
+	AttributeLockResourceKey
+	AttributeLockResourcePage
+	AttributeLockResourceRow
+	AttributeLockResourceTable
+	AttributeLockResourceExtent
+	AttributeLockResourceFile
+	AttributeLockResourceHobt
+	AttributeLockResourceMetadata
+	AttributeLockResourceApplication
+	AttributeLockResourceAllocationUnit
+	AttributeLockResourceDatabaseLevel
+)
+
+// String returns the string representation of the AttributeLockResource.
+func (av AttributeLockResource) String() string {
+	switch av {
+	case AttributeLockResourceKey:
+		return "key"
+	case AttributeLockResourcePage:
+		return "page"
+	case AttributeLockResourceRow:
+		return "row"
+	case AttributeLockResourceTable:
+		return "table"
+	case AttributeLockResourceExtent:
+		return "extent"
+	case AttributeLockResourceFile:
+		return "file"
+	case AttributeLockResourceHobt:
+		return "hobt"
+	case AttributeLockResourceMetadata:
+		return "metadata"
+	case AttributeLockResourceApplication:
+		return "application"
+	case AttributeLockResourceAllocationUnit:
+		return "allocation_unit"
+	case AttributeLockResourceDatabaseLevel:
+		return "database_level"
+	}
+	return ""
+}
+
+// MapAttributeLockResource is a helper map of string to AttributeLockResource attribute value.
+var MapAttributeLockResource = map[string]AttributeLockResource{
+	"key":             AttributeLockResourceKey,
+	"page":            AttributeLockResourcePage,
+	"row":             AttributeLockResourceRow,
+	"table":           AttributeLockResourceTable,
+	"extent":          AttributeLockResourceExtent,
+	"file":            AttributeLockResourceFile,
+	"hobt":            AttributeLockResourceHobt,
+	"metadata":        AttributeLockResourceMetadata,
+	"application":     AttributeLockResourceApplication,
+	"allocation_unit": AttributeLockResourceAllocationUnit,
+	"database_level":  AttributeLockResourceDatabaseLevel,
+}
+
+// AttributeMemberKind specifies the value member.kind attribute.
+type AttributeMemberKind int
+
+const (
+	_ AttributeMemberKind = iota
+	AttributeMemberKindAppRole
+	AttributeMemberKindCrossRole
+	AttributeMemberKindHighPrivilege
+	AttributeMemberKindUnique
+)
+
+// String returns the string representation of the AttributeMemberKind.
+func (av AttributeMemberKind) String() string {
+	switch av {
+	case AttributeMemberKindAppRole:
+		return "app_role"
+	case AttributeMemberKindCrossRole:
+		return "cross_role"
+	case AttributeMemberKindHighPrivilege:
+		return "high_privilege"
+	case AttributeMemberKindUnique:
+		return "unique"
+	}
+	return ""
+}
+
+// MapAttributeMemberKind is a helper map of string to AttributeMemberKind attribute value.
+var MapAttributeMemberKind = map[string]AttributeMemberKind{
+	"app_role":       AttributeMemberKindAppRole,
+	"cross_role":     AttributeMemberKindCrossRole,
+	"high_privilege": AttributeMemberKindHighPrivilege,
+	"unique":         AttributeMemberKindUnique,
+}
+
+// AttributeMembershipKind specifies the value membership.kind attribute.
+type AttributeMembershipKind int
+
+const (
+	_ AttributeMembershipKind = iota
+	AttributeMembershipKindActive
+	AttributeMembershipKindCustom
+	AttributeMembershipKindNested
+	AttributeMembershipKindUsers
+)
+
+// String returns the string representation of the AttributeMembershipKind.
+func (av AttributeMembershipKind) String() string {
+	switch av {
+	case AttributeMembershipKindActive:
+		return "active"
+	case AttributeMembershipKindCustom:
+		return "custom"
+	case AttributeMembershipKindNested:
+		return "nested"
+	case AttributeMembershipKindUsers:
+		return "users"
+	}
+	return ""
+}
+
+// MapAttributeMembershipKind is a helper map of string to AttributeMembershipKind attribute value.
+var MapAttributeMembershipKind = map[string]AttributeMembershipKind{
+	"active": AttributeMembershipKindActive,
+	"custom": AttributeMembershipKindCustom,
+	"nested": AttributeMembershipKindNested,
+	"users":  AttributeMembershipKindUsers,
 }
 
 // AttributeMemoryPool specifies the value memory.pool attribute.
@@ -290,6 +534,48 @@ var MapAttributePageFileState = map[string]AttributePageFileState{
 	"total": AttributePageFileStateTotal,
 }
 
+// AttributePrincipalType specifies the value principal.type attribute.
+type AttributePrincipalType int
+
+const (
+	_ AttributePrincipalType = iota
+	AttributePrincipalTypeSQLUser
+	AttributePrincipalTypeWindowsUser
+	AttributePrincipalTypeRole
+	AttributePrincipalTypeApplicationRole
+	AttributePrincipalTypeCertificateMappedUser
+	AttributePrincipalTypeAsymmetricKeyMappedUser
+)
+
+// String returns the string representation of the AttributePrincipalType.
+func (av AttributePrincipalType) String() string {
+	switch av {
+	case AttributePrincipalTypeSQLUser:
+		return "sql_user"
+	case AttributePrincipalTypeWindowsUser:
+		return "windows_user"
+	case AttributePrincipalTypeRole:
+		return "role"
+	case AttributePrincipalTypeApplicationRole:
+		return "application_role"
+	case AttributePrincipalTypeCertificateMappedUser:
+		return "certificate_mapped_user"
+	case AttributePrincipalTypeAsymmetricKeyMappedUser:
+		return "asymmetric_key_mapped_user"
+	}
+	return ""
+}
+
+// MapAttributePrincipalType is a helper map of string to AttributePrincipalType attribute value.
+var MapAttributePrincipalType = map[string]AttributePrincipalType{
+	"sql_user":                   AttributePrincipalTypeSQLUser,
+	"windows_user":               AttributePrincipalTypeWindowsUser,
+	"role":                       AttributePrincipalTypeRole,
+	"application_role":           AttributePrincipalTypeApplicationRole,
+	"certificate_mapped_user":    AttributePrincipalTypeCertificateMappedUser,
+	"asymmetric_key_mapped_user": AttributePrincipalTypeAsymmetricKeyMappedUser,
+}
+
 // AttributeProcessStatus specifies the value process.status attribute.
 type AttributeProcessStatus int
 
@@ -360,6 +646,126 @@ func (av AttributeReplicaDirection) String() string {
 var MapAttributeReplicaDirection = map[string]AttributeReplicaDirection{
 	"transmit": AttributeReplicaDirectionTransmit,
 	"receive":  AttributeReplicaDirectionReceive,
+}
+
+// AttributeReplicaQueueKind specifies the value replica.queue_kind attribute.
+type AttributeReplicaQueueKind int
+
+const (
+	_ AttributeReplicaQueueKind = iota
+	AttributeReplicaQueueKindLogSend
+	AttributeReplicaQueueKindRedo
+)
+
+// String returns the string representation of the AttributeReplicaQueueKind.
+func (av AttributeReplicaQueueKind) String() string {
+	switch av {
+	case AttributeReplicaQueueKindLogSend:
+		return "log_send"
+	case AttributeReplicaQueueKindRedo:
+		return "redo"
+	}
+	return ""
+}
+
+// MapAttributeReplicaQueueKind is a helper map of string to AttributeReplicaQueueKind attribute value.
+var MapAttributeReplicaQueueKind = map[string]AttributeReplicaQueueKind{
+	"log_send": AttributeReplicaQueueKindLogSend,
+	"redo":     AttributeReplicaQueueKindRedo,
+}
+
+// AttributeReplicaRole specifies the value replica.role attribute.
+type AttributeReplicaRole int
+
+const (
+	_ AttributeReplicaRole = iota
+	AttributeReplicaRolePrimary
+	AttributeReplicaRoleSecondary
+	AttributeReplicaRoleResolving
+	AttributeReplicaRoleUnknown
+)
+
+// String returns the string representation of the AttributeReplicaRole.
+func (av AttributeReplicaRole) String() string {
+	switch av {
+	case AttributeReplicaRolePrimary:
+		return "primary"
+	case AttributeReplicaRoleSecondary:
+		return "secondary"
+	case AttributeReplicaRoleResolving:
+		return "resolving"
+	case AttributeReplicaRoleUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeReplicaRole is a helper map of string to AttributeReplicaRole attribute value.
+var MapAttributeReplicaRole = map[string]AttributeReplicaRole{
+	"primary":   AttributeReplicaRolePrimary,
+	"secondary": AttributeReplicaRoleSecondary,
+	"resolving": AttributeReplicaRoleResolving,
+	"unknown":   AttributeReplicaRoleUnknown,
+}
+
+// AttributeReplicaSyncHealth specifies the value replica.sync_health attribute.
+type AttributeReplicaSyncHealth int
+
+const (
+	_ AttributeReplicaSyncHealth = iota
+	AttributeReplicaSyncHealthHealthy
+	AttributeReplicaSyncHealthPartiallyHealthy
+	AttributeReplicaSyncHealthNotHealthy
+	AttributeReplicaSyncHealthUnknown
+)
+
+// String returns the string representation of the AttributeReplicaSyncHealth.
+func (av AttributeReplicaSyncHealth) String() string {
+	switch av {
+	case AttributeReplicaSyncHealthHealthy:
+		return "healthy"
+	case AttributeReplicaSyncHealthPartiallyHealthy:
+		return "partially_healthy"
+	case AttributeReplicaSyncHealthNotHealthy:
+		return "not_healthy"
+	case AttributeReplicaSyncHealthUnknown:
+		return "unknown"
+	}
+	return ""
+}
+
+// MapAttributeReplicaSyncHealth is a helper map of string to AttributeReplicaSyncHealth attribute value.
+var MapAttributeReplicaSyncHealth = map[string]AttributeReplicaSyncHealth{
+	"healthy":           AttributeReplicaSyncHealthHealthy,
+	"partially_healthy": AttributeReplicaSyncHealthPartiallyHealthy,
+	"not_healthy":       AttributeReplicaSyncHealthNotHealthy,
+	"unknown":           AttributeReplicaSyncHealthUnknown,
+}
+
+// AttributeRoleState specifies the value role.state attribute.
+type AttributeRoleState int
+
+const (
+	_ AttributeRoleState = iota
+	AttributeRoleStateEmpty
+	AttributeRoleStateWithMembers
+)
+
+// String returns the string representation of the AttributeRoleState.
+func (av AttributeRoleState) String() string {
+	switch av {
+	case AttributeRoleStateEmpty:
+		return "empty"
+	case AttributeRoleStateWithMembers:
+		return "with_members"
+	}
+	return ""
+}
+
+// MapAttributeRoleState is a helper map of string to AttributeRoleState attribute value.
+var MapAttributeRoleState = map[string]AttributeRoleState{
+	"empty":        AttributeRoleStateEmpty,
+	"with_members": AttributeRoleStateWithMembers,
 }
 
 // AttributeSqlserverParameterizationResult specifies the value sqlserver.parameterization.result attribute.
@@ -478,6 +884,70 @@ var MapAttributeTableStatus = map[string]AttributeTableStatus{
 	"permanent": AttributeTableStatusPermanent,
 }
 
+// AttributeTaskState specifies the value task.state attribute.
+type AttributeTaskState int
+
+const (
+	_ AttributeTaskState = iota
+	AttributeTaskStateCurrent
+	AttributeTaskStateQueued
+	AttributeTaskStateWaitingForThreadpool
+)
+
+// String returns the string representation of the AttributeTaskState.
+func (av AttributeTaskState) String() string {
+	switch av {
+	case AttributeTaskStateCurrent:
+		return "current"
+	case AttributeTaskStateQueued:
+		return "queued"
+	case AttributeTaskStateWaitingForThreadpool:
+		return "waiting_for_threadpool"
+	}
+	return ""
+}
+
+// MapAttributeTaskState is a helper map of string to AttributeTaskState attribute value.
+var MapAttributeTaskState = map[string]AttributeTaskState{
+	"current":                AttributeTaskStateCurrent,
+	"queued":                 AttributeTaskStateQueued,
+	"waiting_for_threadpool": AttributeTaskStateWaitingForThreadpool,
+}
+
+// AttributeTempdbSpaceKind specifies the value tempdb.space_kind attribute.
+type AttributeTempdbSpaceKind int
+
+const (
+	_ AttributeTempdbSpaceKind = iota
+	AttributeTempdbSpaceKindUserObjects
+	AttributeTempdbSpaceKindInternalObjects
+	AttributeTempdbSpaceKindVersionStore
+	AttributeTempdbSpaceKindFree
+)
+
+// String returns the string representation of the AttributeTempdbSpaceKind.
+func (av AttributeTempdbSpaceKind) String() string {
+	switch av {
+	case AttributeTempdbSpaceKindUserObjects:
+		return "user_objects"
+	case AttributeTempdbSpaceKindInternalObjects:
+		return "internal_objects"
+	case AttributeTempdbSpaceKindVersionStore:
+		return "version_store"
+	case AttributeTempdbSpaceKindFree:
+		return "free"
+	}
+	return ""
+}
+
+// MapAttributeTempdbSpaceKind is a helper map of string to AttributeTempdbSpaceKind attribute value.
+var MapAttributeTempdbSpaceKind = map[string]AttributeTempdbSpaceKind{
+	"user_objects":     AttributeTempdbSpaceKindUserObjects,
+	"internal_objects": AttributeTempdbSpaceKindInternalObjects,
+	"version_store":    AttributeTempdbSpaceKindVersionStore,
+	"free":             AttributeTempdbSpaceKindFree,
+}
+
 // AttributeTempdbState specifies the value tempdb.state attribute.
 type AttributeTempdbState int
 
@@ -528,6 +998,32 @@ func (av AttributeTransitionDirection) String() string {
 var MapAttributeTransitionDirection = map[string]AttributeTransitionDirection{
 	"promotion": AttributeTransitionDirectionPromotion,
 	"demotion":  AttributeTransitionDirectionDemotion,
+}
+
+// AttributeWorkerState specifies the value worker.state attribute.
+type AttributeWorkerState int
+
+const (
+	_ AttributeWorkerState = iota
+	AttributeWorkerStateRunning
+	AttributeWorkerStateSuspendedOrSleeping
+)
+
+// String returns the string representation of the AttributeWorkerState.
+func (av AttributeWorkerState) String() string {
+	switch av {
+	case AttributeWorkerStateRunning:
+		return "running"
+	case AttributeWorkerStateSuspendedOrSleeping:
+		return "suspended_or_sleeping"
+	}
+	return ""
+}
+
+// MapAttributeWorkerState is a helper map of string to AttributeWorkerState attribute value.
+var MapAttributeWorkerState = map[string]AttributeWorkerState{
+	"running":               AttributeWorkerStateRunning,
+	"suspended_or_sleeping": AttributeWorkerStateSuspendedOrSleeping,
 }
 
 var MetricsInfo = metricsInfo{
@@ -588,6 +1084,38 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.database.page_file.size",
 		Attributes: []string{"db.namespace", "page_file.state"},
 	},
+	SqlserverDatabasePrincipalsCount: metricInfo{
+		Name:       "sqlserver.database.principals.count",
+		Attributes: []string{"db.namespace", "principal.type"},
+	},
+	SqlserverDatabasePrincipalsOld: metricInfo{
+		Name:       "sqlserver.database.principals.old",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabasePrincipalsOrphanedUsers: metricInfo{
+		Name:       "sqlserver.database.principals.orphaned_users",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabasePrincipalsRecentlyCreated: metricInfo{
+		Name:       "sqlserver.database.principals.recently_created",
+		Attributes: []string{"db.namespace"},
+	},
+	SqlserverDatabaseRoleMembersCount: metricInfo{
+		Name:       "sqlserver.database.role.members.count",
+		Attributes: []string{"db.namespace", "member.kind"},
+	},
+	SqlserverDatabaseRoleMembershipsCount: metricInfo{
+		Name:       "sqlserver.database.role.memberships.count",
+		Attributes: []string{"db.namespace", "membership.kind"},
+	},
+	SqlserverDatabaseRolePermissionRiskLevel: metricInfo{
+		Name:       "sqlserver.database.role.permission.risk_level",
+		Attributes: []string{"db.namespace", "role"},
+	},
+	SqlserverDatabaseRoleRolesCount: metricInfo{
+		Name:       "sqlserver.database.role.roles.count",
+		Attributes: []string{"db.namespace", "role.state"},
+	},
 	SqlserverDatabaseSecurityRoleMembershipCount: metricInfo{
 		Name:       "sqlserver.database.security.role_membership.count",
 		Attributes: []string{"db.namespace", "role"},
@@ -605,6 +1133,41 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverDeadlockRate: metricInfo{
 		Name: "sqlserver.deadlock.rate",
+	},
+	SqlserverFailoverClusterAgClusterType: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.cluster_type",
+		Attributes: []string{"ag.name", "ag.cluster_type"},
+	},
+	SqlserverFailoverClusterAgFailureConditionLevel: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.failure_condition_level",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterAgHealthCheckTimeout: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.health_check_timeout",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterAgRequiredSyncSecondaries: metricInfo{
+		Name:       "sqlserver.failover_cluster.ag.required_sync_secondaries",
+		Attributes: []string{"ag.name"},
+	},
+	SqlserverFailoverClusterReplicaDatabaseQueueSize: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.database.queue_size",
+		Attributes: []string{"ag.name", "replica.server_name", "db.namespace", "replica.queue_kind"},
+	},
+	SqlserverFailoverClusterReplicaDatabaseRedoRate: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.database.redo.rate",
+		Attributes: []string{"ag.name", "replica.server_name", "db.namespace"},
+	},
+	SqlserverFailoverClusterReplicaFlowControlTime: metricInfo{
+		Name: "sqlserver.failover_cluster.replica.flow_control_time",
+	},
+	SqlserverFailoverClusterReplicaRole: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.role",
+		Attributes: []string{"ag.name", "replica.server_name", "replica.role"},
+	},
+	SqlserverFailoverClusterReplicaSynchronizationHealth: metricInfo{
+		Name:       "sqlserver.failover_cluster.replica.synchronization_health",
+		Attributes: []string{"ag.name", "replica.server_name", "replica.sync_health"},
 	},
 	SqlserverIndexSearchRate: metricInfo{
 		Name: "sqlserver.index.search.rate",
@@ -627,6 +1190,14 @@ var MetricsInfo = metricsInfo{
 	},
 	SqlserverLatchWaitTimeTotal: metricInfo{
 		Name: "sqlserver.latch.wait_time.total",
+	},
+	SqlserverLockByModeCount: metricInfo{
+		Name:       "sqlserver.lock.by_mode.count",
+		Attributes: []string{"db.namespace", "lock.mode"},
+	},
+	SqlserverLockByResourceCount: metricInfo{
+		Name:       "sqlserver.lock.by_resource.count",
+		Attributes: []string{"db.namespace", "lock.resource"},
 	},
 	SqlserverLockTimeoutRate: metricInfo{
 		Name: "sqlserver.lock.timeout.rate",
@@ -757,14 +1328,55 @@ var MetricsInfo = metricsInfo{
 		Name:       "sqlserver.table.count",
 		Attributes: []string{"table.state", "table.status"},
 	},
+	SqlserverTempdbAllocationWaitTimeTotal: metricInfo{
+		Name:       "sqlserver.tempdb.allocation.wait_time.total",
+		Attributes: []string{"allocation.page_type"},
+	},
+	SqlserverTempdbContentionWaitersCount: metricInfo{
+		Name: "sqlserver.tempdb.contention.waiters.count",
+	},
+	SqlserverTempdbDataFilesCount: metricInfo{
+		Name: "sqlserver.tempdb.data_files.count",
+	},
+	SqlserverTempdbFileSize: metricInfo{
+		Name:       "sqlserver.tempdb.file.size",
+		Attributes: []string{"file_type", "tempdb.file.id"},
+	},
+	SqlserverTempdbSpaceUsage: metricInfo{
+		Name:       "sqlserver.tempdb.space.usage",
+		Attributes: []string{"tempdb.space_kind"},
+	},
+	SqlserverThreadPoolTasksCount: metricInfo{
+		Name:       "sqlserver.thread_pool.tasks.count",
+		Attributes: []string{"task.state"},
+	},
+	SqlserverThreadPoolWorkersCount: metricInfo{
+		Name:       "sqlserver.thread_pool.workers.count",
+		Attributes: []string{"worker.state"},
+	},
+	SqlserverThreadPoolWorkersMax: metricInfo{
+		Name: "sqlserver.thread_pool.workers.max",
+	},
+	SqlserverThreadPoolWorkersUtilization: metricInfo{
+		Name: "sqlserver.thread_pool.workers.utilization",
+	},
 	SqlserverTransactionDelay: metricInfo{
 		Name: "sqlserver.transaction.delay",
+	},
+	SqlserverTransactionLongestRunningTime: metricInfo{
+		Name: "sqlserver.transaction.longest_running_time",
 	},
 	SqlserverTransactionMirrorWriteRate: metricInfo{
 		Name: "sqlserver.transaction.mirror_write.rate",
 	},
 	SqlserverTransactionRate: metricInfo{
 		Name: "sqlserver.transaction.rate",
+	},
+	SqlserverTransactionVersionCleanupRate: metricInfo{
+		Name: "sqlserver.transaction.version_cleanup.rate",
+	},
+	SqlserverTransactionVersionGenerationRate: metricInfo{
+		Name: "sqlserver.transaction.version_generation.rate",
 	},
 	SqlserverTransactionWriteRate: metricInfo{
 		Name: "sqlserver.transaction.write.rate",
@@ -793,84 +1405,115 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
-	SqlserverAttentionRate                       metricInfo
-	SqlserverBatchCompilationUtilization         metricInfo
-	SqlserverBatchPageSplitUtilization           metricInfo
-	SqlserverBatchRequestRate                    metricInfo
-	SqlserverBatchSQLCompilationRate             metricInfo
-	SqlserverBatchSQLRecompilationRate           metricInfo
-	SqlserverComputerUptime                      metricInfo
-	SqlserverCPUCount                            metricInfo
-	SqlserverDatabaseBackupOrRestoreRate         metricInfo
-	SqlserverDatabaseCount                       metricInfo
-	SqlserverDatabaseExecutionErrors             metricInfo
-	SqlserverDatabaseFileSize                    metricInfo
-	SqlserverDatabaseFullScanRate                metricInfo
-	SqlserverDatabaseIo                          metricInfo
-	SqlserverDatabaseLatency                     metricInfo
-	SqlserverDatabaseOperations                  metricInfo
-	SqlserverDatabasePageFileSize                metricInfo
-	SqlserverDatabaseSecurityRoleMembershipCount metricInfo
-	SqlserverDatabaseTempdbSpace                 metricInfo
-	SqlserverDatabaseTempdbVersionStoreSize      metricInfo
-	SqlserverDatabaseTransactionsActive          metricInfo
-	SqlserverDeadlockRate                        metricInfo
-	SqlserverIndexSearchRate                     metricInfo
-	SqlserverKillConnectionErrorRate             metricInfo
-	SqlserverLatchSuperlatchCount                metricInfo
-	SqlserverLatchSuperlatchTransitionRate       metricInfo
-	SqlserverLatchWaitRate                       metricInfo
-	SqlserverLatchWaitTimeAvg                    metricInfo
-	SqlserverLatchWaitTimeTotal                  metricInfo
-	SqlserverLockTimeoutRate                     metricInfo
-	SqlserverLockWaitCount                       metricInfo
-	SqlserverLockWaitRate                        metricInfo
-	SqlserverLockWaitTimeAvg                     metricInfo
-	SqlserverLoginRate                           metricInfo
-	SqlserverLogoutRate                          metricInfo
-	SqlserverMemoryArea                          metricInfo
-	SqlserverMemoryCacheObjectCount              metricInfo
-	SqlserverMemoryGrantsPendingCount            metricInfo
-	SqlserverMemoryPageCount                     metricInfo
-	SqlserverMemoryTarget                        metricInfo
-	SqlserverMemoryUsage                         metricInfo
-	SqlserverOsDiskSize                          metricInfo
-	SqlserverOsMemoryUsage                       metricInfo
-	SqlserverOsMemoryUtilization                 metricInfo
-	SqlserverOsSchedulerRunnableTasksCount       metricInfo
-	SqlserverOsWaitDuration                      metricInfo
-	SqlserverOsWaitTasksCount                    metricInfo
-	SqlserverPageBufferCacheFreeListStallsRate   metricInfo
-	SqlserverPageBufferCacheHitRatio             metricInfo
-	SqlserverPageCheckpointFlushRate             metricInfo
-	SqlserverPageLazyWriteRate                   metricInfo
-	SqlserverPageLifeExpectancy                  metricInfo
-	SqlserverPageLookupRate                      metricInfo
-	SqlserverPageOperationRate                   metricInfo
-	SqlserverPageSplitRate                       metricInfo
-	SqlserverParameterizationRate                metricInfo
-	SqlserverPlanExecutionRate                   metricInfo
-	SqlserverProcessCount                        metricInfo
-	SqlserverProcessesBlocked                    metricInfo
-	SqlserverRecompilationRatio                  metricInfo
-	SqlserverReplicaDataRate                     metricInfo
-	SqlserverResourcePoolDiskOperations          metricInfo
-	SqlserverResourcePoolDiskThrottledReadRate   metricInfo
-	SqlserverResourcePoolDiskThrottledWriteRate  metricInfo
-	SqlserverServerSecurityPrincipalCount        metricInfo
-	SqlserverServerSecurityRoleMembershipCount   metricInfo
-	SqlserverTableCount                          metricInfo
-	SqlserverTransactionDelay                    metricInfo
-	SqlserverTransactionMirrorWriteRate          metricInfo
-	SqlserverTransactionRate                     metricInfo
-	SqlserverTransactionWriteRate                metricInfo
-	SqlserverTransactionLogFlushDataRate         metricInfo
-	SqlserverTransactionLogFlushRate             metricInfo
-	SqlserverTransactionLogFlushWaitRate         metricInfo
-	SqlserverTransactionLogGrowthCount           metricInfo
-	SqlserverTransactionLogShrinkCount           metricInfo
-	SqlserverTransactionLogUsage                 metricInfo
-	SqlserverUserConnectionCount                 metricInfo
+	SqlserverAttentionRate                               metricInfo
+	SqlserverBatchCompilationUtilization                 metricInfo
+	SqlserverBatchPageSplitUtilization                   metricInfo
+	SqlserverBatchRequestRate                            metricInfo
+	SqlserverBatchSQLCompilationRate                     metricInfo
+	SqlserverBatchSQLRecompilationRate                   metricInfo
+	SqlserverComputerUptime                              metricInfo
+	SqlserverCPUCount                                    metricInfo
+	SqlserverDatabaseBackupOrRestoreRate                 metricInfo
+	SqlserverDatabaseCount                               metricInfo
+	SqlserverDatabaseExecutionErrors                     metricInfo
+	SqlserverDatabaseFileSize                            metricInfo
+	SqlserverDatabaseFullScanRate                        metricInfo
+	SqlserverDatabaseIo                                  metricInfo
+	SqlserverDatabaseLatency                             metricInfo
+	SqlserverDatabaseOperations                          metricInfo
+	SqlserverDatabasePageFileSize                        metricInfo
+	SqlserverDatabasePrincipalsCount                     metricInfo
+	SqlserverDatabasePrincipalsOld                       metricInfo
+	SqlserverDatabasePrincipalsOrphanedUsers             metricInfo
+	SqlserverDatabasePrincipalsRecentlyCreated           metricInfo
+	SqlserverDatabaseRoleMembersCount                    metricInfo
+	SqlserverDatabaseRoleMembershipsCount                metricInfo
+	SqlserverDatabaseRolePermissionRiskLevel             metricInfo
+	SqlserverDatabaseRoleRolesCount                      metricInfo
+	SqlserverDatabaseSecurityRoleMembershipCount         metricInfo
+	SqlserverDatabaseTempdbSpace                         metricInfo
+	SqlserverDatabaseTempdbVersionStoreSize              metricInfo
+	SqlserverDatabaseTransactionsActive                  metricInfo
+	SqlserverDeadlockRate                                metricInfo
+	SqlserverFailoverClusterAgClusterType                metricInfo
+	SqlserverFailoverClusterAgFailureConditionLevel      metricInfo
+	SqlserverFailoverClusterAgHealthCheckTimeout         metricInfo
+	SqlserverFailoverClusterAgRequiredSyncSecondaries    metricInfo
+	SqlserverFailoverClusterReplicaDatabaseQueueSize     metricInfo
+	SqlserverFailoverClusterReplicaDatabaseRedoRate      metricInfo
+	SqlserverFailoverClusterReplicaFlowControlTime       metricInfo
+	SqlserverFailoverClusterReplicaRole                  metricInfo
+	SqlserverFailoverClusterReplicaSynchronizationHealth metricInfo
+	SqlserverIndexSearchRate                             metricInfo
+	SqlserverKillConnectionErrorRate                     metricInfo
+	SqlserverLatchSuperlatchCount                        metricInfo
+	SqlserverLatchSuperlatchTransitionRate               metricInfo
+	SqlserverLatchWaitRate                               metricInfo
+	SqlserverLatchWaitTimeAvg                            metricInfo
+	SqlserverLatchWaitTimeTotal                          metricInfo
+	SqlserverLockByModeCount                             metricInfo
+	SqlserverLockByResourceCount                         metricInfo
+	SqlserverLockTimeoutRate                             metricInfo
+	SqlserverLockWaitCount                               metricInfo
+	SqlserverLockWaitRate                                metricInfo
+	SqlserverLockWaitTimeAvg                             metricInfo
+	SqlserverLoginRate                                   metricInfo
+	SqlserverLogoutRate                                  metricInfo
+	SqlserverMemoryArea                                  metricInfo
+	SqlserverMemoryCacheObjectCount                      metricInfo
+	SqlserverMemoryGrantsPendingCount                    metricInfo
+	SqlserverMemoryPageCount                             metricInfo
+	SqlserverMemoryTarget                                metricInfo
+	SqlserverMemoryUsage                                 metricInfo
+	SqlserverOsDiskSize                                  metricInfo
+	SqlserverOsMemoryUsage                               metricInfo
+	SqlserverOsMemoryUtilization                         metricInfo
+	SqlserverOsSchedulerRunnableTasksCount               metricInfo
+	SqlserverOsWaitDuration                              metricInfo
+	SqlserverOsWaitTasksCount                            metricInfo
+	SqlserverPageBufferCacheFreeListStallsRate           metricInfo
+	SqlserverPageBufferCacheHitRatio                     metricInfo
+	SqlserverPageCheckpointFlushRate                     metricInfo
+	SqlserverPageLazyWriteRate                           metricInfo
+	SqlserverPageLifeExpectancy                          metricInfo
+	SqlserverPageLookupRate                              metricInfo
+	SqlserverPageOperationRate                           metricInfo
+	SqlserverPageSplitRate                               metricInfo
+	SqlserverParameterizationRate                        metricInfo
+	SqlserverPlanExecutionRate                           metricInfo
+	SqlserverProcessCount                                metricInfo
+	SqlserverProcessesBlocked                            metricInfo
+	SqlserverRecompilationRatio                          metricInfo
+	SqlserverReplicaDataRate                             metricInfo
+	SqlserverResourcePoolDiskOperations                  metricInfo
+	SqlserverResourcePoolDiskThrottledReadRate           metricInfo
+	SqlserverResourcePoolDiskThrottledWriteRate          metricInfo
+	SqlserverServerSecurityPrincipalCount                metricInfo
+	SqlserverServerSecurityRoleMembershipCount           metricInfo
+	SqlserverTableCount                                  metricInfo
+	SqlserverTempdbAllocationWaitTimeTotal               metricInfo
+	SqlserverTempdbContentionWaitersCount                metricInfo
+	SqlserverTempdbDataFilesCount                        metricInfo
+	SqlserverTempdbFileSize                              metricInfo
+	SqlserverTempdbSpaceUsage                            metricInfo
+	SqlserverThreadPoolTasksCount                        metricInfo
+	SqlserverThreadPoolWorkersCount                      metricInfo
+	SqlserverThreadPoolWorkersMax                        metricInfo
+	SqlserverThreadPoolWorkersUtilization                metricInfo
+	SqlserverTransactionDelay                            metricInfo
+	SqlserverTransactionLongestRunningTime               metricInfo
+	SqlserverTransactionMirrorWriteRate                  metricInfo
+	SqlserverTransactionRate                             metricInfo
+	SqlserverTransactionVersionCleanupRate               metricInfo
+	SqlserverTransactionVersionGenerationRate            metricInfo
+	SqlserverTransactionWriteRate                        metricInfo
+	SqlserverTransactionLogFlushDataRate                 metricInfo
+	SqlserverTransactionLogFlushRate                     metricInfo
+	SqlserverTransactionLogFlushWaitRate                 metricInfo
+	SqlserverTransactionLogGrowthCount                   metricInfo
+	SqlserverTransactionLogShrinkCount                   metricInfo
+	SqlserverTransactionLogUsage                         metricInfo
+	SqlserverUserConnectionCount                         metricInfo
 }
 
 type metricInfo struct {
@@ -2001,6 +2644,733 @@ func newMetricSqlserverDatabasePageFileSize(cfg SqlserverDatabasePageFileSizeMet
 	return m
 }
 
+type metricSqlserverDatabasePrincipalsCount struct {
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsCountMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                      // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.count metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsCount) init() {
+	m.data.SetName("sqlserver.database.principals.count")
+	m.data.SetDescription("Number of database security principals broken down by type.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, principalTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsCountMetricAttributeKeyPrincipalType) {
+		dp.Attributes().PutStr("principal.type", principalTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsCount(cfg SqlserverDatabasePrincipalsCountMetricConfig) metricSqlserverDatabasePrincipalsCount {
+	m := metricSqlserverDatabasePrincipalsCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsOld struct {
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsOldMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []int64                                    // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.old metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsOld) init() {
+	m.data.SetName("sqlserver.database.principals.old")
+	m.data.SetDescription("Number of database principals created more than one year ago.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsOld) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsOldMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsOld) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsOld) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsOld(cfg SqlserverDatabasePrincipalsOldMetricConfig) metricSqlserverDatabasePrincipalsOld {
+	m := metricSqlserverDatabasePrincipalsOld{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsOrphanedUsers struct {
+	data          pmetric.Metric                                       // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsOrphanedUsersMetricConfig // metric config provided by user.
+	capacity      int                                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.orphaned_users metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) init() {
+	m.data.SetName("sqlserver.database.principals.orphaned_users")
+	m.data.SetDescription("Number of SQL users in the database that have no matching server login.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsOrphanedUsersMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsOrphanedUsers) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsOrphanedUsers(cfg SqlserverDatabasePrincipalsOrphanedUsersMetricConfig) metricSqlserverDatabasePrincipalsOrphanedUsers {
+	m := metricSqlserverDatabasePrincipalsOrphanedUsers{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabasePrincipalsRecentlyCreated struct {
+	data          pmetric.Metric                                         // data buffer for generated metric.
+	config        SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig // metric config provided by user.
+	capacity      int                                                    // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.principals.recently_created metric with initial data.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) init() {
+	m.data.SetName("sqlserver.database.principals.recently_created")
+	m.data.SetDescription("Number of database principals created in the last 30 days.")
+	m.data.SetUnit("{principals}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabasePrincipalsRecentlyCreatedMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabasePrincipalsRecentlyCreated) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabasePrincipalsRecentlyCreated(cfg SqlserverDatabasePrincipalsRecentlyCreatedMetricConfig) metricSqlserverDatabasePrincipalsRecentlyCreated {
+	m := metricSqlserverDatabasePrincipalsRecentlyCreated{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleMembersCount struct {
+	data          pmetric.Metric                                // data buffer for generated metric.
+	config        SqlserverDatabaseRoleMembersCountMetricConfig // metric config provided by user.
+	capacity      int                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                       // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.members.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleMembersCount) init() {
+	m.data.SetName("sqlserver.database.role.members.count")
+	m.data.SetDescription("Number of database role members broken down by member kind.")
+	m.data.SetUnit("{members}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleMembersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, memberKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembersCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembersCountMetricAttributeKeyMemberKind) {
+		dp.Attributes().PutStr("member.kind", memberKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleMembersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleMembersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleMembersCount(cfg SqlserverDatabaseRoleMembersCountMetricConfig) metricSqlserverDatabaseRoleMembersCount {
+	m := metricSqlserverDatabaseRoleMembersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleMembershipsCount struct {
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        SqlserverDatabaseRoleMembershipsCountMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.memberships.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) init() {
+	m.data.SetName("sqlserver.database.role.memberships.count")
+	m.data.SetDescription("Number of database role memberships broken down by kind.")
+	m.data.SetUnit("{memberships}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleMembershipsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, membershipKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleMembershipsCountMetricAttributeKeyMembershipKind) {
+		dp.Attributes().PutStr("membership.kind", membershipKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleMembershipsCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleMembershipsCount(cfg SqlserverDatabaseRoleMembershipsCountMetricConfig) metricSqlserverDatabaseRoleMembershipsCount {
+	m := metricSqlserverDatabaseRoleMembershipsCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRolePermissionRiskLevel struct {
+	data          pmetric.Metric                                       // data buffer for generated metric.
+	config        SqlserverDatabaseRolePermissionRiskLevelMetricConfig // metric config provided by user.
+	capacity      int                                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.permission.risk_level metric with initial data.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) init() {
+	m.data.SetName("sqlserver.database.role.permission.risk_level")
+	m.data.SetDescription("Risk level assigned to each database role (1=low, 4=high).")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, roleAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRolePermissionRiskLevelMetricAttributeKeyRole) {
+		dp.Attributes().PutStr("role", roleAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRolePermissionRiskLevel) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRolePermissionRiskLevel(cfg SqlserverDatabaseRolePermissionRiskLevelMetricConfig) metricSqlserverDatabaseRolePermissionRiskLevel {
+	m := metricSqlserverDatabaseRolePermissionRiskLevel{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverDatabaseRoleRolesCount struct {
+	data          pmetric.Metric                              // data buffer for generated metric.
+	config        SqlserverDatabaseRoleRolesCountMetricConfig // metric config provided by user.
+	capacity      int                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.database.role.roles.count metric with initial data.
+func (m *metricSqlserverDatabaseRoleRolesCount) init() {
+	m.data.SetName("sqlserver.database.role.roles.count")
+	m.data.SetDescription("Number of database roles broken down by usage state.")
+	m.data.SetUnit("{roles}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverDatabaseRoleRolesCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, roleStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleRolesCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverDatabaseRoleRolesCountMetricAttributeKeyRoleState) {
+		dp.Attributes().PutStr("role.state", roleStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverDatabaseRoleRolesCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverDatabaseRoleRolesCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverDatabaseRoleRolesCount(cfg SqlserverDatabaseRoleRolesCountMetricConfig) metricSqlserverDatabaseRoleRolesCount {
+	m := metricSqlserverDatabaseRoleRolesCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverDatabaseSecurityRoleMembershipCount struct {
 	data          pmetric.Metric                                           // data buffer for generated metric.
 	config        SqlserverDatabaseSecurityRoleMembershipCountMetricConfig // metric config provided by user.
@@ -2365,6 +3735,798 @@ func (m *metricSqlserverDeadlockRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverDeadlockRate(cfg SqlserverDeadlockRateMetricConfig) metricSqlserverDeadlockRate {
 	m := metricSqlserverDeadlockRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgClusterType struct {
+	data          pmetric.Metric                                    // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgClusterTypeMetricConfig // metric config provided by user.
+	capacity      int                                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.cluster_type metric with initial data.
+func (m *metricSqlserverFailoverClusterAgClusterType) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.cluster_type")
+	m.data.SetDescription("Cluster type of the Always-On Availability Group.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgClusterType) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, agClusterTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgClusterTypeMetricAttributeKeyAgClusterType) {
+		dp.Attributes().PutStr("ag.cluster_type", agClusterTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgClusterType) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgClusterType) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgClusterType(cfg SqlserverFailoverClusterAgClusterTypeMetricConfig) metricSqlserverFailoverClusterAgClusterType {
+	m := metricSqlserverFailoverClusterAgClusterType{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgFailureConditionLevel struct {
+	data          pmetric.Metric                                              // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgFailureConditionLevelMetricConfig // metric config provided by user.
+	capacity      int                                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.failure_condition_level metric with initial data.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.failure_condition_level")
+	m.data.SetDescription("Failure condition level configured for the Availability Group (1-5).")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgFailureConditionLevelMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgFailureConditionLevel) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgFailureConditionLevel(cfg SqlserverFailoverClusterAgFailureConditionLevelMetricConfig) metricSqlserverFailoverClusterAgFailureConditionLevel {
+	m := metricSqlserverFailoverClusterAgFailureConditionLevel{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgHealthCheckTimeout struct {
+	data          pmetric.Metric                                           // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig // metric config provided by user.
+	capacity      int                                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.health_check_timeout metric with initial data.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.health_check_timeout")
+	m.data.SetDescription("Health-check timeout configured for the Availability Group.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgHealthCheckTimeoutMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgHealthCheckTimeout) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgHealthCheckTimeout(cfg SqlserverFailoverClusterAgHealthCheckTimeoutMetricConfig) metricSqlserverFailoverClusterAgHealthCheckTimeout {
+	m := metricSqlserverFailoverClusterAgHealthCheckTimeout{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterAgRequiredSyncSecondaries struct {
+	data          pmetric.Metric                                                // data buffer for generated metric.
+	config        SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig // metric config provided by user.
+	capacity      int                                                           // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                       // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.ag.required_sync_secondaries metric with initial data.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) init() {
+	m.data.SetName("sqlserver.failover_cluster.ag.required_sync_secondaries")
+	m.data.SetDescription("Number of synchronized secondary replicas required to commit on the Availability Group.")
+	m.data.SetUnit("{secondaries}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterAgRequiredSyncSecondariesMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterAgRequiredSyncSecondaries) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterAgRequiredSyncSecondaries(cfg SqlserverFailoverClusterAgRequiredSyncSecondariesMetricConfig) metricSqlserverFailoverClusterAgRequiredSyncSecondaries {
+	m := metricSqlserverFailoverClusterAgRequiredSyncSecondaries{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaDatabaseQueueSize struct {
+	data          pmetric.Metric                                               // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig // metric config provided by user.
+	capacity      int                                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                      // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.database.queue_size metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.database.queue_size")
+	m.data.SetDescription("Size of the log-send or redo queue for an AG database replica.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string, replicaQueueKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricAttributeKeyReplicaQueueKind) {
+		dp.Attributes().PutStr("replica.queue_kind", replicaQueueKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseQueueSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaDatabaseQueueSize(cfg SqlserverFailoverClusterReplicaDatabaseQueueSizeMetricConfig) metricSqlserverFailoverClusterReplicaDatabaseQueueSize {
+	m := metricSqlserverFailoverClusterReplicaDatabaseQueueSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaDatabaseRedoRate struct {
+	data          pmetric.Metric                                              // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig // metric config provided by user.
+	capacity      int                                                         // max observed number of data points added to the metric.
+	aggDataPoints []float64                                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.database.redo.rate metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.database.redo.rate")
+	m.data.SetDescription("Redo rate for an AG database replica.")
+	m.data.SetUnit("By/s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaDatabaseRedoRateMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaDatabaseRedoRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaDatabaseRedoRate(cfg SqlserverFailoverClusterReplicaDatabaseRedoRateMetricConfig) metricSqlserverFailoverClusterReplicaDatabaseRedoRate {
+	m := metricSqlserverFailoverClusterReplicaDatabaseRedoRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaFlowControlTime struct {
+	data     pmetric.Metric                                             // data buffer for generated metric.
+	config   SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig // metric config provided by user.
+	capacity int                                                        // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.failover_cluster.replica.flow_control_time metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.flow_control_time")
+	m.data.SetDescription("Cumulative time spent in AG flow control, in milliseconds per second observed.")
+	m.data.SetUnit("ms")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaFlowControlTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaFlowControlTime(cfg SqlserverFailoverClusterReplicaFlowControlTimeMetricConfig) metricSqlserverFailoverClusterReplicaFlowControlTime {
+	m := metricSqlserverFailoverClusterReplicaFlowControlTime{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaRole struct {
+	data          pmetric.Metric                                  // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaRoleMetricConfig // metric config provided by user.
+	capacity      int                                             // max observed number of data points added to the metric.
+	aggDataPoints []int64                                         // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.role metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaRole) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.role")
+	m.data.SetDescription("Role of the availability replica.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaRole) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaRoleAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaRoleMetricAttributeKeyReplicaRole) {
+		dp.Attributes().PutStr("replica.role", replicaRoleAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaRole) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaRole) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaRole(cfg SqlserverFailoverClusterReplicaRoleMetricConfig) metricSqlserverFailoverClusterReplicaRole {
+	m := metricSqlserverFailoverClusterReplicaRole{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverFailoverClusterReplicaSynchronizationHealth struct {
+	data          pmetric.Metric                                                   // data buffer for generated metric.
+	config        SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig // metric config provided by user.
+	capacity      int                                                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                                                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.failover_cluster.replica.synchronization_health metric with initial data.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) init() {
+	m.data.SetName("sqlserver.failover_cluster.replica.synchronization_health")
+	m.data.SetDescription("Synchronization health of the availability replica.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaSyncHealthAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyAgName) {
+		dp.Attributes().PutStr("ag.name", agNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaServerName) {
+		dp.Attributes().PutStr("replica.server_name", replicaServerNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverFailoverClusterReplicaSynchronizationHealthMetricAttributeKeyReplicaSyncHealth) {
+		dp.Attributes().PutStr("replica.sync_health", replicaSyncHealthAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverFailoverClusterReplicaSynchronizationHealth) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverFailoverClusterReplicaSynchronizationHealth(cfg SqlserverFailoverClusterReplicaSynchronizationHealthMetricConfig) metricSqlserverFailoverClusterReplicaSynchronizationHealth {
+	m := metricSqlserverFailoverClusterReplicaSynchronizationHealth{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -2756,6 +4918,190 @@ func (m *metricSqlserverLatchWaitTimeTotal) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverLatchWaitTimeTotal(cfg SqlserverLatchWaitTimeTotalMetricConfig) metricSqlserverLatchWaitTimeTotal {
 	m := metricSqlserverLatchWaitTimeTotal{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverLockByModeCount struct {
+	data          pmetric.Metric                       // data buffer for generated metric.
+	config        SqlserverLockByModeCountMetricConfig // metric config provided by user.
+	capacity      int                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.lock.by_mode.count metric with initial data.
+func (m *metricSqlserverLockByModeCount) init() {
+	m.data.SetName("sqlserver.lock.by_mode.count")
+	m.data.SetDescription("Number of currently active locks held in the database, grouped by lock mode.")
+	m.data.SetUnit("{locks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverLockByModeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, lockModeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByModeCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByModeCountMetricAttributeKeyLockMode) {
+		dp.Attributes().PutStr("lock.mode", lockModeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverLockByModeCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverLockByModeCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverLockByModeCount(cfg SqlserverLockByModeCountMetricConfig) metricSqlserverLockByModeCount {
+	m := metricSqlserverLockByModeCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverLockByResourceCount struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        SqlserverLockByResourceCountMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.lock.by_resource.count metric with initial data.
+func (m *metricSqlserverLockByResourceCount) init() {
+	m.data.SetName("sqlserver.lock.by_resource.count")
+	m.data.SetDescription("Number of currently active locks held in the database, grouped by resource type.")
+	m.data.SetUnit("{locks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverLockByResourceCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbNamespaceAttributeValue string, lockResourceAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByResourceCountMetricAttributeKeyDbNamespace) {
+		dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverLockByResourceCountMetricAttributeKeyLockResource) {
+		dp.Attributes().PutStr("lock.resource", lockResourceAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverLockByResourceCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverLockByResourceCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverLockByResourceCount(cfg SqlserverLockByResourceCountMetricConfig) metricSqlserverLockByResourceCount {
+	m := metricSqlserverLockByResourceCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5270,6 +7616,656 @@ func newMetricSqlserverTableCount(cfg SqlserverTableCountMetricConfig) metricSql
 	return m
 }
 
+type metricSqlserverTempdbAllocationWaitTimeTotal struct {
+	data          pmetric.Metric                                     // data buffer for generated metric.
+	config        SqlserverTempdbAllocationWaitTimeTotalMetricConfig // metric config provided by user.
+	capacity      int                                                // max observed number of data points added to the metric.
+	aggDataPoints []float64                                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.allocation.wait_time.total metric with initial data.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) init() {
+	m.data.SetName("sqlserver.tempdb.allocation.wait_time.total")
+	m.data.SetDescription("Cumulative wait time on tempdb allocation pages, broken down by page type.")
+	m.data.SetUnit("s")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, allocationPageTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbAllocationWaitTimeTotalMetricAttributeKeyAllocationPageType) {
+		dp.Attributes().PutStr("allocation.page_type", allocationPageTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbAllocationWaitTimeTotal) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetDoubleValue(m.data.Sum().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbAllocationWaitTimeTotal(cfg SqlserverTempdbAllocationWaitTimeTotalMetricConfig) metricSqlserverTempdbAllocationWaitTimeTotal {
+	m := metricSqlserverTempdbAllocationWaitTimeTotal{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbContentionWaitersCount struct {
+	data     pmetric.Metric                                    // data buffer for generated metric.
+	config   SqlserverTempdbContentionWaitersCountMetricConfig // metric config provided by user.
+	capacity int                                               // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.tempdb.contention.waiters.count metric with initial data.
+func (m *metricSqlserverTempdbContentionWaitersCount) init() {
+	m.data.SetName("sqlserver.tempdb.contention.waiters.count")
+	m.data.SetDescription("Number of tempdb pagelatch wait types with at least one active waiter.")
+	m.data.SetUnit("{waiters}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTempdbContentionWaitersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbContentionWaitersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbContentionWaitersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbContentionWaitersCount(cfg SqlserverTempdbContentionWaitersCountMetricConfig) metricSqlserverTempdbContentionWaitersCount {
+	m := metricSqlserverTempdbContentionWaitersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbDataFilesCount struct {
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   SqlserverTempdbDataFilesCountMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.tempdb.data_files.count metric with initial data.
+func (m *metricSqlserverTempdbDataFilesCount) init() {
+	m.data.SetName("sqlserver.tempdb.data_files.count")
+	m.data.SetDescription("Number of tempdb data files configured on the instance.")
+	m.data.SetUnit("{files}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTempdbDataFilesCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbDataFilesCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbDataFilesCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbDataFilesCount(cfg SqlserverTempdbDataFilesCountMetricConfig) metricSqlserverTempdbDataFilesCount {
+	m := metricSqlserverTempdbDataFilesCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbFileSize struct {
+	data          pmetric.Metric                      // data buffer for generated metric.
+	config        SqlserverTempdbFileSizeMetricConfig // metric config provided by user.
+	capacity      int                                 // max observed number of data points added to the metric.
+	aggDataPoints []int64                             // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.file.size metric with initial data.
+func (m *metricSqlserverTempdbFileSize) init() {
+	m.data.SetName("sqlserver.tempdb.file.size")
+	m.data.SetDescription("Size of each tempdb data or log file.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbFileSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, fileTypeAttributeValue string, tempdbFileIDAttributeValue int64) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbFileSizeMetricAttributeKeyFileType) {
+		dp.Attributes().PutStr("file_type", fileTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbFileSizeMetricAttributeKeyTempdbFileID) {
+		dp.Attributes().PutInt("tempdb.file.id", tempdbFileIDAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbFileSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbFileSize) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbFileSize(cfg SqlserverTempdbFileSizeMetricConfig) metricSqlserverTempdbFileSize {
+	m := metricSqlserverTempdbFileSize{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTempdbSpaceUsage struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        SqlserverTempdbSpaceUsageMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.tempdb.space.usage metric with initial data.
+func (m *metricSqlserverTempdbSpaceUsage) init() {
+	m.data.SetName("sqlserver.tempdb.space.usage")
+	m.data.SetDescription("Space used by tempdb, broken down by allocation category.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverTempdbSpaceUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tempdbSpaceKindAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverTempdbSpaceUsageMetricAttributeKeyTempdbSpaceKind) {
+		dp.Attributes().PutStr("tempdb.space_kind", tempdbSpaceKindAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTempdbSpaceUsage) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTempdbSpaceUsage) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTempdbSpaceUsage(cfg SqlserverTempdbSpaceUsageMetricConfig) metricSqlserverTempdbSpaceUsage {
+	m := metricSqlserverTempdbSpaceUsage{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolTasksCount struct {
+	data          pmetric.Metric                            // data buffer for generated metric.
+	config        SqlserverThreadPoolTasksCountMetricConfig // metric config provided by user.
+	capacity      int                                       // max observed number of data points added to the metric.
+	aggDataPoints []int64                                   // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.thread_pool.tasks.count metric with initial data.
+func (m *metricSqlserverThreadPoolTasksCount) init() {
+	m.data.SetName("sqlserver.thread_pool.tasks.count")
+	m.data.SetDescription("Number of SQL Server tasks broken down by state.")
+	m.data.SetUnit("{tasks}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverThreadPoolTasksCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, taskStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverThreadPoolTasksCountMetricAttributeKeyTaskState) {
+		dp.Attributes().PutStr("task.state", taskStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolTasksCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolTasksCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolTasksCount(cfg SqlserverThreadPoolTasksCountMetricConfig) metricSqlserverThreadPoolTasksCount {
+	m := metricSqlserverThreadPoolTasksCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersCount struct {
+	data          pmetric.Metric                              // data buffer for generated metric.
+	config        SqlserverThreadPoolWorkersCountMetricConfig // metric config provided by user.
+	capacity      int                                         // max observed number of data points added to the metric.
+	aggDataPoints []int64                                     // slice containing number of aggregated datapoints at each index
+}
+
+// init fills sqlserver.thread_pool.workers.count metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersCount) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.count")
+	m.data.SetDescription("Number of SQL Server worker threads broken down by state.")
+	m.data.SetUnit("{workers}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricSqlserverThreadPoolWorkersCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, workerStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, SqlserverThreadPoolWorkersCountMetricAttributeKeyWorkerState) {
+		dp.Attributes().PutStr("worker.state", workerStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersCount) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersCount(cfg SqlserverThreadPoolWorkersCountMetricConfig) metricSqlserverThreadPoolWorkersCount {
+	m := metricSqlserverThreadPoolWorkersCount{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersMax struct {
+	data     pmetric.Metric                            // data buffer for generated metric.
+	config   SqlserverThreadPoolWorkersMaxMetricConfig // metric config provided by user.
+	capacity int                                       // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.thread_pool.workers.max metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersMax) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.max")
+	m.data.SetDescription("Maximum number of SQL Server worker threads configured on the instance.")
+	m.data.SetUnit("{workers}")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverThreadPoolWorkersMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersMax) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersMax) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersMax(cfg SqlserverThreadPoolWorkersMaxMetricConfig) metricSqlserverThreadPoolWorkersMax {
+	m := metricSqlserverThreadPoolWorkersMax{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverThreadPoolWorkersUtilization struct {
+	data     pmetric.Metric                                    // data buffer for generated metric.
+	config   SqlserverThreadPoolWorkersUtilizationMetricConfig // metric config provided by user.
+	capacity int                                               // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.thread_pool.workers.utilization metric with initial data.
+func (m *metricSqlserverThreadPoolWorkersUtilization) init() {
+	m.data.SetName("sqlserver.thread_pool.workers.utilization")
+	m.data.SetDescription("Fraction of configured SQL Server worker threads currently running.")
+	m.data.SetUnit("1")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverThreadPoolWorkersUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverThreadPoolWorkersUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverThreadPoolWorkersUtilization) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverThreadPoolWorkersUtilization(cfg SqlserverThreadPoolWorkersUtilizationMetricConfig) metricSqlserverThreadPoolWorkersUtilization {
+	m := metricSqlserverThreadPoolWorkersUtilization{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSqlserverTransactionDelay struct {
 	data     pmetric.Metric                        // data buffer for generated metric.
 	config   SqlserverTransactionDelayMetricConfig // metric config provided by user.
@@ -5314,6 +8310,56 @@ func (m *metricSqlserverTransactionDelay) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverTransactionDelay(cfg SqlserverTransactionDelayMetricConfig) metricSqlserverTransactionDelay {
 	m := metricSqlserverTransactionDelay{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionLongestRunningTime struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverTransactionLongestRunningTimeMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.longest_running_time metric with initial data.
+func (m *metricSqlserverTransactionLongestRunningTime) init() {
+	m.data.SetName("sqlserver.transaction.longest_running_time")
+	m.data.SetDescription("Age in seconds of the longest currently-open transaction on the server.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricSqlserverTransactionLongestRunningTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionLongestRunningTime) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionLongestRunningTime) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionLongestRunningTime(cfg SqlserverTransactionLongestRunningTimeMetricConfig) metricSqlserverTransactionLongestRunningTime {
+	m := metricSqlserverTransactionLongestRunningTime{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5414,6 +8460,110 @@ func (m *metricSqlserverTransactionRate) emit(metrics pmetric.MetricSlice) {
 
 func newMetricSqlserverTransactionRate(cfg SqlserverTransactionRateMetricConfig) metricSqlserverTransactionRate {
 	m := metricSqlserverTransactionRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionVersionCleanupRate struct {
+	data     pmetric.Metric                                     // data buffer for generated metric.
+	config   SqlserverTransactionVersionCleanupRateMetricConfig // metric config provided by user.
+	capacity int                                                // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.version_cleanup.rate metric with initial data.
+func (m *metricSqlserverTransactionVersionCleanupRate) init() {
+	m.data.SetName("sqlserver.transaction.version_cleanup.rate")
+	m.data.SetDescription("Cumulative bytes cleaned from the tempdb version store.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSqlserverTransactionVersionCleanupRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionVersionCleanupRate) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionVersionCleanupRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionVersionCleanupRate(cfg SqlserverTransactionVersionCleanupRateMetricConfig) metricSqlserverTransactionVersionCleanupRate {
+	m := metricSqlserverTransactionVersionCleanupRate{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSqlserverTransactionVersionGenerationRate struct {
+	data     pmetric.Metric                                        // data buffer for generated metric.
+	config   SqlserverTransactionVersionGenerationRateMetricConfig // metric config provided by user.
+	capacity int                                                   // max observed number of data points added to the metric.
+}
+
+// init fills sqlserver.transaction.version_generation.rate metric with initial data.
+func (m *metricSqlserverTransactionVersionGenerationRate) init() {
+	m.data.SetName("sqlserver.transaction.version_generation.rate")
+	m.data.SetDescription("Cumulative bytes of row versions written to the tempdb version store.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSqlserverTransactionVersionGenerationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSqlserverTransactionVersionGenerationRate) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSqlserverTransactionVersionGenerationRate) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSqlserverTransactionVersionGenerationRate(cfg SqlserverTransactionVersionGenerationRateMetricConfig) metricSqlserverTransactionVersionGenerationRate {
+	m := metricSqlserverTransactionVersionGenerationRate{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5829,91 +8979,122 @@ func newMetricSqlserverUserConnectionCount(cfg SqlserverUserConnectionCountMetri
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                                             MetricsBuilderConfig // config of the metrics builder.
-	startTime                                          pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity                                    int                  // maximum observed number of metrics per resource.
-	metricsBuffer                                      pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                                          component.BuildInfo  // contains version information.
-	resourceAttributeIncludeFilter                     map[string]filter.Filter
-	resourceAttributeExcludeFilter                     map[string]filter.Filter
-	metricSqlserverAttentionRate                       metricSqlserverAttentionRate
-	metricSqlserverBatchCompilationUtilization         metricSqlserverBatchCompilationUtilization
-	metricSqlserverBatchPageSplitUtilization           metricSqlserverBatchPageSplitUtilization
-	metricSqlserverBatchRequestRate                    metricSqlserverBatchRequestRate
-	metricSqlserverBatchSQLCompilationRate             metricSqlserverBatchSQLCompilationRate
-	metricSqlserverBatchSQLRecompilationRate           metricSqlserverBatchSQLRecompilationRate
-	metricSqlserverComputerUptime                      metricSqlserverComputerUptime
-	metricSqlserverCPUCount                            metricSqlserverCPUCount
-	metricSqlserverDatabaseBackupOrRestoreRate         metricSqlserverDatabaseBackupOrRestoreRate
-	metricSqlserverDatabaseCount                       metricSqlserverDatabaseCount
-	metricSqlserverDatabaseExecutionErrors             metricSqlserverDatabaseExecutionErrors
-	metricSqlserverDatabaseFileSize                    metricSqlserverDatabaseFileSize
-	metricSqlserverDatabaseFullScanRate                metricSqlserverDatabaseFullScanRate
-	metricSqlserverDatabaseIo                          metricSqlserverDatabaseIo
-	metricSqlserverDatabaseLatency                     metricSqlserverDatabaseLatency
-	metricSqlserverDatabaseOperations                  metricSqlserverDatabaseOperations
-	metricSqlserverDatabasePageFileSize                metricSqlserverDatabasePageFileSize
-	metricSqlserverDatabaseSecurityRoleMembershipCount metricSqlserverDatabaseSecurityRoleMembershipCount
-	metricSqlserverDatabaseTempdbSpace                 metricSqlserverDatabaseTempdbSpace
-	metricSqlserverDatabaseTempdbVersionStoreSize      metricSqlserverDatabaseTempdbVersionStoreSize
-	metricSqlserverDatabaseTransactionsActive          metricSqlserverDatabaseTransactionsActive
-	metricSqlserverDeadlockRate                        metricSqlserverDeadlockRate
-	metricSqlserverIndexSearchRate                     metricSqlserverIndexSearchRate
-	metricSqlserverKillConnectionErrorRate             metricSqlserverKillConnectionErrorRate
-	metricSqlserverLatchSuperlatchCount                metricSqlserverLatchSuperlatchCount
-	metricSqlserverLatchSuperlatchTransitionRate       metricSqlserverLatchSuperlatchTransitionRate
-	metricSqlserverLatchWaitRate                       metricSqlserverLatchWaitRate
-	metricSqlserverLatchWaitTimeAvg                    metricSqlserverLatchWaitTimeAvg
-	metricSqlserverLatchWaitTimeTotal                  metricSqlserverLatchWaitTimeTotal
-	metricSqlserverLockTimeoutRate                     metricSqlserverLockTimeoutRate
-	metricSqlserverLockWaitCount                       metricSqlserverLockWaitCount
-	metricSqlserverLockWaitRate                        metricSqlserverLockWaitRate
-	metricSqlserverLockWaitTimeAvg                     metricSqlserverLockWaitTimeAvg
-	metricSqlserverLoginRate                           metricSqlserverLoginRate
-	metricSqlserverLogoutRate                          metricSqlserverLogoutRate
-	metricSqlserverMemoryArea                          metricSqlserverMemoryArea
-	metricSqlserverMemoryCacheObjectCount              metricSqlserverMemoryCacheObjectCount
-	metricSqlserverMemoryGrantsPendingCount            metricSqlserverMemoryGrantsPendingCount
-	metricSqlserverMemoryPageCount                     metricSqlserverMemoryPageCount
-	metricSqlserverMemoryTarget                        metricSqlserverMemoryTarget
-	metricSqlserverMemoryUsage                         metricSqlserverMemoryUsage
-	metricSqlserverOsDiskSize                          metricSqlserverOsDiskSize
-	metricSqlserverOsMemoryUsage                       metricSqlserverOsMemoryUsage
-	metricSqlserverOsMemoryUtilization                 metricSqlserverOsMemoryUtilization
-	metricSqlserverOsSchedulerRunnableTasksCount       metricSqlserverOsSchedulerRunnableTasksCount
-	metricSqlserverOsWaitDuration                      metricSqlserverOsWaitDuration
-	metricSqlserverOsWaitTasksCount                    metricSqlserverOsWaitTasksCount
-	metricSqlserverPageBufferCacheFreeListStallsRate   metricSqlserverPageBufferCacheFreeListStallsRate
-	metricSqlserverPageBufferCacheHitRatio             metricSqlserverPageBufferCacheHitRatio
-	metricSqlserverPageCheckpointFlushRate             metricSqlserverPageCheckpointFlushRate
-	metricSqlserverPageLazyWriteRate                   metricSqlserverPageLazyWriteRate
-	metricSqlserverPageLifeExpectancy                  metricSqlserverPageLifeExpectancy
-	metricSqlserverPageLookupRate                      metricSqlserverPageLookupRate
-	metricSqlserverPageOperationRate                   metricSqlserverPageOperationRate
-	metricSqlserverPageSplitRate                       metricSqlserverPageSplitRate
-	metricSqlserverParameterizationRate                metricSqlserverParameterizationRate
-	metricSqlserverPlanExecutionRate                   metricSqlserverPlanExecutionRate
-	metricSqlserverProcessCount                        metricSqlserverProcessCount
-	metricSqlserverProcessesBlocked                    metricSqlserverProcessesBlocked
-	metricSqlserverRecompilationRatio                  metricSqlserverRecompilationRatio
-	metricSqlserverReplicaDataRate                     metricSqlserverReplicaDataRate
-	metricSqlserverResourcePoolDiskOperations          metricSqlserverResourcePoolDiskOperations
-	metricSqlserverResourcePoolDiskThrottledReadRate   metricSqlserverResourcePoolDiskThrottledReadRate
-	metricSqlserverResourcePoolDiskThrottledWriteRate  metricSqlserverResourcePoolDiskThrottledWriteRate
-	metricSqlserverServerSecurityPrincipalCount        metricSqlserverServerSecurityPrincipalCount
-	metricSqlserverServerSecurityRoleMembershipCount   metricSqlserverServerSecurityRoleMembershipCount
-	metricSqlserverTableCount                          metricSqlserverTableCount
-	metricSqlserverTransactionDelay                    metricSqlserverTransactionDelay
-	metricSqlserverTransactionMirrorWriteRate          metricSqlserverTransactionMirrorWriteRate
-	metricSqlserverTransactionRate                     metricSqlserverTransactionRate
-	metricSqlserverTransactionWriteRate                metricSqlserverTransactionWriteRate
-	metricSqlserverTransactionLogFlushDataRate         metricSqlserverTransactionLogFlushDataRate
-	metricSqlserverTransactionLogFlushRate             metricSqlserverTransactionLogFlushRate
-	metricSqlserverTransactionLogFlushWaitRate         metricSqlserverTransactionLogFlushWaitRate
-	metricSqlserverTransactionLogGrowthCount           metricSqlserverTransactionLogGrowthCount
-	metricSqlserverTransactionLogShrinkCount           metricSqlserverTransactionLogShrinkCount
-	metricSqlserverTransactionLogUsage                 metricSqlserverTransactionLogUsage
-	metricSqlserverUserConnectionCount                 metricSqlserverUserConnectionCount
+	config                                                     MetricsBuilderConfig // config of the metrics builder.
+	startTime                                                  pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity                                            int                  // maximum observed number of metrics per resource.
+	metricsBuffer                                              pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                                                  component.BuildInfo  // contains version information.
+	resourceAttributeIncludeFilter                             map[string]filter.Filter
+	resourceAttributeExcludeFilter                             map[string]filter.Filter
+	metricSqlserverAttentionRate                               metricSqlserverAttentionRate
+	metricSqlserverBatchCompilationUtilization                 metricSqlserverBatchCompilationUtilization
+	metricSqlserverBatchPageSplitUtilization                   metricSqlserverBatchPageSplitUtilization
+	metricSqlserverBatchRequestRate                            metricSqlserverBatchRequestRate
+	metricSqlserverBatchSQLCompilationRate                     metricSqlserverBatchSQLCompilationRate
+	metricSqlserverBatchSQLRecompilationRate                   metricSqlserverBatchSQLRecompilationRate
+	metricSqlserverComputerUptime                              metricSqlserverComputerUptime
+	metricSqlserverCPUCount                                    metricSqlserverCPUCount
+	metricSqlserverDatabaseBackupOrRestoreRate                 metricSqlserverDatabaseBackupOrRestoreRate
+	metricSqlserverDatabaseCount                               metricSqlserverDatabaseCount
+	metricSqlserverDatabaseExecutionErrors                     metricSqlserverDatabaseExecutionErrors
+	metricSqlserverDatabaseFileSize                            metricSqlserverDatabaseFileSize
+	metricSqlserverDatabaseFullScanRate                        metricSqlserverDatabaseFullScanRate
+	metricSqlserverDatabaseIo                                  metricSqlserverDatabaseIo
+	metricSqlserverDatabaseLatency                             metricSqlserverDatabaseLatency
+	metricSqlserverDatabaseOperations                          metricSqlserverDatabaseOperations
+	metricSqlserverDatabasePageFileSize                        metricSqlserverDatabasePageFileSize
+	metricSqlserverDatabasePrincipalsCount                     metricSqlserverDatabasePrincipalsCount
+	metricSqlserverDatabasePrincipalsOld                       metricSqlserverDatabasePrincipalsOld
+	metricSqlserverDatabasePrincipalsOrphanedUsers             metricSqlserverDatabasePrincipalsOrphanedUsers
+	metricSqlserverDatabasePrincipalsRecentlyCreated           metricSqlserverDatabasePrincipalsRecentlyCreated
+	metricSqlserverDatabaseRoleMembersCount                    metricSqlserverDatabaseRoleMembersCount
+	metricSqlserverDatabaseRoleMembershipsCount                metricSqlserverDatabaseRoleMembershipsCount
+	metricSqlserverDatabaseRolePermissionRiskLevel             metricSqlserverDatabaseRolePermissionRiskLevel
+	metricSqlserverDatabaseRoleRolesCount                      metricSqlserverDatabaseRoleRolesCount
+	metricSqlserverDatabaseSecurityRoleMembershipCount         metricSqlserverDatabaseSecurityRoleMembershipCount
+	metricSqlserverDatabaseTempdbSpace                         metricSqlserverDatabaseTempdbSpace
+	metricSqlserverDatabaseTempdbVersionStoreSize              metricSqlserverDatabaseTempdbVersionStoreSize
+	metricSqlserverDatabaseTransactionsActive                  metricSqlserverDatabaseTransactionsActive
+	metricSqlserverDeadlockRate                                metricSqlserverDeadlockRate
+	metricSqlserverFailoverClusterAgClusterType                metricSqlserverFailoverClusterAgClusterType
+	metricSqlserverFailoverClusterAgFailureConditionLevel      metricSqlserverFailoverClusterAgFailureConditionLevel
+	metricSqlserverFailoverClusterAgHealthCheckTimeout         metricSqlserverFailoverClusterAgHealthCheckTimeout
+	metricSqlserverFailoverClusterAgRequiredSyncSecondaries    metricSqlserverFailoverClusterAgRequiredSyncSecondaries
+	metricSqlserverFailoverClusterReplicaDatabaseQueueSize     metricSqlserverFailoverClusterReplicaDatabaseQueueSize
+	metricSqlserverFailoverClusterReplicaDatabaseRedoRate      metricSqlserverFailoverClusterReplicaDatabaseRedoRate
+	metricSqlserverFailoverClusterReplicaFlowControlTime       metricSqlserverFailoverClusterReplicaFlowControlTime
+	metricSqlserverFailoverClusterReplicaRole                  metricSqlserverFailoverClusterReplicaRole
+	metricSqlserverFailoverClusterReplicaSynchronizationHealth metricSqlserverFailoverClusterReplicaSynchronizationHealth
+	metricSqlserverIndexSearchRate                             metricSqlserverIndexSearchRate
+	metricSqlserverKillConnectionErrorRate                     metricSqlserverKillConnectionErrorRate
+	metricSqlserverLatchSuperlatchCount                        metricSqlserverLatchSuperlatchCount
+	metricSqlserverLatchSuperlatchTransitionRate               metricSqlserverLatchSuperlatchTransitionRate
+	metricSqlserverLatchWaitRate                               metricSqlserverLatchWaitRate
+	metricSqlserverLatchWaitTimeAvg                            metricSqlserverLatchWaitTimeAvg
+	metricSqlserverLatchWaitTimeTotal                          metricSqlserverLatchWaitTimeTotal
+	metricSqlserverLockByModeCount                             metricSqlserverLockByModeCount
+	metricSqlserverLockByResourceCount                         metricSqlserverLockByResourceCount
+	metricSqlserverLockTimeoutRate                             metricSqlserverLockTimeoutRate
+	metricSqlserverLockWaitCount                               metricSqlserverLockWaitCount
+	metricSqlserverLockWaitRate                                metricSqlserverLockWaitRate
+	metricSqlserverLockWaitTimeAvg                             metricSqlserverLockWaitTimeAvg
+	metricSqlserverLoginRate                                   metricSqlserverLoginRate
+	metricSqlserverLogoutRate                                  metricSqlserverLogoutRate
+	metricSqlserverMemoryArea                                  metricSqlserverMemoryArea
+	metricSqlserverMemoryCacheObjectCount                      metricSqlserverMemoryCacheObjectCount
+	metricSqlserverMemoryGrantsPendingCount                    metricSqlserverMemoryGrantsPendingCount
+	metricSqlserverMemoryPageCount                             metricSqlserverMemoryPageCount
+	metricSqlserverMemoryTarget                                metricSqlserverMemoryTarget
+	metricSqlserverMemoryUsage                                 metricSqlserverMemoryUsage
+	metricSqlserverOsDiskSize                                  metricSqlserverOsDiskSize
+	metricSqlserverOsMemoryUsage                               metricSqlserverOsMemoryUsage
+	metricSqlserverOsMemoryUtilization                         metricSqlserverOsMemoryUtilization
+	metricSqlserverOsSchedulerRunnableTasksCount               metricSqlserverOsSchedulerRunnableTasksCount
+	metricSqlserverOsWaitDuration                              metricSqlserverOsWaitDuration
+	metricSqlserverOsWaitTasksCount                            metricSqlserverOsWaitTasksCount
+	metricSqlserverPageBufferCacheFreeListStallsRate           metricSqlserverPageBufferCacheFreeListStallsRate
+	metricSqlserverPageBufferCacheHitRatio                     metricSqlserverPageBufferCacheHitRatio
+	metricSqlserverPageCheckpointFlushRate                     metricSqlserverPageCheckpointFlushRate
+	metricSqlserverPageLazyWriteRate                           metricSqlserverPageLazyWriteRate
+	metricSqlserverPageLifeExpectancy                          metricSqlserverPageLifeExpectancy
+	metricSqlserverPageLookupRate                              metricSqlserverPageLookupRate
+	metricSqlserverPageOperationRate                           metricSqlserverPageOperationRate
+	metricSqlserverPageSplitRate                               metricSqlserverPageSplitRate
+	metricSqlserverParameterizationRate                        metricSqlserverParameterizationRate
+	metricSqlserverPlanExecutionRate                           metricSqlserverPlanExecutionRate
+	metricSqlserverProcessCount                                metricSqlserverProcessCount
+	metricSqlserverProcessesBlocked                            metricSqlserverProcessesBlocked
+	metricSqlserverRecompilationRatio                          metricSqlserverRecompilationRatio
+	metricSqlserverReplicaDataRate                             metricSqlserverReplicaDataRate
+	metricSqlserverResourcePoolDiskOperations                  metricSqlserverResourcePoolDiskOperations
+	metricSqlserverResourcePoolDiskThrottledReadRate           metricSqlserverResourcePoolDiskThrottledReadRate
+	metricSqlserverResourcePoolDiskThrottledWriteRate          metricSqlserverResourcePoolDiskThrottledWriteRate
+	metricSqlserverServerSecurityPrincipalCount                metricSqlserverServerSecurityPrincipalCount
+	metricSqlserverServerSecurityRoleMembershipCount           metricSqlserverServerSecurityRoleMembershipCount
+	metricSqlserverTableCount                                  metricSqlserverTableCount
+	metricSqlserverTempdbAllocationWaitTimeTotal               metricSqlserverTempdbAllocationWaitTimeTotal
+	metricSqlserverTempdbContentionWaitersCount                metricSqlserverTempdbContentionWaitersCount
+	metricSqlserverTempdbDataFilesCount                        metricSqlserverTempdbDataFilesCount
+	metricSqlserverTempdbFileSize                              metricSqlserverTempdbFileSize
+	metricSqlserverTempdbSpaceUsage                            metricSqlserverTempdbSpaceUsage
+	metricSqlserverThreadPoolTasksCount                        metricSqlserverThreadPoolTasksCount
+	metricSqlserverThreadPoolWorkersCount                      metricSqlserverThreadPoolWorkersCount
+	metricSqlserverThreadPoolWorkersMax                        metricSqlserverThreadPoolWorkersMax
+	metricSqlserverThreadPoolWorkersUtilization                metricSqlserverThreadPoolWorkersUtilization
+	metricSqlserverTransactionDelay                            metricSqlserverTransactionDelay
+	metricSqlserverTransactionLongestRunningTime               metricSqlserverTransactionLongestRunningTime
+	metricSqlserverTransactionMirrorWriteRate                  metricSqlserverTransactionMirrorWriteRate
+	metricSqlserverTransactionRate                             metricSqlserverTransactionRate
+	metricSqlserverTransactionVersionCleanupRate               metricSqlserverTransactionVersionCleanupRate
+	metricSqlserverTransactionVersionGenerationRate            metricSqlserverTransactionVersionGenerationRate
+	metricSqlserverTransactionWriteRate                        metricSqlserverTransactionWriteRate
+	metricSqlserverTransactionLogFlushDataRate                 metricSqlserverTransactionLogFlushDataRate
+	metricSqlserverTransactionLogFlushRate                     metricSqlserverTransactionLogFlushRate
+	metricSqlserverTransactionLogFlushWaitRate                 metricSqlserverTransactionLogFlushWaitRate
+	metricSqlserverTransactionLogGrowthCount                   metricSqlserverTransactionLogGrowthCount
+	metricSqlserverTransactionLogShrinkCount                   metricSqlserverTransactionLogShrinkCount
+	metricSqlserverTransactionLogUsage                         metricSqlserverTransactionLogUsage
+	metricSqlserverUserConnectionCount                         metricSqlserverUserConnectionCount
 }
 
 // MetricBuilderOption applies changes to default metrics builder.
@@ -5940,85 +9121,116 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricsBuffer:                pmetric.NewMetrics(),
 		buildInfo:                    settings.BuildInfo,
 		metricSqlserverAttentionRate: newMetricSqlserverAttentionRate(mbc.Metrics.SqlserverAttentionRate),
-		metricSqlserverBatchCompilationUtilization:         newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
-		metricSqlserverBatchPageSplitUtilization:           newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
-		metricSqlserverBatchRequestRate:                    newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
-		metricSqlserverBatchSQLCompilationRate:             newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
-		metricSqlserverBatchSQLRecompilationRate:           newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
-		metricSqlserverComputerUptime:                      newMetricSqlserverComputerUptime(mbc.Metrics.SqlserverComputerUptime),
-		metricSqlserverCPUCount:                            newMetricSqlserverCPUCount(mbc.Metrics.SqlserverCPUCount),
-		metricSqlserverDatabaseBackupOrRestoreRate:         newMetricSqlserverDatabaseBackupOrRestoreRate(mbc.Metrics.SqlserverDatabaseBackupOrRestoreRate),
-		metricSqlserverDatabaseCount:                       newMetricSqlserverDatabaseCount(mbc.Metrics.SqlserverDatabaseCount),
-		metricSqlserverDatabaseExecutionErrors:             newMetricSqlserverDatabaseExecutionErrors(mbc.Metrics.SqlserverDatabaseExecutionErrors),
-		metricSqlserverDatabaseFileSize:                    newMetricSqlserverDatabaseFileSize(mbc.Metrics.SqlserverDatabaseFileSize),
-		metricSqlserverDatabaseFullScanRate:                newMetricSqlserverDatabaseFullScanRate(mbc.Metrics.SqlserverDatabaseFullScanRate),
-		metricSqlserverDatabaseIo:                          newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
-		metricSqlserverDatabaseLatency:                     newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
-		metricSqlserverDatabaseOperations:                  newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
-		metricSqlserverDatabasePageFileSize:                newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
-		metricSqlserverDatabaseSecurityRoleMembershipCount: newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
-		metricSqlserverDatabaseTempdbSpace:                 newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
-		metricSqlserverDatabaseTempdbVersionStoreSize:      newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
-		metricSqlserverDatabaseTransactionsActive:          newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
-		metricSqlserverDeadlockRate:                        newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
-		metricSqlserverIndexSearchRate:                     newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
-		metricSqlserverKillConnectionErrorRate:             newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
-		metricSqlserverLatchSuperlatchCount:                newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
-		metricSqlserverLatchSuperlatchTransitionRate:       newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
-		metricSqlserverLatchWaitRate:                       newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
-		metricSqlserverLatchWaitTimeAvg:                    newMetricSqlserverLatchWaitTimeAvg(mbc.Metrics.SqlserverLatchWaitTimeAvg),
-		metricSqlserverLatchWaitTimeTotal:                  newMetricSqlserverLatchWaitTimeTotal(mbc.Metrics.SqlserverLatchWaitTimeTotal),
-		metricSqlserverLockTimeoutRate:                     newMetricSqlserverLockTimeoutRate(mbc.Metrics.SqlserverLockTimeoutRate),
-		metricSqlserverLockWaitCount:                       newMetricSqlserverLockWaitCount(mbc.Metrics.SqlserverLockWaitCount),
-		metricSqlserverLockWaitRate:                        newMetricSqlserverLockWaitRate(mbc.Metrics.SqlserverLockWaitRate),
-		metricSqlserverLockWaitTimeAvg:                     newMetricSqlserverLockWaitTimeAvg(mbc.Metrics.SqlserverLockWaitTimeAvg),
-		metricSqlserverLoginRate:                           newMetricSqlserverLoginRate(mbc.Metrics.SqlserverLoginRate),
-		metricSqlserverLogoutRate:                          newMetricSqlserverLogoutRate(mbc.Metrics.SqlserverLogoutRate),
-		metricSqlserverMemoryArea:                          newMetricSqlserverMemoryArea(mbc.Metrics.SqlserverMemoryArea),
-		metricSqlserverMemoryCacheObjectCount:              newMetricSqlserverMemoryCacheObjectCount(mbc.Metrics.SqlserverMemoryCacheObjectCount),
-		metricSqlserverMemoryGrantsPendingCount:            newMetricSqlserverMemoryGrantsPendingCount(mbc.Metrics.SqlserverMemoryGrantsPendingCount),
-		metricSqlserverMemoryPageCount:                     newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
-		metricSqlserverMemoryTarget:                        newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
-		metricSqlserverMemoryUsage:                         newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
-		metricSqlserverOsDiskSize:                          newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
-		metricSqlserverOsMemoryUsage:                       newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
-		metricSqlserverOsMemoryUtilization:                 newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
-		metricSqlserverOsSchedulerRunnableTasksCount:       newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
-		metricSqlserverOsWaitDuration:                      newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
-		metricSqlserverOsWaitTasksCount:                    newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
-		metricSqlserverPageBufferCacheFreeListStallsRate:   newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
-		metricSqlserverPageBufferCacheHitRatio:             newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
-		metricSqlserverPageCheckpointFlushRate:             newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
-		metricSqlserverPageLazyWriteRate:                   newMetricSqlserverPageLazyWriteRate(mbc.Metrics.SqlserverPageLazyWriteRate),
-		metricSqlserverPageLifeExpectancy:                  newMetricSqlserverPageLifeExpectancy(mbc.Metrics.SqlserverPageLifeExpectancy),
-		metricSqlserverPageLookupRate:                      newMetricSqlserverPageLookupRate(mbc.Metrics.SqlserverPageLookupRate),
-		metricSqlserverPageOperationRate:                   newMetricSqlserverPageOperationRate(mbc.Metrics.SqlserverPageOperationRate),
-		metricSqlserverPageSplitRate:                       newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
-		metricSqlserverParameterizationRate:                newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
-		metricSqlserverPlanExecutionRate:                   newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
-		metricSqlserverProcessCount:                        newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
-		metricSqlserverProcessesBlocked:                    newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
-		metricSqlserverRecompilationRatio:                  newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
-		metricSqlserverReplicaDataRate:                     newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
-		metricSqlserverResourcePoolDiskOperations:          newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
-		metricSqlserverResourcePoolDiskThrottledReadRate:   newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
-		metricSqlserverResourcePoolDiskThrottledWriteRate:  newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
-		metricSqlserverServerSecurityPrincipalCount:        newMetricSqlserverServerSecurityPrincipalCount(mbc.Metrics.SqlserverServerSecurityPrincipalCount),
-		metricSqlserverServerSecurityRoleMembershipCount:   newMetricSqlserverServerSecurityRoleMembershipCount(mbc.Metrics.SqlserverServerSecurityRoleMembershipCount),
-		metricSqlserverTableCount:                          newMetricSqlserverTableCount(mbc.Metrics.SqlserverTableCount),
-		metricSqlserverTransactionDelay:                    newMetricSqlserverTransactionDelay(mbc.Metrics.SqlserverTransactionDelay),
-		metricSqlserverTransactionMirrorWriteRate:          newMetricSqlserverTransactionMirrorWriteRate(mbc.Metrics.SqlserverTransactionMirrorWriteRate),
-		metricSqlserverTransactionRate:                     newMetricSqlserverTransactionRate(mbc.Metrics.SqlserverTransactionRate),
-		metricSqlserverTransactionWriteRate:                newMetricSqlserverTransactionWriteRate(mbc.Metrics.SqlserverTransactionWriteRate),
-		metricSqlserverTransactionLogFlushDataRate:         newMetricSqlserverTransactionLogFlushDataRate(mbc.Metrics.SqlserverTransactionLogFlushDataRate),
-		metricSqlserverTransactionLogFlushRate:             newMetricSqlserverTransactionLogFlushRate(mbc.Metrics.SqlserverTransactionLogFlushRate),
-		metricSqlserverTransactionLogFlushWaitRate:         newMetricSqlserverTransactionLogFlushWaitRate(mbc.Metrics.SqlserverTransactionLogFlushWaitRate),
-		metricSqlserverTransactionLogGrowthCount:           newMetricSqlserverTransactionLogGrowthCount(mbc.Metrics.SqlserverTransactionLogGrowthCount),
-		metricSqlserverTransactionLogShrinkCount:           newMetricSqlserverTransactionLogShrinkCount(mbc.Metrics.SqlserverTransactionLogShrinkCount),
-		metricSqlserverTransactionLogUsage:                 newMetricSqlserverTransactionLogUsage(mbc.Metrics.SqlserverTransactionLogUsage),
-		metricSqlserverUserConnectionCount:                 newMetricSqlserverUserConnectionCount(mbc.Metrics.SqlserverUserConnectionCount),
-		resourceAttributeIncludeFilter:                     make(map[string]filter.Filter),
-		resourceAttributeExcludeFilter:                     make(map[string]filter.Filter),
+		metricSqlserverBatchCompilationUtilization:                 newMetricSqlserverBatchCompilationUtilization(mbc.Metrics.SqlserverBatchCompilationUtilization),
+		metricSqlserverBatchPageSplitUtilization:                   newMetricSqlserverBatchPageSplitUtilization(mbc.Metrics.SqlserverBatchPageSplitUtilization),
+		metricSqlserverBatchRequestRate:                            newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
+		metricSqlserverBatchSQLCompilationRate:                     newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
+		metricSqlserverBatchSQLRecompilationRate:                   newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
+		metricSqlserverComputerUptime:                              newMetricSqlserverComputerUptime(mbc.Metrics.SqlserverComputerUptime),
+		metricSqlserverCPUCount:                                    newMetricSqlserverCPUCount(mbc.Metrics.SqlserverCPUCount),
+		metricSqlserverDatabaseBackupOrRestoreRate:                 newMetricSqlserverDatabaseBackupOrRestoreRate(mbc.Metrics.SqlserverDatabaseBackupOrRestoreRate),
+		metricSqlserverDatabaseCount:                               newMetricSqlserverDatabaseCount(mbc.Metrics.SqlserverDatabaseCount),
+		metricSqlserverDatabaseExecutionErrors:                     newMetricSqlserverDatabaseExecutionErrors(mbc.Metrics.SqlserverDatabaseExecutionErrors),
+		metricSqlserverDatabaseFileSize:                            newMetricSqlserverDatabaseFileSize(mbc.Metrics.SqlserverDatabaseFileSize),
+		metricSqlserverDatabaseFullScanRate:                        newMetricSqlserverDatabaseFullScanRate(mbc.Metrics.SqlserverDatabaseFullScanRate),
+		metricSqlserverDatabaseIo:                                  newMetricSqlserverDatabaseIo(mbc.Metrics.SqlserverDatabaseIo),
+		metricSqlserverDatabaseLatency:                             newMetricSqlserverDatabaseLatency(mbc.Metrics.SqlserverDatabaseLatency),
+		metricSqlserverDatabaseOperations:                          newMetricSqlserverDatabaseOperations(mbc.Metrics.SqlserverDatabaseOperations),
+		metricSqlserverDatabasePageFileSize:                        newMetricSqlserverDatabasePageFileSize(mbc.Metrics.SqlserverDatabasePageFileSize),
+		metricSqlserverDatabasePrincipalsCount:                     newMetricSqlserverDatabasePrincipalsCount(mbc.Metrics.SqlserverDatabasePrincipalsCount),
+		metricSqlserverDatabasePrincipalsOld:                       newMetricSqlserverDatabasePrincipalsOld(mbc.Metrics.SqlserverDatabasePrincipalsOld),
+		metricSqlserverDatabasePrincipalsOrphanedUsers:             newMetricSqlserverDatabasePrincipalsOrphanedUsers(mbc.Metrics.SqlserverDatabasePrincipalsOrphanedUsers),
+		metricSqlserverDatabasePrincipalsRecentlyCreated:           newMetricSqlserverDatabasePrincipalsRecentlyCreated(mbc.Metrics.SqlserverDatabasePrincipalsRecentlyCreated),
+		metricSqlserverDatabaseRoleMembersCount:                    newMetricSqlserverDatabaseRoleMembersCount(mbc.Metrics.SqlserverDatabaseRoleMembersCount),
+		metricSqlserverDatabaseRoleMembershipsCount:                newMetricSqlserverDatabaseRoleMembershipsCount(mbc.Metrics.SqlserverDatabaseRoleMembershipsCount),
+		metricSqlserverDatabaseRolePermissionRiskLevel:             newMetricSqlserverDatabaseRolePermissionRiskLevel(mbc.Metrics.SqlserverDatabaseRolePermissionRiskLevel),
+		metricSqlserverDatabaseRoleRolesCount:                      newMetricSqlserverDatabaseRoleRolesCount(mbc.Metrics.SqlserverDatabaseRoleRolesCount),
+		metricSqlserverDatabaseSecurityRoleMembershipCount:         newMetricSqlserverDatabaseSecurityRoleMembershipCount(mbc.Metrics.SqlserverDatabaseSecurityRoleMembershipCount),
+		metricSqlserverDatabaseTempdbSpace:                         newMetricSqlserverDatabaseTempdbSpace(mbc.Metrics.SqlserverDatabaseTempdbSpace),
+		metricSqlserverDatabaseTempdbVersionStoreSize:              newMetricSqlserverDatabaseTempdbVersionStoreSize(mbc.Metrics.SqlserverDatabaseTempdbVersionStoreSize),
+		metricSqlserverDatabaseTransactionsActive:                  newMetricSqlserverDatabaseTransactionsActive(mbc.Metrics.SqlserverDatabaseTransactionsActive),
+		metricSqlserverDeadlockRate:                                newMetricSqlserverDeadlockRate(mbc.Metrics.SqlserverDeadlockRate),
+		metricSqlserverFailoverClusterAgClusterType:                newMetricSqlserverFailoverClusterAgClusterType(mbc.Metrics.SqlserverFailoverClusterAgClusterType),
+		metricSqlserverFailoverClusterAgFailureConditionLevel:      newMetricSqlserverFailoverClusterAgFailureConditionLevel(mbc.Metrics.SqlserverFailoverClusterAgFailureConditionLevel),
+		metricSqlserverFailoverClusterAgHealthCheckTimeout:         newMetricSqlserverFailoverClusterAgHealthCheckTimeout(mbc.Metrics.SqlserverFailoverClusterAgHealthCheckTimeout),
+		metricSqlserverFailoverClusterAgRequiredSyncSecondaries:    newMetricSqlserverFailoverClusterAgRequiredSyncSecondaries(mbc.Metrics.SqlserverFailoverClusterAgRequiredSyncSecondaries),
+		metricSqlserverFailoverClusterReplicaDatabaseQueueSize:     newMetricSqlserverFailoverClusterReplicaDatabaseQueueSize(mbc.Metrics.SqlserverFailoverClusterReplicaDatabaseQueueSize),
+		metricSqlserverFailoverClusterReplicaDatabaseRedoRate:      newMetricSqlserverFailoverClusterReplicaDatabaseRedoRate(mbc.Metrics.SqlserverFailoverClusterReplicaDatabaseRedoRate),
+		metricSqlserverFailoverClusterReplicaFlowControlTime:       newMetricSqlserverFailoverClusterReplicaFlowControlTime(mbc.Metrics.SqlserverFailoverClusterReplicaFlowControlTime),
+		metricSqlserverFailoverClusterReplicaRole:                  newMetricSqlserverFailoverClusterReplicaRole(mbc.Metrics.SqlserverFailoverClusterReplicaRole),
+		metricSqlserverFailoverClusterReplicaSynchronizationHealth: newMetricSqlserverFailoverClusterReplicaSynchronizationHealth(mbc.Metrics.SqlserverFailoverClusterReplicaSynchronizationHealth),
+		metricSqlserverIndexSearchRate:                             newMetricSqlserverIndexSearchRate(mbc.Metrics.SqlserverIndexSearchRate),
+		metricSqlserverKillConnectionErrorRate:                     newMetricSqlserverKillConnectionErrorRate(mbc.Metrics.SqlserverKillConnectionErrorRate),
+		metricSqlserverLatchSuperlatchCount:                        newMetricSqlserverLatchSuperlatchCount(mbc.Metrics.SqlserverLatchSuperlatchCount),
+		metricSqlserverLatchSuperlatchTransitionRate:               newMetricSqlserverLatchSuperlatchTransitionRate(mbc.Metrics.SqlserverLatchSuperlatchTransitionRate),
+		metricSqlserverLatchWaitRate:                               newMetricSqlserverLatchWaitRate(mbc.Metrics.SqlserverLatchWaitRate),
+		metricSqlserverLatchWaitTimeAvg:                            newMetricSqlserverLatchWaitTimeAvg(mbc.Metrics.SqlserverLatchWaitTimeAvg),
+		metricSqlserverLatchWaitTimeTotal:                          newMetricSqlserverLatchWaitTimeTotal(mbc.Metrics.SqlserverLatchWaitTimeTotal),
+		metricSqlserverLockByModeCount:                             newMetricSqlserverLockByModeCount(mbc.Metrics.SqlserverLockByModeCount),
+		metricSqlserverLockByResourceCount:                         newMetricSqlserverLockByResourceCount(mbc.Metrics.SqlserverLockByResourceCount),
+		metricSqlserverLockTimeoutRate:                             newMetricSqlserverLockTimeoutRate(mbc.Metrics.SqlserverLockTimeoutRate),
+		metricSqlserverLockWaitCount:                               newMetricSqlserverLockWaitCount(mbc.Metrics.SqlserverLockWaitCount),
+		metricSqlserverLockWaitRate:                                newMetricSqlserverLockWaitRate(mbc.Metrics.SqlserverLockWaitRate),
+		metricSqlserverLockWaitTimeAvg:                             newMetricSqlserverLockWaitTimeAvg(mbc.Metrics.SqlserverLockWaitTimeAvg),
+		metricSqlserverLoginRate:                                   newMetricSqlserverLoginRate(mbc.Metrics.SqlserverLoginRate),
+		metricSqlserverLogoutRate:                                  newMetricSqlserverLogoutRate(mbc.Metrics.SqlserverLogoutRate),
+		metricSqlserverMemoryArea:                                  newMetricSqlserverMemoryArea(mbc.Metrics.SqlserverMemoryArea),
+		metricSqlserverMemoryCacheObjectCount:                      newMetricSqlserverMemoryCacheObjectCount(mbc.Metrics.SqlserverMemoryCacheObjectCount),
+		metricSqlserverMemoryGrantsPendingCount:                    newMetricSqlserverMemoryGrantsPendingCount(mbc.Metrics.SqlserverMemoryGrantsPendingCount),
+		metricSqlserverMemoryPageCount:                             newMetricSqlserverMemoryPageCount(mbc.Metrics.SqlserverMemoryPageCount),
+		metricSqlserverMemoryTarget:                                newMetricSqlserverMemoryTarget(mbc.Metrics.SqlserverMemoryTarget),
+		metricSqlserverMemoryUsage:                                 newMetricSqlserverMemoryUsage(mbc.Metrics.SqlserverMemoryUsage),
+		metricSqlserverOsDiskSize:                                  newMetricSqlserverOsDiskSize(mbc.Metrics.SqlserverOsDiskSize),
+		metricSqlserverOsMemoryUsage:                               newMetricSqlserverOsMemoryUsage(mbc.Metrics.SqlserverOsMemoryUsage),
+		metricSqlserverOsMemoryUtilization:                         newMetricSqlserverOsMemoryUtilization(mbc.Metrics.SqlserverOsMemoryUtilization),
+		metricSqlserverOsSchedulerRunnableTasksCount:               newMetricSqlserverOsSchedulerRunnableTasksCount(mbc.Metrics.SqlserverOsSchedulerRunnableTasksCount),
+		metricSqlserverOsWaitDuration:                              newMetricSqlserverOsWaitDuration(mbc.Metrics.SqlserverOsWaitDuration),
+		metricSqlserverOsWaitTasksCount:                            newMetricSqlserverOsWaitTasksCount(mbc.Metrics.SqlserverOsWaitTasksCount),
+		metricSqlserverPageBufferCacheFreeListStallsRate:           newMetricSqlserverPageBufferCacheFreeListStallsRate(mbc.Metrics.SqlserverPageBufferCacheFreeListStallsRate),
+		metricSqlserverPageBufferCacheHitRatio:                     newMetricSqlserverPageBufferCacheHitRatio(mbc.Metrics.SqlserverPageBufferCacheHitRatio),
+		metricSqlserverPageCheckpointFlushRate:                     newMetricSqlserverPageCheckpointFlushRate(mbc.Metrics.SqlserverPageCheckpointFlushRate),
+		metricSqlserverPageLazyWriteRate:                           newMetricSqlserverPageLazyWriteRate(mbc.Metrics.SqlserverPageLazyWriteRate),
+		metricSqlserverPageLifeExpectancy:                          newMetricSqlserverPageLifeExpectancy(mbc.Metrics.SqlserverPageLifeExpectancy),
+		metricSqlserverPageLookupRate:                              newMetricSqlserverPageLookupRate(mbc.Metrics.SqlserverPageLookupRate),
+		metricSqlserverPageOperationRate:                           newMetricSqlserverPageOperationRate(mbc.Metrics.SqlserverPageOperationRate),
+		metricSqlserverPageSplitRate:                               newMetricSqlserverPageSplitRate(mbc.Metrics.SqlserverPageSplitRate),
+		metricSqlserverParameterizationRate:                        newMetricSqlserverParameterizationRate(mbc.Metrics.SqlserverParameterizationRate),
+		metricSqlserverPlanExecutionRate:                           newMetricSqlserverPlanExecutionRate(mbc.Metrics.SqlserverPlanExecutionRate),
+		metricSqlserverProcessCount:                                newMetricSqlserverProcessCount(mbc.Metrics.SqlserverProcessCount),
+		metricSqlserverProcessesBlocked:                            newMetricSqlserverProcessesBlocked(mbc.Metrics.SqlserverProcessesBlocked),
+		metricSqlserverRecompilationRatio:                          newMetricSqlserverRecompilationRatio(mbc.Metrics.SqlserverRecompilationRatio),
+		metricSqlserverReplicaDataRate:                             newMetricSqlserverReplicaDataRate(mbc.Metrics.SqlserverReplicaDataRate),
+		metricSqlserverResourcePoolDiskOperations:                  newMetricSqlserverResourcePoolDiskOperations(mbc.Metrics.SqlserverResourcePoolDiskOperations),
+		metricSqlserverResourcePoolDiskThrottledReadRate:           newMetricSqlserverResourcePoolDiskThrottledReadRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledReadRate),
+		metricSqlserverResourcePoolDiskThrottledWriteRate:          newMetricSqlserverResourcePoolDiskThrottledWriteRate(mbc.Metrics.SqlserverResourcePoolDiskThrottledWriteRate),
+		metricSqlserverServerSecurityPrincipalCount:                newMetricSqlserverServerSecurityPrincipalCount(mbc.Metrics.SqlserverServerSecurityPrincipalCount),
+		metricSqlserverServerSecurityRoleMembershipCount:           newMetricSqlserverServerSecurityRoleMembershipCount(mbc.Metrics.SqlserverServerSecurityRoleMembershipCount),
+		metricSqlserverTableCount:                                  newMetricSqlserverTableCount(mbc.Metrics.SqlserverTableCount),
+		metricSqlserverTempdbAllocationWaitTimeTotal:               newMetricSqlserverTempdbAllocationWaitTimeTotal(mbc.Metrics.SqlserverTempdbAllocationWaitTimeTotal),
+		metricSqlserverTempdbContentionWaitersCount:                newMetricSqlserverTempdbContentionWaitersCount(mbc.Metrics.SqlserverTempdbContentionWaitersCount),
+		metricSqlserverTempdbDataFilesCount:                        newMetricSqlserverTempdbDataFilesCount(mbc.Metrics.SqlserverTempdbDataFilesCount),
+		metricSqlserverTempdbFileSize:                              newMetricSqlserverTempdbFileSize(mbc.Metrics.SqlserverTempdbFileSize),
+		metricSqlserverTempdbSpaceUsage:                            newMetricSqlserverTempdbSpaceUsage(mbc.Metrics.SqlserverTempdbSpaceUsage),
+		metricSqlserverThreadPoolTasksCount:                        newMetricSqlserverThreadPoolTasksCount(mbc.Metrics.SqlserverThreadPoolTasksCount),
+		metricSqlserverThreadPoolWorkersCount:                      newMetricSqlserverThreadPoolWorkersCount(mbc.Metrics.SqlserverThreadPoolWorkersCount),
+		metricSqlserverThreadPoolWorkersMax:                        newMetricSqlserverThreadPoolWorkersMax(mbc.Metrics.SqlserverThreadPoolWorkersMax),
+		metricSqlserverThreadPoolWorkersUtilization:                newMetricSqlserverThreadPoolWorkersUtilization(mbc.Metrics.SqlserverThreadPoolWorkersUtilization),
+		metricSqlserverTransactionDelay:                            newMetricSqlserverTransactionDelay(mbc.Metrics.SqlserverTransactionDelay),
+		metricSqlserverTransactionLongestRunningTime:               newMetricSqlserverTransactionLongestRunningTime(mbc.Metrics.SqlserverTransactionLongestRunningTime),
+		metricSqlserverTransactionMirrorWriteRate:                  newMetricSqlserverTransactionMirrorWriteRate(mbc.Metrics.SqlserverTransactionMirrorWriteRate),
+		metricSqlserverTransactionRate:                             newMetricSqlserverTransactionRate(mbc.Metrics.SqlserverTransactionRate),
+		metricSqlserverTransactionVersionCleanupRate:               newMetricSqlserverTransactionVersionCleanupRate(mbc.Metrics.SqlserverTransactionVersionCleanupRate),
+		metricSqlserverTransactionVersionGenerationRate:            newMetricSqlserverTransactionVersionGenerationRate(mbc.Metrics.SqlserverTransactionVersionGenerationRate),
+		metricSqlserverTransactionWriteRate:                        newMetricSqlserverTransactionWriteRate(mbc.Metrics.SqlserverTransactionWriteRate),
+		metricSqlserverTransactionLogFlushDataRate:                 newMetricSqlserverTransactionLogFlushDataRate(mbc.Metrics.SqlserverTransactionLogFlushDataRate),
+		metricSqlserverTransactionLogFlushRate:                     newMetricSqlserverTransactionLogFlushRate(mbc.Metrics.SqlserverTransactionLogFlushRate),
+		metricSqlserverTransactionLogFlushWaitRate:                 newMetricSqlserverTransactionLogFlushWaitRate(mbc.Metrics.SqlserverTransactionLogFlushWaitRate),
+		metricSqlserverTransactionLogGrowthCount:                   newMetricSqlserverTransactionLogGrowthCount(mbc.Metrics.SqlserverTransactionLogGrowthCount),
+		metricSqlserverTransactionLogShrinkCount:                   newMetricSqlserverTransactionLogShrinkCount(mbc.Metrics.SqlserverTransactionLogShrinkCount),
+		metricSqlserverTransactionLogUsage:                         newMetricSqlserverTransactionLogUsage(mbc.Metrics.SqlserverTransactionLogUsage),
+		metricSqlserverUserConnectionCount:                         newMetricSqlserverUserConnectionCount(mbc.Metrics.SqlserverUserConnectionCount),
+		resourceAttributeIncludeFilter:                             make(map[string]filter.Filter),
+		resourceAttributeExcludeFilter:                             make(map[string]filter.Filter),
 	}
 	if mbc.ResourceAttributes.HostName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["host.name"] = filter.CreateFilter(mbc.ResourceAttributes.HostName.MetricsInclude)
@@ -6160,11 +9372,28 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverDatabaseLatency.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseOperations.emit(ils.Metrics())
 	mb.metricSqlserverDatabasePageFileSize.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsOld.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsOrphanedUsers.emit(ils.Metrics())
+	mb.metricSqlserverDatabasePrincipalsRecentlyCreated.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleMembersCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleMembershipsCount.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRolePermissionRiskLevel.emit(ils.Metrics())
+	mb.metricSqlserverDatabaseRoleRolesCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbSpace.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTempdbVersionStoreSize.emit(ils.Metrics())
 	mb.metricSqlserverDatabaseTransactionsActive.emit(ils.Metrics())
 	mb.metricSqlserverDeadlockRate.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgClusterType.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgFailureConditionLevel.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaFlowControlTime.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaRole.emit(ils.Metrics())
+	mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.emit(ils.Metrics())
 	mb.metricSqlserverIndexSearchRate.emit(ils.Metrics())
 	mb.metricSqlserverKillConnectionErrorRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchSuperlatchCount.emit(ils.Metrics())
@@ -6172,6 +9401,8 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverLatchWaitRate.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitTimeAvg.emit(ils.Metrics())
 	mb.metricSqlserverLatchWaitTimeTotal.emit(ils.Metrics())
+	mb.metricSqlserverLockByModeCount.emit(ils.Metrics())
+	mb.metricSqlserverLockByResourceCount.emit(ils.Metrics())
 	mb.metricSqlserverLockTimeoutRate.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitCount.emit(ils.Metrics())
 	mb.metricSqlserverLockWaitRate.emit(ils.Metrics())
@@ -6210,9 +9441,21 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricSqlserverServerSecurityPrincipalCount.emit(ils.Metrics())
 	mb.metricSqlserverServerSecurityRoleMembershipCount.emit(ils.Metrics())
 	mb.metricSqlserverTableCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbAllocationWaitTimeTotal.emit(ils.Metrics())
+	mb.metricSqlserverTempdbContentionWaitersCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbDataFilesCount.emit(ils.Metrics())
+	mb.metricSqlserverTempdbFileSize.emit(ils.Metrics())
+	mb.metricSqlserverTempdbSpaceUsage.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolTasksCount.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersCount.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersMax.emit(ils.Metrics())
+	mb.metricSqlserverThreadPoolWorkersUtilization.emit(ils.Metrics())
 	mb.metricSqlserverTransactionDelay.emit(ils.Metrics())
+	mb.metricSqlserverTransactionLongestRunningTime.emit(ils.Metrics())
 	mb.metricSqlserverTransactionMirrorWriteRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionRate.emit(ils.Metrics())
+	mb.metricSqlserverTransactionVersionCleanupRate.emit(ils.Metrics())
+	mb.metricSqlserverTransactionVersionGenerationRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionWriteRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionLogFlushDataRate.emit(ils.Metrics())
 	mb.metricSqlserverTransactionLogFlushRate.emit(ils.Metrics())
@@ -6372,6 +9615,86 @@ func (mb *MetricsBuilder) RecordSqlserverDatabasePageFileSizeDataPoint(ts pcommo
 	return nil
 }
 
+// RecordSqlserverDatabasePrincipalsCountDataPoint adds a data point to sqlserver.database.principals.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, principalTypeAttributeValue AttributePrincipalType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, principalTypeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsOldDataPoint adds a data point to sqlserver.database.principals.old metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsOldDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsOld, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsOld.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint adds a data point to sqlserver.database.principals.orphaned_users metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsOrphanedUsers, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsOrphanedUsers.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint adds a data point to sqlserver.database.principals.recently_created metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabasePrincipalsRecentlyCreated, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabasePrincipalsRecentlyCreated.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleMembersCountDataPoint adds a data point to sqlserver.database.role.members.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleMembersCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, memberKindAttributeValue AttributeMemberKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleMembersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleMembersCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, memberKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleMembershipsCountDataPoint adds a data point to sqlserver.database.role.memberships.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, membershipKindAttributeValue AttributeMembershipKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleMembershipsCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleMembershipsCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, membershipKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint adds a data point to sqlserver.database.role.permission.risk_level metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRolePermissionRiskLevel, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRolePermissionRiskLevel.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, roleAttributeValue)
+	return nil
+}
+
+// RecordSqlserverDatabaseRoleRolesCountDataPoint adds a data point to sqlserver.database.role.roles.count metric.
+func (mb *MetricsBuilder) RecordSqlserverDatabaseRoleRolesCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleStateAttributeValue AttributeRoleState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverDatabaseRoleRolesCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverDatabaseRoleRolesCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, roleStateAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint adds a data point to sqlserver.database.security.role_membership.count metric.
 func (mb *MetricsBuilder) RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, roleAttributeValue string) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
@@ -6407,6 +9730,86 @@ func (mb *MetricsBuilder) RecordSqlserverDeadlockRateDataPoint(ts pcommon.Timest
 	mb.metricSqlserverDeadlockRate.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordSqlserverFailoverClusterAgClusterTypeDataPoint adds a data point to sqlserver.failover_cluster.ag.cluster_type metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, agClusterTypeAttributeValue AttributeAgClusterType) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgClusterType, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgClusterType.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, agClusterTypeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint adds a data point to sqlserver.failover_cluster.ag.failure_condition_level metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgFailureConditionLevel, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgFailureConditionLevel.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint adds a data point to sqlserver.failover_cluster.ag.health_check_timeout metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgHealthCheckTimeout, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint adds a data point to sqlserver.failover_cluster.ag.required_sync_secondaries metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterAgRequiredSyncSecondaries, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue)
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint adds a data point to sqlserver.failover_cluster.replica.database.queue_size metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string, replicaQueueKindAttributeValue AttributeReplicaQueueKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaDatabaseQueueSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, dbNamespaceAttributeValue, replicaQueueKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint adds a data point to sqlserver.failover_cluster.replica.database.redo.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts pcommon.Timestamp, val float64, agNameAttributeValue string, replicaServerNameAttributeValue string, dbNamespaceAttributeValue string) {
+	mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, dbNamespaceAttributeValue)
+}
+
+// RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint adds a data point to sqlserver.failover_cluster.replica.flow_control_time metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverFailoverClusterReplicaFlowControlTime.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverFailoverClusterReplicaRoleDataPoint adds a data point to sqlserver.failover_cluster.replica.role metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaRoleAttributeValue AttributeReplicaRole) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaRole, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaRole.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, replicaRoleAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint adds a data point to sqlserver.failover_cluster.replica.synchronization_health metric.
+func (mb *MetricsBuilder) RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts pcommon.Timestamp, inputVal string, agNameAttributeValue string, replicaServerNameAttributeValue string, replicaSyncHealthAttributeValue AttributeReplicaSyncHealth) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverFailoverClusterReplicaSynchronizationHealth, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.recordDataPoint(mb.startTime, ts, val, agNameAttributeValue, replicaServerNameAttributeValue, replicaSyncHealthAttributeValue.String())
+	return nil
+}
+
 // RecordSqlserverIndexSearchRateDataPoint adds a data point to sqlserver.index.search.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverIndexSearchRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverIndexSearchRate.recordDataPoint(mb.startTime, ts, val)
@@ -6440,6 +9843,26 @@ func (mb *MetricsBuilder) RecordSqlserverLatchWaitTimeAvgDataPoint(ts pcommon.Ti
 // RecordSqlserverLatchWaitTimeTotalDataPoint adds a data point to sqlserver.latch.wait_time.total metric.
 func (mb *MetricsBuilder) RecordSqlserverLatchWaitTimeTotalDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverLatchWaitTimeTotal.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverLockByModeCountDataPoint adds a data point to sqlserver.lock.by_mode.count metric.
+func (mb *MetricsBuilder) RecordSqlserverLockByModeCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, lockModeAttributeValue AttributeLockMode) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverLockByModeCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverLockByModeCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, lockModeAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverLockByResourceCountDataPoint adds a data point to sqlserver.lock.by_resource.count metric.
+func (mb *MetricsBuilder) RecordSqlserverLockByResourceCountDataPoint(ts pcommon.Timestamp, inputVal string, dbNamespaceAttributeValue string, lockResourceAttributeValue AttributeLockResource) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverLockByResourceCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverLockByResourceCount.recordDataPoint(mb.startTime, ts, val, dbNamespaceAttributeValue, lockResourceAttributeValue.String())
+	return nil
 }
 
 // RecordSqlserverLockTimeoutRateDataPoint adds a data point to sqlserver.lock.timeout.rate metric.
@@ -6687,9 +10110,94 @@ func (mb *MetricsBuilder) RecordSqlserverTableCountDataPoint(ts pcommon.Timestam
 	mb.metricSqlserverTableCount.recordDataPoint(mb.startTime, ts, val, tableStateAttributeValue.String(), tableStatusAttributeValue.String())
 }
 
+// RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint adds a data point to sqlserver.tempdb.allocation.wait_time.total metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts pcommon.Timestamp, val float64, allocationPageTypeAttributeValue AttributeAllocationPageType) {
+	mb.metricSqlserverTempdbAllocationWaitTimeTotal.recordDataPoint(mb.startTime, ts, val, allocationPageTypeAttributeValue.String())
+}
+
+// RecordSqlserverTempdbContentionWaitersCountDataPoint adds a data point to sqlserver.tempdb.contention.waiters.count metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbContentionWaitersCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbContentionWaitersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbContentionWaitersCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverTempdbDataFilesCountDataPoint adds a data point to sqlserver.tempdb.data_files.count metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbDataFilesCountDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbDataFilesCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbDataFilesCount.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverTempdbFileSizeDataPoint adds a data point to sqlserver.tempdb.file.size metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbFileSizeDataPoint(ts pcommon.Timestamp, inputVal string, fileTypeAttributeValue string, tempdbFileIDAttributeValue int64) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbFileSize, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbFileSize.recordDataPoint(mb.startTime, ts, val, fileTypeAttributeValue, tempdbFileIDAttributeValue)
+	return nil
+}
+
+// RecordSqlserverTempdbSpaceUsageDataPoint adds a data point to sqlserver.tempdb.space.usage metric.
+func (mb *MetricsBuilder) RecordSqlserverTempdbSpaceUsageDataPoint(ts pcommon.Timestamp, inputVal string, tempdbSpaceKindAttributeValue AttributeTempdbSpaceKind) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverTempdbSpaceUsage, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverTempdbSpaceUsage.recordDataPoint(mb.startTime, ts, val, tempdbSpaceKindAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolTasksCountDataPoint adds a data point to sqlserver.thread_pool.tasks.count metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolTasksCountDataPoint(ts pcommon.Timestamp, inputVal string, taskStateAttributeValue AttributeTaskState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolTasksCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolTasksCount.recordDataPoint(mb.startTime, ts, val, taskStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersCountDataPoint adds a data point to sqlserver.thread_pool.workers.count metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersCountDataPoint(ts pcommon.Timestamp, inputVal string, workerStateAttributeValue AttributeWorkerState) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolWorkersCount, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolWorkersCount.recordDataPoint(mb.startTime, ts, val, workerStateAttributeValue.String())
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersMaxDataPoint adds a data point to sqlserver.thread_pool.workers.max metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersMaxDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for SqlserverThreadPoolWorkersMax, value was %s: %w", inputVal, err)
+	}
+	mb.metricSqlserverThreadPoolWorkersMax.recordDataPoint(mb.startTime, ts, val)
+	return nil
+}
+
+// RecordSqlserverThreadPoolWorkersUtilizationDataPoint adds a data point to sqlserver.thread_pool.workers.utilization metric.
+func (mb *MetricsBuilder) RecordSqlserverThreadPoolWorkersUtilizationDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverThreadPoolWorkersUtilization.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordSqlserverTransactionDelayDataPoint adds a data point to sqlserver.transaction.delay metric.
 func (mb *MetricsBuilder) RecordSqlserverTransactionDelayDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverTransactionDelay.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionLongestRunningTimeDataPoint adds a data point to sqlserver.transaction.longest_running_time metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionLongestRunningTimeDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionLongestRunningTime.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionMirrorWriteRateDataPoint adds a data point to sqlserver.transaction.mirror_write.rate metric.
@@ -6700,6 +10208,16 @@ func (mb *MetricsBuilder) RecordSqlserverTransactionMirrorWriteRateDataPoint(ts 
 // RecordSqlserverTransactionRateDataPoint adds a data point to sqlserver.transaction.rate metric.
 func (mb *MetricsBuilder) RecordSqlserverTransactionRateDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricSqlserverTransactionRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionVersionCleanupRateDataPoint adds a data point to sqlserver.transaction.version_cleanup.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionVersionCleanupRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionVersionCleanupRate.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSqlserverTransactionVersionGenerationRateDataPoint adds a data point to sqlserver.transaction.version_generation.rate metric.
+func (mb *MetricsBuilder) RecordSqlserverTransactionVersionGenerationRateDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricSqlserverTransactionVersionGenerationRate.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionWriteRateDataPoint adds a data point to sqlserver.transaction.write.rate metric.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -73,10 +73,28 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.database.latency"] = mb.metricSqlserverDatabaseLatency.config.AggregationStrategy
 			aggMap["sqlserver.database.operations"] = mb.metricSqlserverDatabaseOperations.config.AggregationStrategy
 			aggMap["sqlserver.database.page_file.size"] = mb.metricSqlserverDatabasePageFileSize.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.count"] = mb.metricSqlserverDatabasePrincipalsCount.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.old"] = mb.metricSqlserverDatabasePrincipalsOld.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.orphaned_users"] = mb.metricSqlserverDatabasePrincipalsOrphanedUsers.config.AggregationStrategy
+			aggMap["sqlserver.database.principals.recently_created"] = mb.metricSqlserverDatabasePrincipalsRecentlyCreated.config.AggregationStrategy
+			aggMap["sqlserver.database.role.members.count"] = mb.metricSqlserverDatabaseRoleMembersCount.config.AggregationStrategy
+			aggMap["sqlserver.database.role.memberships.count"] = mb.metricSqlserverDatabaseRoleMembershipsCount.config.AggregationStrategy
+			aggMap["sqlserver.database.role.permission.risk_level"] = mb.metricSqlserverDatabaseRolePermissionRiskLevel.config.AggregationStrategy
+			aggMap["sqlserver.database.role.roles.count"] = mb.metricSqlserverDatabaseRoleRolesCount.config.AggregationStrategy
 			aggMap["sqlserver.database.security.role_membership.count"] = mb.metricSqlserverDatabaseSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.database.tempdb.space"] = mb.metricSqlserverDatabaseTempdbSpace.config.AggregationStrategy
 			aggMap["sqlserver.database.transactions.active"] = mb.metricSqlserverDatabaseTransactionsActive.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.cluster_type"] = mb.metricSqlserverFailoverClusterAgClusterType.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.failure_condition_level"] = mb.metricSqlserverFailoverClusterAgFailureConditionLevel.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.health_check_timeout"] = mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.ag.required_sync_secondaries"] = mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.database.queue_size"] = mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.database.redo.rate"] = mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.role"] = mb.metricSqlserverFailoverClusterReplicaRole.config.AggregationStrategy
+			aggMap["sqlserver.failover_cluster.replica.synchronization_health"] = mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.config.AggregationStrategy
 			aggMap["sqlserver.latch.superlatch.transition.rate"] = mb.metricSqlserverLatchSuperlatchTransitionRate.config.AggregationStrategy
+			aggMap["sqlserver.lock.by_mode.count"] = mb.metricSqlserverLockByModeCount.config.AggregationStrategy
+			aggMap["sqlserver.lock.by_resource.count"] = mb.metricSqlserverLockByResourceCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.area"] = mb.metricSqlserverMemoryArea.config.AggregationStrategy
 			aggMap["sqlserver.memory.cache.object.count"] = mb.metricSqlserverMemoryCacheObjectCount.config.AggregationStrategy
 			aggMap["sqlserver.memory.page.count"] = mb.metricSqlserverMemoryPageCount.config.AggregationStrategy
@@ -92,6 +110,11 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["sqlserver.resource_pool.disk.operations"] = mb.metricSqlserverResourcePoolDiskOperations.config.AggregationStrategy
 			aggMap["sqlserver.server.security.role_membership.count"] = mb.metricSqlserverServerSecurityRoleMembershipCount.config.AggregationStrategy
 			aggMap["sqlserver.table.count"] = mb.metricSqlserverTableCount.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.allocation.wait_time.total"] = mb.metricSqlserverTempdbAllocationWaitTimeTotal.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.file.size"] = mb.metricSqlserverTempdbFileSize.config.AggregationStrategy
+			aggMap["sqlserver.tempdb.space.usage"] = mb.metricSqlserverTempdbSpaceUsage.config.AggregationStrategy
+			aggMap["sqlserver.thread_pool.tasks.count"] = mb.metricSqlserverThreadPoolTasksCount.config.AggregationStrategy
+			aggMap["sqlserver.thread_pool.workers.count"] = mb.metricSqlserverThreadPoolWorkersCount.config.AggregationStrategy
 
 			expectedWarnings := 0
 			if tt.metricsSet != testDataSetReag {
@@ -171,6 +194,54 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsCountDataPoint(ts, "1", "db.namespace-val", AttributePrincipalTypeSQLUser)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsCountDataPoint(ts, "3", "db.namespace-val-2", AttributePrincipalTypeWindowsUser)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsOldDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsOldDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts, "1", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(ts, "3", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(ts, "1", "db.namespace-val", AttributeMemberKindAppRole)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(ts, "3", "db.namespace-val-2", AttributeMemberKindCrossRole)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts, "1", "db.namespace-val", AttributeMembershipKindActive)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(ts, "3", "db.namespace-val-2", AttributeMembershipKindCustom)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts, "1", "db.namespace-val", "role-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(ts, "1", "db.namespace-val", AttributeRoleStateEmpty)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(ts, "3", "db.namespace-val-2", AttributeRoleStateWithMembers)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "1", "db.namespace-val", "role-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordSqlserverDatabaseSecurityRoleMembershipCountDataPoint(ts, "3", "db.namespace-val-2", "role-val-2")
@@ -195,6 +266,57 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordSqlserverDeadlockRateDataPoint(ts, 1)
 
 			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts, "1", "ag.name-val", AttributeAgClusterTypeWsfc)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(ts, "3", "ag.name-val-2", AttributeAgClusterTypeExternal)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts, "1", "ag.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(ts, "3", "ag.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", "db.namespace-val", AttributeReplicaQueueKindLogSend)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", "db.namespace-val-2", AttributeReplicaQueueKindRedo)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts, 1, "ag.name-val", "replica.server_name-val", "db.namespace-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(ts, 3, "ag.name-val-2", "replica.server_name-val-2", "db.namespace-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", AttributeReplicaRolePrimary)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", AttributeReplicaRoleSecondary)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts, "1", "ag.name-val", "replica.server_name-val", AttributeReplicaSyncHealthHealthy)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(ts, "3", "ag.name-val-2", "replica.server_name-val-2", AttributeReplicaSyncHealthPartiallyHealthy)
+			}
+
+			allMetricsCount++
 			mb.RecordSqlserverIndexSearchRateDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -217,6 +339,18 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordSqlserverLatchWaitTimeTotalDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverLockByModeCountDataPoint(ts, "1", "db.namespace-val", AttributeLockModeShared)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverLockByModeCountDataPoint(ts, "3", "db.namespace-val-2", AttributeLockModeExclusive)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverLockByResourceCountDataPoint(ts, "1", "db.namespace-val", AttributeLockResourceKey)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverLockByResourceCountDataPoint(ts, "3", "db.namespace-val-2", AttributeLockResourcePage)
+			}
 
 			allMetricsCount++
 			mb.RecordSqlserverLockTimeoutRateDataPoint(ts, 1)
@@ -378,13 +512,64 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts, 1, AttributeAllocationPageTypeGam)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(ts, 3, AttributeAllocationPageTypeSgam)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbContentionWaitersCountDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbDataFilesCountDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbFileSizeDataPoint(ts, "1", "file_type-val", 14)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbFileSizeDataPoint(ts, "3", "file_type-val-2", 15)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverTempdbSpaceUsageDataPoint(ts, "1", AttributeTempdbSpaceKindUserObjects)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverTempdbSpaceUsageDataPoint(ts, "3", AttributeTempdbSpaceKindInternalObjects)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolTasksCountDataPoint(ts, "1", AttributeTaskStateCurrent)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverThreadPoolTasksCountDataPoint(ts, "3", AttributeTaskStateQueued)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersCountDataPoint(ts, "1", AttributeWorkerStateRunning)
+			if tt.name == "reaggregate_set" {
+				mb.RecordSqlserverThreadPoolWorkersCountDataPoint(ts, "3", AttributeWorkerStateSuspendedOrSleeping)
+			}
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersMaxDataPoint(ts, "1")
+
+			allMetricsCount++
+			mb.RecordSqlserverThreadPoolWorkersUtilizationDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordSqlserverTransactionDelayDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionLongestRunningTimeDataPoint(ts, 1)
 
 			allMetricsCount++
 			mb.RecordSqlserverTransactionMirrorWriteRateDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverTransactionRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionVersionCleanupRateDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSqlserverTransactionVersionGenerationRateDataPoint(ts, 1)
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSqlserverTransactionWriteRateDataPoint(ts, 1)
@@ -429,10 +614,28 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverDatabaseLatency.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabasePageFileSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsOld.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsOrphanedUsers.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabasePrincipalsRecentlyCreated.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleMembersCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleMembershipsCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRolePermissionRiskLevel.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverDatabaseRoleRolesCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTempdbSpace.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverDatabaseTransactionsActive.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgClusterType.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgFailureConditionLevel.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgHealthCheckTimeout.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterAgRequiredSyncSecondaries.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaDatabaseQueueSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaDatabaseRedoRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaRole.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverFailoverClusterReplicaSynchronizationHealth.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverLatchSuperlatchTransitionRate.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverLockByModeCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverLockByResourceCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryArea.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryCacheObjectCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverMemoryPageCount.aggDataPoints)
@@ -448,6 +651,11 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricSqlserverResourcePoolDiskOperations.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverServerSecurityRoleMembershipCount.aggDataPoints)
 				assert.Empty(t, mb.metricSqlserverTableCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbAllocationWaitTimeTotal.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbFileSize.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverTempdbSpaceUsage.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverThreadPoolTasksCount.aggDataPoints)
+				assert.Empty(t, mb.metricSqlserverThreadPoolWorkersCount.aggDataPoints)
 			}
 
 			if tt.expectEmpty {
@@ -914,6 +1122,351 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("page_file.state")
 						assert.False(t, ok)
 					}
+				case "sqlserver.database.principals.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.count"], "Found a duplicate in the metrics slice: sqlserver.database.principals.count")
+						validatedMetrics["sqlserver.database.principals.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database security principals broken down by type.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						principalTypeAttrVal, ok := dp.Attributes().Get("principal.type")
+						assert.True(t, ok)
+						assert.Equal(t, "sql_user", principalTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.count"], "Found a duplicate in the metrics slice: sqlserver.database.principals.count")
+						validatedMetrics["sqlserver.database.principals.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database security principals broken down by type.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("principal.type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.old":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.old"], "Found a duplicate in the metrics slice: sqlserver.database.principals.old")
+						validatedMetrics["sqlserver.database.principals.old"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created more than one year ago.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.old"], "Found a duplicate in the metrics slice: sqlserver.database.principals.old")
+						validatedMetrics["sqlserver.database.principals.old"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created more than one year ago.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.old"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.orphaned_users":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.orphaned_users"], "Found a duplicate in the metrics slice: sqlserver.database.principals.orphaned_users")
+						validatedMetrics["sqlserver.database.principals.orphaned_users"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL users in the database that have no matching server login.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.orphaned_users"], "Found a duplicate in the metrics slice: sqlserver.database.principals.orphaned_users")
+						validatedMetrics["sqlserver.database.principals.orphaned_users"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL users in the database that have no matching server login.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.orphaned_users"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.principals.recently_created":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.recently_created"], "Found a duplicate in the metrics slice: sqlserver.database.principals.recently_created")
+						validatedMetrics["sqlserver.database.principals.recently_created"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created in the last 30 days.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.principals.recently_created"], "Found a duplicate in the metrics slice: sqlserver.database.principals.recently_created")
+						validatedMetrics["sqlserver.database.principals.recently_created"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database principals created in the last 30 days.", mi.Description())
+						assert.Equal(t, "{principals}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.principals.recently_created"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.members.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.members.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.members.count")
+						validatedMetrics["sqlserver.database.role.members.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role members broken down by member kind.", mi.Description())
+						assert.Equal(t, "{members}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						memberKindAttrVal, ok := dp.Attributes().Get("member.kind")
+						assert.True(t, ok)
+						assert.Equal(t, "app_role", memberKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.members.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.members.count")
+						validatedMetrics["sqlserver.database.role.members.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role members broken down by member kind.", mi.Description())
+						assert.Equal(t, "{members}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.members.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("member.kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.memberships.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.memberships.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.memberships.count")
+						validatedMetrics["sqlserver.database.role.memberships.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role memberships broken down by kind.", mi.Description())
+						assert.Equal(t, "{memberships}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						membershipKindAttrVal, ok := dp.Attributes().Get("membership.kind")
+						assert.True(t, ok)
+						assert.Equal(t, "active", membershipKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.memberships.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.memberships.count")
+						validatedMetrics["sqlserver.database.role.memberships.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database role memberships broken down by kind.", mi.Description())
+						assert.Equal(t, "{memberships}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.memberships.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("membership.kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.permission.risk_level":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.permission.risk_level"], "Found a duplicate in the metrics slice: sqlserver.database.role.permission.risk_level")
+						validatedMetrics["sqlserver.database.role.permission.risk_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Risk level assigned to each database role (1=low, 4=high).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						roleAttrVal, ok := dp.Attributes().Get("role")
+						assert.True(t, ok)
+						assert.Equal(t, "role-val", roleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.permission.risk_level"], "Found a duplicate in the metrics slice: sqlserver.database.role.permission.risk_level")
+						validatedMetrics["sqlserver.database.role.permission.risk_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Risk level assigned to each database role (1=low, 4=high).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.permission.risk_level"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("role")
+						assert.False(t, ok)
+					}
+				case "sqlserver.database.role.roles.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.database.role.roles.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.roles.count")
+						validatedMetrics["sqlserver.database.role.roles.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database roles broken down by usage state.", mi.Description())
+						assert.Equal(t, "{roles}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						roleStateAttrVal, ok := dp.Attributes().Get("role.state")
+						assert.True(t, ok)
+						assert.Equal(t, "empty", roleStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.database.role.roles.count"], "Found a duplicate in the metrics slice: sqlserver.database.role.roles.count")
+						validatedMetrics["sqlserver.database.role.roles.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of database roles broken down by usage state.", mi.Description())
+						assert.Equal(t, "{roles}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.database.role.roles.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("role.state")
+						assert.False(t, ok)
+					}
 				case "sqlserver.database.security.role_membership.count":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["sqlserver.database.security.role_membership.count"], "Found a duplicate in the metrics slice: sqlserver.database.security.role_membership.count")
@@ -1067,6 +1620,388 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.failover_cluster.ag.cluster_type":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.cluster_type")
+						validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cluster type of the Always-On Availability Group.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						agClusterTypeAttrVal, ok := dp.Attributes().Get("ag.cluster_type")
+						assert.True(t, ok)
+						assert.Equal(t, "wsfc", agClusterTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.cluster_type")
+						validatedMetrics["sqlserver.failover_cluster.ag.cluster_type"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Cluster type of the Always-On Availability Group.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.cluster_type"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("ag.cluster_type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.failure_condition_level":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.failure_condition_level")
+						validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Failure condition level configured for the Availability Group (1-5).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.failure_condition_level")
+						validatedMetrics["sqlserver.failover_cluster.ag.failure_condition_level"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Failure condition level configured for the Availability Group (1-5).", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.failure_condition_level"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.health_check_timeout":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.health_check_timeout")
+						validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Health-check timeout configured for the Availability Group.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.health_check_timeout")
+						validatedMetrics["sqlserver.failover_cluster.ag.health_check_timeout"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Health-check timeout configured for the Availability Group.", mi.Description())
+						assert.Equal(t, "ms", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.health_check_timeout"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.ag.required_sync_secondaries":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.required_sync_secondaries")
+						validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of synchronized secondary replicas required to commit on the Availability Group.", mi.Description())
+						assert.Equal(t, "{secondaries}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.ag.required_sync_secondaries")
+						validatedMetrics["sqlserver.failover_cluster.ag.required_sync_secondaries"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of synchronized secondary replicas required to commit on the Availability Group.", mi.Description())
+						assert.Equal(t, "{secondaries}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.ag.required_sync_secondaries"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.database.queue_size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.queue_size")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of the log-send or redo queue for an AG database replica.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						replicaQueueKindAttrVal, ok := dp.Attributes().Get("replica.queue_kind")
+						assert.True(t, ok)
+						assert.Equal(t, "log_send", replicaQueueKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.queue_size")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.queue_size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of the log-send or redo queue for an AG database replica.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.database.queue_size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.queue_kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.database.redo.rate":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.redo.rate")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Redo rate for an AG database replica.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.database.redo.rate")
+						validatedMetrics["sqlserver.failover_cluster.replica.database.redo.rate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Redo rate for an AG database replica.", mi.Description())
+						assert.Equal(t, "By/s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.database.redo.rate"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.flow_control_time":
+					assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.flow_control_time"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.flow_control_time")
+					validatedMetrics["sqlserver.failover_cluster.replica.flow_control_time"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Cumulative time spent in AG flow control, in milliseconds per second observed.", mi.Description())
+					assert.Equal(t, "ms", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.failover_cluster.replica.role":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.role"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.role")
+						validatedMetrics["sqlserver.failover_cluster.replica.role"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Role of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						replicaRoleAttrVal, ok := dp.Attributes().Get("replica.role")
+						assert.True(t, ok)
+						assert.Equal(t, "primary", replicaRoleAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.role"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.role")
+						validatedMetrics["sqlserver.failover_cluster.replica.role"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Role of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.role"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.role")
+						assert.False(t, ok)
+					}
+				case "sqlserver.failover_cluster.replica.synchronization_health":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.synchronization_health")
+						validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Synchronization health of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						agNameAttrVal, ok := dp.Attributes().Get("ag.name")
+						assert.True(t, ok)
+						assert.Equal(t, "ag.name-val", agNameAttrVal.Str())
+						replicaServerNameAttrVal, ok := dp.Attributes().Get("replica.server_name")
+						assert.True(t, ok)
+						assert.Equal(t, "replica.server_name-val", replicaServerNameAttrVal.Str())
+						replicaSyncHealthAttrVal, ok := dp.Attributes().Get("replica.sync_health")
+						assert.True(t, ok)
+						assert.Equal(t, "healthy", replicaSyncHealthAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"], "Found a duplicate in the metrics slice: sqlserver.failover_cluster.replica.synchronization_health")
+						validatedMetrics["sqlserver.failover_cluster.replica.synchronization_health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Synchronization health of the availability replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.failover_cluster.replica.synchronization_health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("ag.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.server_name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("replica.sync_health")
+						assert.False(t, ok)
+					}
 				case "sqlserver.index.search.rate":
 					assert.False(t, validatedMetrics["sqlserver.index.search.rate"], "Found a duplicate in the metrics slice: sqlserver.index.search.rate")
 					validatedMetrics["sqlserver.index.search.rate"] = true
@@ -1181,6 +2116,96 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.lock.by_mode.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_mode.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_mode.count")
+						validatedMetrics["sqlserver.lock.by_mode.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by lock mode.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						lockModeAttrVal, ok := dp.Attributes().Get("lock.mode")
+						assert.True(t, ok)
+						assert.Equal(t, "shared", lockModeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_mode.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_mode.count")
+						validatedMetrics["sqlserver.lock.by_mode.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by lock mode.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.lock.by_mode.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("lock.mode")
+						assert.False(t, ok)
+					}
+				case "sqlserver.lock.by_resource.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_resource.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_resource.count")
+						validatedMetrics["sqlserver.lock.by_resource.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by resource type.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						dbNamespaceAttrVal, ok := dp.Attributes().Get("db.namespace")
+						assert.True(t, ok)
+						assert.Equal(t, "db.namespace-val", dbNamespaceAttrVal.Str())
+						lockResourceAttrVal, ok := dp.Attributes().Get("lock.resource")
+						assert.True(t, ok)
+						assert.Equal(t, "key", lockResourceAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.lock.by_resource.count"], "Found a duplicate in the metrics slice: sqlserver.lock.by_resource.count")
+						validatedMetrics["sqlserver.lock.by_resource.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of currently active locks held in the database, grouped by resource type.", mi.Description())
+						assert.Equal(t, "{locks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.lock.by_resource.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("db.namespace")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("lock.resource")
+						assert.False(t, ok)
+					}
 				case "sqlserver.lock.timeout.rate":
 					assert.False(t, validatedMetrics["sqlserver.lock.timeout.rate"], "Found a duplicate in the metrics slice: sqlserver.lock.timeout.rate")
 					validatedMetrics["sqlserver.lock.timeout.rate"] = true
@@ -2090,6 +3115,263 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("table.status")
 						assert.False(t, ok)
 					}
+				case "sqlserver.tempdb.allocation.wait_time.total":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"], "Found a duplicate in the metrics slice: sqlserver.tempdb.allocation.wait_time.total")
+						validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative wait time on tempdb allocation pages, broken down by page type.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						allocationPageTypeAttrVal, ok := dp.Attributes().Get("allocation.page_type")
+						assert.True(t, ok)
+						assert.Equal(t, "gam", allocationPageTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"], "Found a duplicate in the metrics slice: sqlserver.tempdb.allocation.wait_time.total")
+						validatedMetrics["sqlserver.tempdb.allocation.wait_time.total"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Cumulative wait time on tempdb allocation pages, broken down by page type.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.allocation.wait_time.total"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("allocation.page_type")
+						assert.False(t, ok)
+					}
+				case "sqlserver.tempdb.contention.waiters.count":
+					assert.False(t, validatedMetrics["sqlserver.tempdb.contention.waiters.count"], "Found a duplicate in the metrics slice: sqlserver.tempdb.contention.waiters.count")
+					validatedMetrics["sqlserver.tempdb.contention.waiters.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of tempdb pagelatch wait types with at least one active waiter.", mi.Description())
+					assert.Equal(t, "{waiters}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.tempdb.data_files.count":
+					assert.False(t, validatedMetrics["sqlserver.tempdb.data_files.count"], "Found a duplicate in the metrics slice: sqlserver.tempdb.data_files.count")
+					validatedMetrics["sqlserver.tempdb.data_files.count"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Number of tempdb data files configured on the instance.", mi.Description())
+					assert.Equal(t, "{files}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.tempdb.file.size":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.file.size"], "Found a duplicate in the metrics slice: sqlserver.tempdb.file.size")
+						validatedMetrics["sqlserver.tempdb.file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of each tempdb data or log file.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						fileTypeAttrVal, ok := dp.Attributes().Get("file_type")
+						assert.True(t, ok)
+						assert.Equal(t, "file_type-val", fileTypeAttrVal.Str())
+						tempdbFileIDAttrVal, ok := dp.Attributes().Get("tempdb.file.id")
+						assert.True(t, ok)
+						assert.EqualValues(t, 14, tempdbFileIDAttrVal.Int())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.file.size"], "Found a duplicate in the metrics slice: sqlserver.tempdb.file.size")
+						validatedMetrics["sqlserver.tempdb.file.size"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Size of each tempdb data or log file.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.file.size"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("file_type")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("tempdb.file.id")
+						assert.False(t, ok)
+					}
+				case "sqlserver.tempdb.space.usage":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.space.usage"], "Found a duplicate in the metrics slice: sqlserver.tempdb.space.usage")
+						validatedMetrics["sqlserver.tempdb.space.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Space used by tempdb, broken down by allocation category.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						tempdbSpaceKindAttrVal, ok := dp.Attributes().Get("tempdb.space_kind")
+						assert.True(t, ok)
+						assert.Equal(t, "user_objects", tempdbSpaceKindAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.tempdb.space.usage"], "Found a duplicate in the metrics slice: sqlserver.tempdb.space.usage")
+						validatedMetrics["sqlserver.tempdb.space.usage"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Space used by tempdb, broken down by allocation category.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.tempdb.space.usage"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("tempdb.space_kind")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.tasks.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.tasks.count")
+						validatedMetrics["sqlserver.thread_pool.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server tasks broken down by state.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						taskStateAttrVal, ok := dp.Attributes().Get("task.state")
+						assert.True(t, ok)
+						assert.Equal(t, "current", taskStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.tasks.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.tasks.count")
+						validatedMetrics["sqlserver.thread_pool.tasks.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server tasks broken down by state.", mi.Description())
+						assert.Equal(t, "{tasks}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.thread_pool.tasks.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("task.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.workers.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.count")
+						validatedMetrics["sqlserver.thread_pool.workers.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server worker threads broken down by state.", mi.Description())
+						assert.Equal(t, "{workers}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						workerStateAttrVal, ok := dp.Attributes().Get("worker.state")
+						assert.True(t, ok)
+						assert.Equal(t, "running", workerStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.count"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.count")
+						validatedMetrics["sqlserver.thread_pool.workers.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Number of SQL Server worker threads broken down by state.", mi.Description())
+						assert.Equal(t, "{workers}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["sqlserver.thread_pool.workers.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("worker.state")
+						assert.False(t, ok)
+					}
+				case "sqlserver.thread_pool.workers.max":
+					assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.max"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.max")
+					validatedMetrics["sqlserver.thread_pool.workers.max"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Maximum number of SQL Server worker threads configured on the instance.", mi.Description())
+					assert.Equal(t, "{workers}", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "sqlserver.thread_pool.workers.utilization":
+					assert.False(t, validatedMetrics["sqlserver.thread_pool.workers.utilization"], "Found a duplicate in the metrics slice: sqlserver.thread_pool.workers.utilization")
+					validatedMetrics["sqlserver.thread_pool.workers.utilization"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Fraction of configured SQL Server worker threads currently running.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "sqlserver.transaction.delay":
 					assert.False(t, validatedMetrics["sqlserver.transaction.delay"], "Found a duplicate in the metrics slice: sqlserver.transaction.delay")
 					validatedMetrics["sqlserver.transaction.delay"] = true
@@ -2100,6 +3382,18 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.False(t, mi.Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
 					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.longest_running_time":
+					assert.False(t, validatedMetrics["sqlserver.transaction.longest_running_time"], "Found a duplicate in the metrics slice: sqlserver.transaction.longest_running_time")
+					validatedMetrics["sqlserver.transaction.longest_running_time"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "Age in seconds of the longest currently-open transaction on the server.", mi.Description())
+					assert.Equal(t, "s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
@@ -2124,6 +3418,34 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, "Number of transactions started for the database (not including XTP-only transactions).", mi.Description())
 					assert.Equal(t, "{transactions}/s", mi.Unit())
 					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.version_cleanup.rate":
+					assert.False(t, validatedMetrics["sqlserver.transaction.version_cleanup.rate"], "Found a duplicate in the metrics slice: sqlserver.transaction.version_cleanup.rate")
+					validatedMetrics["sqlserver.transaction.version_cleanup.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Cumulative bytes cleaned from the tempdb version store.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "sqlserver.transaction.version_generation.rate":
+					assert.False(t, validatedMetrics["sqlserver.transaction.version_generation.rate"], "Found a duplicate in the metrics slice: sqlserver.transaction.version_generation.rate")
+					validatedMetrics["sqlserver.transaction.version_generation.rate"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "Cumulative bytes of row versions written to the tempdb version store.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -41,6 +41,30 @@ all_set:
     sqlserver.database.page_file.size:
       enabled: true
       attributes: ["db.namespace","page_file.state"]
+    sqlserver.database.principals.count:
+      enabled: true
+      attributes: ["db.namespace","principal.type"]
+    sqlserver.database.principals.old:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.orphaned_users:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.recently_created:
+      enabled: true
+      attributes: ["db.namespace"]
+    sqlserver.database.role.members.count:
+      enabled: true
+      attributes: ["db.namespace","member.kind"]
+    sqlserver.database.role.memberships.count:
+      enabled: true
+      attributes: ["db.namespace","membership.kind"]
+    sqlserver.database.role.permission.risk_level:
+      enabled: true
+      attributes: ["db.namespace","role"]
+    sqlserver.database.role.roles.count:
+      enabled: true
+      attributes: ["db.namespace","role.state"]
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: ["db.namespace","role"]
@@ -54,6 +78,32 @@ all_set:
       attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: true
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: true
+      attributes: ["ag.name","ag.cluster_type"]
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: true
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","db.namespace","replica.queue_kind"]
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","db.namespace"]
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: true
+    sqlserver.failover_cluster.replica.role:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","replica.role"]
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: true
+      attributes: ["ag.name","replica.server_name","replica.sync_health"]
     sqlserver.index.search.rate:
       enabled: true
     sqlserver.kill_connection.error.rate:
@@ -69,6 +119,12 @@ all_set:
       enabled: true
     sqlserver.latch.wait_time.total:
       enabled: true
+    sqlserver.lock.by_mode.count:
+      enabled: true
+      attributes: ["db.namespace","lock.mode"]
+    sqlserver.lock.by_resource.count:
+      enabled: true
+      attributes: ["db.namespace","lock.resource"]
     sqlserver.lock.timeout.rate:
       enabled: true
     sqlserver.lock.wait.count:
@@ -160,11 +216,40 @@ all_set:
     sqlserver.table.count:
       enabled: true
       attributes: ["table.state","table.status"]
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: true
+      attributes: ["allocation.page_type"]
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: true
+    sqlserver.tempdb.data_files.count:
+      enabled: true
+    sqlserver.tempdb.file.size:
+      enabled: true
+      attributes: ["file_type","tempdb.file.id"]
+    sqlserver.tempdb.space.usage:
+      enabled: true
+      attributes: ["tempdb.space_kind"]
+    sqlserver.thread_pool.tasks.count:
+      enabled: true
+      attributes: ["task.state"]
+    sqlserver.thread_pool.workers.count:
+      enabled: true
+      attributes: ["worker.state"]
+    sqlserver.thread_pool.workers.max:
+      enabled: true
+    sqlserver.thread_pool.workers.utilization:
+      enabled: true
     sqlserver.transaction.delay:
+      enabled: true
+    sqlserver.transaction.longest_running_time:
       enabled: true
     sqlserver.transaction.mirror_write.rate:
       enabled: true
     sqlserver.transaction.rate:
+      enabled: true
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: true
+    sqlserver.transaction.version_generation.rate:
       enabled: true
     sqlserver.transaction.write.rate:
       enabled: true
@@ -248,6 +333,30 @@ reaggregate_set:
     sqlserver.database.page_file.size:
       enabled: true
       attributes: []
+    sqlserver.database.principals.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.old:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.orphaned_users:
+      enabled: true
+      attributes: []
+    sqlserver.database.principals.recently_created:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.members.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.memberships.count:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.permission.risk_level:
+      enabled: true
+      attributes: []
+    sqlserver.database.role.roles.count:
+      enabled: true
+      attributes: []
     sqlserver.database.security.role_membership.count:
       enabled: true
       attributes: []
@@ -261,6 +370,32 @@ reaggregate_set:
       attributes: []
     sqlserver.deadlock.rate:
       enabled: true
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: true
+    sqlserver.failover_cluster.replica.role:
+      enabled: true
+      attributes: []
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: true
+      attributes: []
     sqlserver.index.search.rate:
       enabled: true
     sqlserver.kill_connection.error.rate:
@@ -276,6 +411,12 @@ reaggregate_set:
       enabled: true
     sqlserver.latch.wait_time.total:
       enabled: true
+    sqlserver.lock.by_mode.count:
+      enabled: true
+      attributes: []
+    sqlserver.lock.by_resource.count:
+      enabled: true
+      attributes: []
     sqlserver.lock.timeout.rate:
       enabled: true
     sqlserver.lock.wait.count:
@@ -367,11 +508,40 @@ reaggregate_set:
     sqlserver.table.count:
       enabled: true
       attributes: []
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: true
+      attributes: []
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: true
+    sqlserver.tempdb.data_files.count:
+      enabled: true
+    sqlserver.tempdb.file.size:
+      enabled: true
+      attributes: []
+    sqlserver.tempdb.space.usage:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.tasks.count:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.workers.count:
+      enabled: true
+      attributes: []
+    sqlserver.thread_pool.workers.max:
+      enabled: true
+    sqlserver.thread_pool.workers.utilization:
+      enabled: true
     sqlserver.transaction.delay:
+      enabled: true
+    sqlserver.transaction.longest_running_time:
       enabled: true
     sqlserver.transaction.mirror_write.rate:
       enabled: true
     sqlserver.transaction.rate:
+      enabled: true
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: true
+    sqlserver.transaction.version_generation.rate:
       enabled: true
     sqlserver.transaction.write.rate:
       enabled: true
@@ -455,6 +625,30 @@ none_set:
     sqlserver.database.page_file.size:
       enabled: false
       attributes: ["db.namespace","page_file.state"]
+    sqlserver.database.principals.count:
+      enabled: false
+      attributes: ["db.namespace","principal.type"]
+    sqlserver.database.principals.old:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.orphaned_users:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.principals.recently_created:
+      enabled: false
+      attributes: ["db.namespace"]
+    sqlserver.database.role.members.count:
+      enabled: false
+      attributes: ["db.namespace","member.kind"]
+    sqlserver.database.role.memberships.count:
+      enabled: false
+      attributes: ["db.namespace","membership.kind"]
+    sqlserver.database.role.permission.risk_level:
+      enabled: false
+      attributes: ["db.namespace","role"]
+    sqlserver.database.role.roles.count:
+      enabled: false
+      attributes: ["db.namespace","role.state"]
     sqlserver.database.security.role_membership.count:
       enabled: false
       attributes: ["db.namespace","role"]
@@ -468,6 +662,32 @@ none_set:
       attributes: ["db.namespace"]
     sqlserver.deadlock.rate:
       enabled: false
+    sqlserver.failover_cluster.ag.cluster_type:
+      enabled: false
+      attributes: ["ag.name","ag.cluster_type"]
+    sqlserver.failover_cluster.ag.failure_condition_level:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.health_check_timeout:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.ag.required_sync_secondaries:
+      enabled: false
+      attributes: ["ag.name"]
+    sqlserver.failover_cluster.replica.database.queue_size:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","db.namespace","replica.queue_kind"]
+    sqlserver.failover_cluster.replica.database.redo.rate:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","db.namespace"]
+    sqlserver.failover_cluster.replica.flow_control_time:
+      enabled: false
+    sqlserver.failover_cluster.replica.role:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","replica.role"]
+    sqlserver.failover_cluster.replica.synchronization_health:
+      enabled: false
+      attributes: ["ag.name","replica.server_name","replica.sync_health"]
     sqlserver.index.search.rate:
       enabled: false
     sqlserver.kill_connection.error.rate:
@@ -483,6 +703,12 @@ none_set:
       enabled: false
     sqlserver.latch.wait_time.total:
       enabled: false
+    sqlserver.lock.by_mode.count:
+      enabled: false
+      attributes: ["db.namespace","lock.mode"]
+    sqlserver.lock.by_resource.count:
+      enabled: false
+      attributes: ["db.namespace","lock.resource"]
     sqlserver.lock.timeout.rate:
       enabled: false
     sqlserver.lock.wait.count:
@@ -574,11 +800,40 @@ none_set:
     sqlserver.table.count:
       enabled: false
       attributes: ["table.state","table.status"]
+    sqlserver.tempdb.allocation.wait_time.total:
+      enabled: false
+      attributes: ["allocation.page_type"]
+    sqlserver.tempdb.contention.waiters.count:
+      enabled: false
+    sqlserver.tempdb.data_files.count:
+      enabled: false
+    sqlserver.tempdb.file.size:
+      enabled: false
+      attributes: ["file_type","tempdb.file.id"]
+    sqlserver.tempdb.space.usage:
+      enabled: false
+      attributes: ["tempdb.space_kind"]
+    sqlserver.thread_pool.tasks.count:
+      enabled: false
+      attributes: ["task.state"]
+    sqlserver.thread_pool.workers.count:
+      enabled: false
+      attributes: ["worker.state"]
+    sqlserver.thread_pool.workers.max:
+      enabled: false
+    sqlserver.thread_pool.workers.utilization:
+      enabled: false
     sqlserver.transaction.delay:
+      enabled: false
+    sqlserver.transaction.longest_running_time:
       enabled: false
     sqlserver.transaction.mirror_write.rate:
       enabled: false
     sqlserver.transaction.rate:
+      enabled: false
+    sqlserver.transaction.version_cleanup.rate:
+      enabled: false
+    sqlserver.transaction.version_generation.rate:
       enabled: false
     sqlserver.transaction.write.rate:
       enabled: false

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -60,6 +60,20 @@ resource_attributes:
 
 attributes:
   # attributes for metrics
+  ag.cluster_type:
+    description: Cluster type of the Always-On Availability Group.
+    type: string
+    requirement_level: recommended
+    enum: [wsfc, external, none, unknown]
+  ag.name:
+    description: Name of the Always-On Availability Group.
+    type: string
+    requirement_level: recommended
+  allocation.page_type:
+    description: TempDB allocation-page wait type.
+    type: string
+    requirement_level: recommended
+    enum: [gam, sgam, pfs, other]
   cache.state:
     description: The state of the cache objects.
     type: string
@@ -112,10 +126,30 @@ attributes:
     description: The type of file being monitored.
     type: string
     requirement_level: recommended
+  lock.mode:
+    description: SQL Server lock request mode.
+    type: string
+    requirement_level: recommended
+    enum: [shared, exclusive, update, intent, schema, bulk_update, shared_intent_exclusive]
+  lock.resource:
+    description: SQL Server lock resource type.
+    type: string
+    requirement_level: recommended
+    enum: [key, page, row, table, extent, file, hobt, metadata, application, allocation_unit, database_level]
   logical_filename:
     description: The logical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  member.kind:
+    description: Role-membership member breakdown bucket.
+    type: string
+    requirement_level: recommended
+    enum: [app_role, cross_role, high_privilege, unique]
+  membership.kind:
+    description: Role-membership grouping bucket.
+    type: string
+    requirement_level: recommended
+    enum: [active, custom, nested, users]
   memory.pool:
     description: The functional area of SQL Server memory.
     type: string
@@ -158,6 +192,11 @@ attributes:
     description: The physical filename of the file being monitored.
     type: string
     requirement_level: recommended
+  principal.type:
+    description: Database security principal type.
+    type: string
+    requirement_level: recommended
+    enum: [sql_user, windows_user, role, application_role, certificate_mapped_user, asymmetric_key_mapped_user]
   process.status:
     description: The status of the SQL Server process/session.
     type: string
@@ -168,10 +207,34 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [transmit, receive]
+  replica.queue_kind:
+    description: Type of AG database-replica queue.
+    type: string
+    requirement_level: recommended
+    enum: [log_send, redo]
+  replica.role:
+    description: Availability replica role.
+    type: string
+    requirement_level: recommended
+    enum: [primary, secondary, resolving, unknown]
+  replica.server_name:
+    description: Server name of the availability replica.
+    type: string
+    requirement_level: recommended
+  replica.sync_health:
+    description: Synchronization health of the availability replica.
+    type: string
+    requirement_level: recommended
+    enum: [healthy, partially_healthy, not_healthy, unknown]
   role:
     description: The name of the database or server role.
     type: string
     requirement_level: recommended
+  role.state:
+    description: Database role usage state.
+    type: string
+    requirement_level: recommended
+    enum: [empty, with_members]
   server.address:
     description: The network address of the server hosting the database.
     type: string
@@ -378,6 +441,20 @@ attributes:
     type: string
     requirement_level: recommended
     enum: [temporary, permanent]
+  task.state:
+    description: SQL Server task state for thread-pool diagnostics.
+    type: string
+    requirement_level: recommended
+    enum: [current, queued, waiting_for_threadpool]
+  tempdb.file.id:
+    description: Numeric file_id within tempdb (sys.master_files.file_id).
+    type: int
+    requirement_level: recommended
+  tempdb.space_kind:
+    description: TempDB space usage category.
+    type: string
+    requirement_level: recommended
+    enum: [user_objects, internal_objects, version_store, free]
   tempdb.state:
     description: The status of the tempdb space usage.
     type: string
@@ -401,6 +478,11 @@ attributes:
     description: Type of the wait, view [WaitTypes documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql?view=sql-server-ver16#WaitTypes) for more information.
     type: string
     requirement_level: recommended
+  worker.state:
+    description: SQL Server worker state.
+    type: string
+    requirement_level: recommended
+    enum: [running, suspended_or_sleeping]
   # attributes for events
   ## common
 events:
@@ -635,6 +717,86 @@ metrics:
       input_type: string
     attributes: [db.namespace, page_file.state]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.count:
+    enabled: false
+    description: Number of database security principals broken down by type.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, principal.type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.old:
+    enabled: false
+    description: Number of database principals created more than one year ago.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.orphaned_users:
+    enabled: false
+    description: Number of SQL users in the database that have no matching server login.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.principals.recently_created:
+    enabled: false
+    description: Number of database principals created in the last 30 days.
+    stability: development
+    unit: "{principals}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.members.count:
+    enabled: false
+    description: Number of database role members broken down by member kind.
+    stability: development
+    unit: "{members}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, member.kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.memberships.count:
+    enabled: false
+    description: Number of database role memberships broken down by kind.
+    stability: development
+    unit: "{memberships}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, membership.kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.permission.risk_level:
+    enabled: false
+    description: Risk level assigned to each database role (1=low, 4=high).
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, role]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.database.role.roles.count:
+    enabled: false
+    description: Number of database roles broken down by usage state.
+    stability: development
+    unit: "{roles}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, role.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.database.security.role_membership.count:
     enabled: false
     description: Number of members in a database role.
@@ -681,6 +843,94 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  sqlserver.failover_cluster.ag.cluster_type:
+    enabled: false
+    description: Cluster type of the Always-On Availability Group.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, ag.cluster_type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.failure_condition_level:
+    enabled: false
+    description: Failure condition level configured for the Availability Group (1-5).
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.health_check_timeout:
+    enabled: false
+    description: Health-check timeout configured for the Availability Group.
+    stability: development
+    unit: "ms"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.ag.required_sync_secondaries:
+    enabled: false
+    description: Number of synchronized secondary replicas required to commit on the Availability Group.
+    stability: development
+    unit: "{secondaries}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.database.queue_size:
+    enabled: false
+    description: Size of the log-send or redo queue for an AG database replica.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, db.namespace, replica.queue_kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.database.redo.rate:
+    enabled: false
+    description: Redo rate for an AG database replica.
+    stability: development
+    unit: By/s
+    gauge:
+      value_type: double
+    attributes: [ag.name, replica.server_name, db.namespace]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.flow_control_time:
+    enabled: false
+    description: Cumulative time spent in AG flow control, in milliseconds per second observed.
+    stability: development
+    unit: ms
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.role:
+    enabled: false
+    description: Role of the availability replica.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, replica.role]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.failover_cluster.replica.synchronization_health:
+    enabled: false
+    description: Synchronization health of the availability replica.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [ag.name, replica.server_name, replica.sync_health]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.index.search.rate:
     enabled: false
     description: Total number of index searches.
@@ -744,6 +994,26 @@ metrics:
       aggregation_temporality: cumulative
       value_type: double
     attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.lock.by_mode.count:
+    enabled: false
+    description: Number of currently active locks held in the database, grouped by lock mode.
+    stability: development
+    unit: "{locks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, lock.mode]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.lock.by_resource.count:
+    enabled: false
+    description: Number of currently active locks held in the database, grouped by resource type.
+    stability: development
+    unit: "{locks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [db.namespace, lock.resource]
     extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.lock.timeout.rate:
     enabled: false
@@ -1088,6 +1358,96 @@ metrics:
       monotonic: false
       value_type: int
     attributes: [table.state, table.status]
+  sqlserver.tempdb.allocation.wait_time.total:
+    enabled: false
+    description: Cumulative wait time on tempdb allocation pages, broken down by page type.
+    stability: development
+    unit: s
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: [allocation.page_type]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.contention.waiters.count:
+    enabled: false
+    description: Number of tempdb pagelatch wait types with at least one active waiter.
+    stability: development
+    unit: "{waiters}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.data_files.count:
+    enabled: false
+    description: Number of tempdb data files configured on the instance.
+    stability: development
+    unit: "{files}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.file.size:
+    enabled: false
+    description: Size of each tempdb data or log file.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [file_type, tempdb.file.id]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.tempdb.space.usage:
+    enabled: false
+    description: Space used by tempdb, broken down by allocation category.
+    stability: development
+    unit: By
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [tempdb.space_kind]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.tasks.count:
+    enabled: false
+    description: Number of SQL Server tasks broken down by state.
+    stability: development
+    unit: "{tasks}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [task.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.count:
+    enabled: false
+    description: Number of SQL Server worker threads broken down by state.
+    stability: development
+    unit: "{workers}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: [worker.state]
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.max:
+    enabled: false
+    description: Maximum number of SQL Server worker threads configured on the instance.
+    stability: development
+    unit: "{workers}"
+    gauge:
+      value_type: int
+      input_type: string
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.thread_pool.workers.utilization:
+    enabled: false
+    description: Fraction of configured SQL Server worker threads currently running.
+    stability: development
+    unit: "1"
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.delay:
     enabled: false
     description: Time consumed in transaction delays.
@@ -1098,6 +1458,15 @@ metrics:
       monotonic: false
       value_type: double
     attributes: []
+  sqlserver.transaction.longest_running_time:
+    enabled: false
+    description: Age in seconds of the longest currently-open transaction on the server.
+    stability: development
+    unit: s
+    gauge:
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.mirror_write.rate:
     enabled: false
     description: Total number of mirror write transactions.
@@ -1114,6 +1483,28 @@ metrics:
     gauge:
       value_type: double
     extended_documentation: This metric is only available when running on Windows.
+  sqlserver.transaction.version_cleanup.rate:
+    enabled: false
+    description: Cumulative bytes cleaned from the tempdb version store.
+    stability: development
+    unit: By
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
+  sqlserver.transaction.version_generation.rate:
+    enabled: false
+    description: Cumulative bytes of row versions written to the tempdb version store.
+    stability: development
+    unit: By
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: double
+    attributes: []
+    extended_documentation: This metric is only available when the receiver is configured to directly connect to SQL Server.
   sqlserver.transaction.write.rate:
     enabled: true
     description: Number of transactions that wrote to the database and committed.

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -141,7 +141,7 @@ attributes:
     type: string
     requirement_level: recommended
   member.kind:
-    description: Role-membership member breakdown bucket.
+    description: Role-membership member breakdown bucket. `high_privilege` covers db_owner, db_securityadmin, db_accessadmin, db_backupoperator, db_ddladmin.
     type: string
     requirement_level: recommended
     enum: [app_role, cross_role, high_privilege, unique]

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -1915,7 +1915,6 @@ INNER JOIN sys.dm_tran_session_transactions AS st WITH (NOLOCK) ON tat.transacti
 INNER JOIN sys.dm_exec_sessions             AS sess WITH (NOLOCK) ON st.session_id = sess.session_id
 WHERE tat.transaction_type IN (1,2,4)
   AND tat.transaction_state IN (2,3)
-  AND sess.session_id > 50
   AND sess.is_user_process = 1
 {filter_instance_name};
 `

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -161,6 +161,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'
@@ -1456,4 +1458,474 @@ func getSQLServerDatabasePageFileQuery(instanceName string) string {
 
 	r := strings.NewReplacer("{filter_instance_name}", "")
 	return r.Replace(sqlServerDatabasePageFileQuery)
+}
+
+// One row per database with active locks; mode + resource buckets in a single row.
+const sqlServerLockQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.lock.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_lock' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	DB_NAME(tl.resource_database_id) AS [db_name],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('S','IS')              THEN 1 ELSE 0 END) AS BIGINT) AS [mode_shared],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('X','IX')              THEN 1 ELSE 0 END) AS BIGINT) AS [mode_exclusive],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('U','IU','SIU','UIX')  THEN 1 ELSE 0 END) AS BIGINT) AS [mode_update],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('IS','IX','IU','SIU','SIX','UIX') THEN 1 ELSE 0 END) AS BIGINT) AS [mode_intent],
+	CAST(SUM(CASE WHEN tl.request_mode IN ('Sch-S','Sch-M')        THEN 1 ELSE 0 END) AS BIGINT) AS [mode_schema],
+	CAST(SUM(CASE WHEN tl.request_mode = 'BU'                      THEN 1 ELSE 0 END) AS BIGINT) AS [mode_bulk_update],
+	CAST(SUM(CASE WHEN tl.request_mode = 'SIX'                     THEN 1 ELSE 0 END) AS BIGINT) AS [mode_shared_intent_exclusive],
+	CAST(SUM(CASE WHEN tl.resource_type = 'KEY'             THEN 1 ELSE 0 END) AS BIGINT) AS [resource_key],
+	CAST(SUM(CASE WHEN tl.resource_type = 'PAGE'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_page],
+	CAST(SUM(CASE WHEN tl.resource_type = 'RID'             THEN 1 ELSE 0 END) AS BIGINT) AS [resource_row],
+	CAST(SUM(CASE WHEN tl.resource_type = 'OBJECT'          THEN 1 ELSE 0 END) AS BIGINT) AS [resource_table],
+	CAST(SUM(CASE WHEN tl.resource_type = 'EXTENT'          THEN 1 ELSE 0 END) AS BIGINT) AS [resource_extent],
+	CAST(SUM(CASE WHEN tl.resource_type = 'FILE'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_file],
+	CAST(SUM(CASE WHEN tl.resource_type = 'HOBT'            THEN 1 ELSE 0 END) AS BIGINT) AS [resource_hobt],
+	CAST(SUM(CASE WHEN tl.resource_type = 'METADATA'        THEN 1 ELSE 0 END) AS BIGINT) AS [resource_metadata],
+	CAST(SUM(CASE WHEN tl.resource_type = 'APPLICATION'     THEN 1 ELSE 0 END) AS BIGINT) AS [resource_application],
+	CAST(SUM(CASE WHEN tl.resource_type = 'ALLOCATION_UNIT' THEN 1 ELSE 0 END) AS BIGINT) AS [resource_allocation_unit],
+	CAST(SUM(CASE WHEN tl.resource_type = 'DATABASE'        THEN 1 ELSE 0 END) AS BIGINT) AS [resource_database_level]
+FROM sys.dm_tran_locks tl WITH (NOLOCK)
+WHERE tl.resource_database_id > 0
+{filter_instance_name}
+GROUP BY tl.resource_database_id
+HAVING COUNT(*) > 0;
+`
+
+func getSQLServerLockQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerLockQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerLockQuery)
+}
+
+// Single-row snapshot of worker / task / scheduler state for thread-pool diagnostics.
+const sqlServerThreadPoolQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.thread_pool.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+;
+WITH
+waits AS (
+	SELECT COUNT(*) AS waiting_for_threadpool
+	FROM sys.dm_os_waiting_tasks WITH (NOLOCK)
+	WHERE wait_type = 'THREADPOOL'
+),
+sched AS (
+	SELECT
+		ISNULL(SUM(work_queue_count),0) AS work_queue,
+		ISNULL(SUM(current_tasks_count),0) AS current_tasks
+	FROM sys.dm_os_schedulers WITH (NOLOCK)
+	WHERE scheduler_id < 255 AND status = 'VISIBLE ONLINE'
+),
+workers AS (
+	SELECT
+		SUM(CASE WHEN state = 'RUNNING' THEN 1 ELSE 0 END) AS running,
+		SUM(CASE WHEN state NOT IN ('RUNNING','RUNNABLE') THEN 1 ELSE 0 END) AS suspended_or_sleeping
+	FROM sys.dm_os_workers WITH (NOLOCK)
+),
+cfg AS (
+	SELECT max_workers_count AS max_workers FROM sys.dm_os_sys_info
+)
+SELECT
+	'sqlserver_thread_pool' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(workers.running AS BIGINT)                AS [workers_running],
+	CAST(workers.suspended_or_sleeping AS BIGINT)  AS [workers_suspended_or_sleeping],
+	CAST(cfg.max_workers AS BIGINT)                AS [workers_max],
+	CAST(CAST(workers.running AS float) / NULLIF(CAST(cfg.max_workers AS float), 0) AS float) AS [workers_utilization],
+	CAST(sched.current_tasks AS BIGINT)            AS [tasks_current],
+	CAST(sched.work_queue AS BIGINT)               AS [tasks_queued],
+	CAST(waits.waiting_for_threadpool AS BIGINT)   AS [tasks_waiting_for_threadpool]
+FROM waits, sched, workers, cfg
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerThreadPoolQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerThreadPoolQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerThreadPoolQuery)
+}
+
+// Single-row tempdb diagnostics covering space usage, data-file count, pagelatch waiters, and allocation-page wait time.
+const sqlServerTempDBQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.tempdb.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+;
+WITH
+file_space AS (
+	SELECT
+		CAST(SUM(user_object_reserved_page_count)     AS BIGINT) * 8 * 1024 AS bytes_user_objects,
+		CAST(SUM(internal_object_reserved_page_count) AS BIGINT) * 8 * 1024 AS bytes_internal_objects,
+		CAST(SUM(version_store_reserved_page_count)   AS BIGINT) * 8 * 1024 AS bytes_version_store,
+		CAST(SUM(unallocated_extent_page_count)       AS BIGINT) * 8 * 1024 AS bytes_free
+	FROM tempdb.sys.dm_db_file_space_usage WITH (NOLOCK)
+),
+files AS (
+	SELECT CAST(COUNT(*) AS BIGINT) AS data_file_count
+	FROM sys.master_files WITH (NOLOCK)
+	WHERE database_id = 2 AND type = 0
+),
+contention AS (
+	SELECT CAST(COUNT(*) AS BIGINT) AS pagelatch_waiters
+	FROM sys.dm_os_wait_stats WITH (NOLOCK)
+	WHERE wait_type IN ('PAGELATCH_IO','PAGELATCH_SH','PAGELATCH_EX','PAGELATCH_UP')
+	  AND waiting_tasks_count > 0
+),
+alloc AS (
+	SELECT
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%GAM%'  AND wait_type NOT LIKE '%SGAM%'), 0) AS gam_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%SGAM%'), 0) AS sgam_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK) WHERE wait_type LIKE '%PFS%'),  0) AS pfs_ms,
+		ISNULL((SELECT SUM(wait_time_ms) FROM sys.dm_os_wait_stats WITH (NOLOCK)
+		        WHERE wait_type LIKE '%ALLOCATION%'
+		          AND wait_type NOT LIKE '%GAM%'
+		          AND wait_type NOT LIKE '%SGAM%'
+		          AND wait_type NOT LIKE '%PFS%'), 0) AS other_ms
+)
+SELECT
+	'sqlserver_tempdb' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	file_space.bytes_user_objects,
+	file_space.bytes_internal_objects,
+	file_space.bytes_version_store,
+	file_space.bytes_free,
+	files.data_file_count,
+	contention.pagelatch_waiters,
+	alloc.gam_ms,
+	alloc.sgam_ms,
+	alloc.pfs_ms,
+	alloc.other_ms
+FROM file_space, files, contention, alloc
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerTempDBQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerTempDBQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerTempDBQuery)
+}
+
+// One row per tempdb data/log file.
+const sqlServerTempDBFileQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.tempdb.file.size.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_tempdb_file' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	CAST(file_id AS BIGINT) AS [file_id],
+	CASE type WHEN 0 THEN 'data' WHEN 1 THEN 'log' ELSE 'other' END AS [file_type],
+	CAST(size AS BIGINT) * 8 * 1024 AS [size_bytes]
+FROM sys.master_files WITH (NOLOCK)
+WHERE database_id = 2 AND type IN (0, 1)
+{filter_instance_name};
+`
+
+func getSQLServerTempDBFileQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerTempDBFileQuery)
+	}
+
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerTempDBFileQuery)
+}
+
+// One row per Availability Group on this instance. Returns zero rows if Always-On is not configured.
+const sqlServerFailoverClusterAGQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.ag.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_ag' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	LOWER(ISNULL(ag.cluster_type_desc, 'UNKNOWN')) AS [cluster_type],
+	CAST(ISNULL(ag.failure_condition_level, 0) AS BIGINT) AS [failure_condition_level],
+	CAST(ISNULL(ag.health_check_timeout, 0) AS BIGINT) AS [health_check_timeout],
+	CAST(ISNULL(ag.required_synchronized_secondaries_to_commit, 0) AS BIGINT) AS [required_sync_secondaries]
+FROM sys.availability_groups AS ag WITH (NOLOCK)
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterAGQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterAGQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterAGQuery)
+}
+
+// One row per availability replica.
+const sqlServerFailoverClusterReplicaQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.replica.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_replica' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	ISNULL(ar.replica_server_name, 'UNKNOWN') AS [replica_server_name],
+	LOWER(ISNULL(ars.role_desc, 'UNKNOWN')) AS [role],
+	LOWER(REPLACE(ISNULL(ars.synchronization_health_desc, 'UNKNOWN'), '_', '_')) AS [sync_health]
+FROM sys.dm_hadr_availability_replica_states AS ars WITH (NOLOCK)
+INNER JOIN sys.availability_replicas AS ar WITH (NOLOCK) ON ars.replica_id = ar.replica_id
+INNER JOIN sys.availability_groups   AS ag WITH (NOLOCK) ON ar.group_id   = ag.group_id
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterReplicaQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterReplicaQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterReplicaQuery)
+}
+
+// One row per AG database replica.
+const sqlServerFailoverClusterReplicaDatabaseQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.failover_cluster.replica.database.* metrics.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_failover_cluster_replica_database' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(ag.name, 'UNKNOWN') AS [ag_name],
+	ISNULL(ar.replica_server_name, 'UNKNOWN') AS [replica_server_name],
+	ISNULL(d.name, 'UNKNOWN') AS [db_name],
+	CAST(ISNULL(drs.log_send_queue_size, 0) AS BIGINT) * 1024 AS [log_send_queue_bytes],
+	CAST(ISNULL(drs.redo_queue_size, 0) AS BIGINT)     * 1024 AS [redo_queue_bytes],
+	CAST(ISNULL(drs.redo_rate, 0) AS float)            * 1024 AS [redo_rate_bytes_per_sec]
+FROM sys.dm_hadr_database_replica_states AS drs WITH (NOLOCK)
+INNER JOIN sys.availability_replicas AS ar WITH (NOLOCK) ON drs.replica_id = ar.replica_id
+INNER JOIN sys.availability_groups   AS ag WITH (NOLOCK) ON ar.group_id    = ag.group_id
+INNER JOIN sys.databases             AS d  WITH (NOLOCK) ON drs.database_id = d.database_id
+WHERE 1=1
+{filter_instance_name};
+`
+
+func getSQLServerFailoverClusterReplicaDatabaseQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerFailoverClusterReplicaDatabaseQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerFailoverClusterReplicaDatabaseQuery)
+}
+
+// One row per user database with principal counts (typed and lifecycle).
+// Dynamic SQL with UNION ALL so the entire result set is one rowset.
+const sqlServerDatabasePrincipalsQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.principals.* metrics (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''S'' THEN 1 ELSE 0 END) AS BIGINT) AS [sql_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''U'' THEN 1 ELSE 0 END) AS BIGINT) AS [windows_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''R'' THEN 1 ELSE 0 END) AS BIGINT) AS [role], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''A'' THEN 1 ELSE 0 END) AS BIGINT) AS [application_role], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''C'' THEN 1 ELSE 0 END) AS BIGINT) AS [certificate_mapped_user], ' +
+	N'CAST(SUM(CASE WHEN p.type = ''K'' THEN 1 ELSE 0 END) AS BIGINT) AS [asymmetric_key_mapped_user], ' +
+	N'CAST(SUM(CASE WHEN p.create_date >= DATEADD(day, -30, GETDATE()) THEN 1 ELSE 0 END) AS BIGINT) AS [recently_created], ' +
+	N'CAST(SUM(CASE WHEN p.create_date <  DATEADD(year, -1,  GETDATE()) THEN 1 ELSE 0 END) AS BIGINT) AS [old], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_principals dp WHERE dp.type = ''S'' AND dp.is_fixed_role = 0 AND dp.name <> ''dbo'' AND dp.principal_id > 4 AND NOT EXISTS (SELECT 1 FROM sys.server_principals sp WHERE sp.name = dp.name AND sp.type = ''S'')) AS BIGINT) AS [orphaned_users] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.database_principals p ' +
+	N'WHERE p.is_fixed_role = 0 AND p.type <> ''X'' AND p.name NOT IN (''guest'', ''INFORMATION_SCHEMA'', ''sys'')'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabasePrincipalsQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabasePrincipalsQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabasePrincipalsQuery)
+}
+
+// One row per user database with role-membership aggregates.
+const sqlServerDatabaseRoleMembershipQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.role.* metrics (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], ' +
+	-- members.* (4 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.type = ''A'') AS BIGINT) AS [members_app_role], ' +
+	N'CAST((SELECT COUNT(DISTINCT drm1.member_principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm1 WHERE EXISTS (SELECT 1 FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm2 WHERE drm2.member_principal_id = drm1.member_principal_id AND drm2.role_principal_id <> drm1.role_principal_id)) AS BIGINT) AS [members_cross_role], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.name IN (''db_owner'',''db_securityadmin'',''db_accessadmin'',''db_backupoperator'',''db_ddladmin'')) AS BIGINT) AS [members_high_privilege], ' +
+	N'CAST((SELECT COUNT(DISTINCT member_principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_role_members) AS BIGINT) AS [members_unique], ' +
+	-- memberships.* (4 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members) AS BIGINT) AS [memberships_active], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.is_fixed_role = 0) AS BIGINT) AS [memberships_custom], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals m ON drm.member_principal_id = m.principal_id WHERE m.type = ''R'') AS BIGINT) AS [memberships_nested], ' +
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm JOIN ' + QUOTENAME(name) + N'.sys.database_principals m ON drm.member_principal_id = m.principal_id WHERE m.type IN (''S'',''U'',''G'')) AS BIGINT) AS [memberships_users], ' +
+	-- roles.* (2 kinds)
+	N'CAST((SELECT COUNT(*) FROM ' + QUOTENAME(name) + N'.sys.database_principals r WHERE r.type IN (''R'',''A'') AND NOT EXISTS (SELECT 1 FROM ' + QUOTENAME(name) + N'.sys.database_role_members drm WHERE drm.role_principal_id = r.principal_id)) AS BIGINT) AS [roles_empty], ' +
+	N'CAST((SELECT COUNT(DISTINCT r.principal_id) FROM ' + QUOTENAME(name) + N'.sys.database_principals r JOIN ' + QUOTENAME(name) + N'.sys.database_role_members drm ON drm.role_principal_id = r.principal_id WHERE r.type IN (''R'',''A'')) AS BIGINT) AS [roles_with_members]'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabaseRoleMembershipQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabaseRoleMembershipQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabaseRoleMembershipQuery)
+}
+
+// One row per user database, per role, with a static risk-level mapping.
+const sqlServerDatabaseRoleRiskLevelQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.database.role.permission.risk_level (Azure SQL Database does not allow cross-database 3-part naming).';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+DECLARE @SQL nvarchar(max) = N'';
+
+SELECT @SQL = @SQL +
+	CASE WHEN @SQL = N'' THEN N'' ELSE N' UNION ALL ' END +
+	N'SELECT ''' + REPLACE(name, '''', '''''') + N''' AS [db_name], r.name AS [role_name], ' +
+	N'CAST(CASE WHEN r.name = ''db_owner'' THEN 4 ' +
+	N'          WHEN r.name IN (''db_securityadmin'',''db_accessadmin'') THEN 3 ' +
+	N'          WHEN r.name IN (''db_ddladmin'',''db_backupoperator'') THEN 2 ' +
+	N'          ELSE 1 END AS BIGINT) AS [risk_level] ' +
+	N'FROM ' + QUOTENAME(name) + N'.sys.database_principals r WHERE r.type IN (''R'',''A'')'
+FROM sys.databases WITH (NOLOCK)
+WHERE database_id > 4
+	AND state = 0
+	AND name NOT IN ('rdsadmin', 'distribution', 'model_msdb', 'model_replicatedmaster')
+{filter_instance_name};
+
+IF @SQL <> N'' EXEC sp_executesql @SQL;
+`
+
+func getSQLServerDatabaseRoleRiskLevelQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerDatabaseRoleRiskLevelQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerDatabaseRoleRiskLevelQuery)
+}
+
+// Returns the age (in seconds) of the longest currently-open transaction.
+// Returns 0 if no user transactions are open.
+const sqlServerLongestRunningTransactionQuery = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,8) BEGIN
+	DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:' + @@ServerName + ',Database:' + DB_NAME() + ' is not supported for sqlserver.transaction.longest_running_time.';
+	RAISERROR (@ErrorMessage,11,1)
+	RETURN
+END
+
+SELECT
+	'sqlserver_longest_running_transaction' AS [measurement],
+	REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
+	ISNULL(MAX(DATEDIFF(SECOND, tat.transaction_begin_time, GETDATE())), 0) AS [longest_running_seconds]
+FROM sys.dm_tran_active_transactions   AS tat WITH (NOLOCK)
+INNER JOIN sys.dm_tran_session_transactions AS st WITH (NOLOCK) ON tat.transaction_id = st.transaction_id
+INNER JOIN sys.dm_exec_sessions             AS sess WITH (NOLOCK) ON st.session_id = sess.session_id
+WHERE tat.transaction_type IN (1,2,4)
+  AND tat.transaction_state IN (2,3)
+  AND sess.session_id > 50
+  AND sess.is_user_process = 1
+{filter_instance_name};
+`
+
+func getSQLServerLongestRunningTransactionQuery(instanceName string) string {
+	if instanceName != "" {
+		whereClause := fmt.Sprintf("\tAND @@SERVERNAME = '%s'", instanceName)
+		r := strings.NewReplacer("{filter_instance_name}", whereClause)
+		return r.Replace(sqlServerLongestRunningTransactionQuery)
+	}
+	r := strings.NewReplacer("{filter_instance_name}", "")
+	return r.Replace(sqlServerLongestRunningTransactionQuery)
 }

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -146,6 +146,28 @@ func (s *sqlServerScraperHelper) ScrapeMetrics(ctx context.Context) (pmetric.Met
 		err = s.recordProcessCountMetrics(ctx)
 	case getSQLServerDatabasePageFileQuery(s.config.InstanceName):
 		err = s.recordDatabasePageFileMetrics(ctx)
+	case getSQLServerLockQuery(s.config.InstanceName):
+		err = s.recordLockMetrics(ctx)
+	case getSQLServerThreadPoolQuery(s.config.InstanceName):
+		err = s.recordThreadPoolMetrics(ctx)
+	case getSQLServerTempDBQuery(s.config.InstanceName):
+		err = s.recordTempDBMetrics(ctx)
+	case getSQLServerTempDBFileQuery(s.config.InstanceName):
+		err = s.recordTempDBFileMetrics(ctx)
+	case getSQLServerFailoverClusterAGQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterAGMetrics(ctx)
+	case getSQLServerFailoverClusterReplicaQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterReplicaMetrics(ctx)
+	case getSQLServerFailoverClusterReplicaDatabaseQuery(s.config.InstanceName):
+		err = s.recordFailoverClusterReplicaDatabaseMetrics(ctx)
+	case getSQLServerDatabasePrincipalsQuery(s.config.InstanceName):
+		err = s.recordDatabasePrincipalsMetrics(ctx)
+	case getSQLServerDatabaseRoleMembershipQuery(s.config.InstanceName):
+		err = s.recordDatabaseRoleMembershipMetrics(ctx)
+	case getSQLServerDatabaseRoleRiskLevelQuery(s.config.InstanceName):
+		err = s.recordDatabaseRoleRiskLevelMetrics(ctx)
+	case getSQLServerLongestRunningTransactionQuery(s.config.InstanceName):
+		err = s.recordLongestRunningTransactionMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -442,6 +464,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const bufferCacheHitRatio = "Buffer cache hit ratio"
 	const bytesReceivedFromReplicaPerSec = "Bytes Received from Replica/sec"
 	const bytesSentForReplicaPerSec = "Bytes Sent to Replica/sec"
+	const flowControlTimePerSec = "Flow Control Time (ms/sec)"
 	const diskReadIOSec = "Disk Read IO/sec"
 	const diskReadIOThrottled = "Disk Read IO Throttled/sec"
 	const diskWriteIOSec = "Disk Write IO/sec"
@@ -478,6 +501,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	const userConnCount = "User Connections"
 	const usedMemory = "Used memory (KB)"
 	const versionStoreSize = "Version Store Size (KB)"
+	const versionGenerationRate = "Version Generation rate (KB/s)"
+	const versionCleanupRate = "Version Cleanup rate (KB/s)"
 	const sqlCacheMemory = "SQL Cache Memory (KB)"
 	const optimizerMemory = "Optimizer Memory (KB)"
 	const connectionMemory = "Connection Memory (KB)"
@@ -588,6 +613,31 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				errs = append(errs, err)
 			} else {
 				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionTransmit)
+			}
+		case flowControlTimePerSec:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, flowControlTimePerSec)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverFailoverClusterReplicaFlowControlTimeDataPoint(now, val.(float64))
+			}
+		case versionGenerationRate:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, versionGenerationRate)
+				errs = append(errs, err)
+			} else {
+				// Convert KB/s to By/s.
+				s.mb.RecordSqlserverTransactionVersionGenerationRateDataPoint(now, val.(float64)*1024)
+			}
+		case versionCleanupRate:
+			val, err := retrieveFloat(row, valueKey)
+			if err != nil {
+				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, versionCleanupRate)
+				errs = append(errs, err)
+			} else {
+				s.mb.RecordSqlserverTransactionVersionCleanupRateDataPoint(now, val.(float64)*1024)
 			}
 		case diskReadIOSec:
 			val, err := retrieveFloat(row, valueKey)
@@ -1386,6 +1436,505 @@ func (s *sqlServerScraperHelper) recordDatabasePageFileMetrics(ctx context.Conte
 		if totalErr == nil && freeErr == nil {
 			usedBytes := max(totalVal.(int64)-freeVal.(int64), 0)
 			errs = append(errs, s.mb.RecordSqlserverDatabasePageFileSizeDataPoint(now, fmt.Sprintf("%d", usedBytes), row[databaseName], metadata.AttributePageFileStateUsed))
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordLockMetrics(ctx context.Context) error {
+	const databaseName = "db_name"
+	lockModeCols := []struct {
+		col   string
+		value metadata.AttributeLockMode
+	}{
+		{"mode_shared", metadata.AttributeLockModeShared},
+		{"mode_exclusive", metadata.AttributeLockModeExclusive},
+		{"mode_update", metadata.AttributeLockModeUpdate},
+		{"mode_intent", metadata.AttributeLockModeIntent},
+		{"mode_schema", metadata.AttributeLockModeSchema},
+		{"mode_bulk_update", metadata.AttributeLockModeBulkUpdate},
+		{"mode_shared_intent_exclusive", metadata.AttributeLockModeSharedIntentExclusive},
+	}
+	lockResourceCols := []struct {
+		col   string
+		value metadata.AttributeLockResource
+	}{
+		{"resource_key", metadata.AttributeLockResourceKey},
+		{"resource_page", metadata.AttributeLockResourcePage},
+		{"resource_row", metadata.AttributeLockResourceRow},
+		{"resource_table", metadata.AttributeLockResourceTable},
+		{"resource_extent", metadata.AttributeLockResourceExtent},
+		{"resource_file", metadata.AttributeLockResourceFile},
+		{"resource_hobt", metadata.AttributeLockResourceHobt},
+		{"resource_metadata", metadata.AttributeLockResourceMetadata},
+		{"resource_application", metadata.AttributeLockResourceApplication},
+		{"resource_allocation_unit", metadata.AttributeLockResourceAllocationUnit},
+		{"resource_database_level", metadata.AttributeLockResourceDatabaseLevel},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range lockModeCols {
+			errs = append(errs, s.mb.RecordSqlserverLockByModeCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range lockResourceCols {
+			errs = append(errs, s.mb.RecordSqlserverLockByResourceCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordThreadPoolMetrics(ctx context.Context) error {
+	const (
+		workersRunning             = "workers_running"
+		workersSuspendedOrSleeping = "workers_suspended_or_sleeping"
+		workersMax                 = "workers_max"
+		workersUtilization         = "workers_utilization"
+		tasksCurrent               = "tasks_current"
+		tasksQueued                = "tasks_queued"
+		tasksWaitingForThreadpool  = "tasks_waiting_for_threadpool"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverThreadPoolWorkersCountDataPoint(now, row[workersRunning], metadata.AttributeWorkerStateRunning),
+			s.mb.RecordSqlserverThreadPoolWorkersCountDataPoint(now, row[workersSuspendedOrSleeping], metadata.AttributeWorkerStateSuspendedOrSleeping),
+			s.mb.RecordSqlserverThreadPoolWorkersMaxDataPoint(now, row[workersMax]),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksCurrent], metadata.AttributeTaskStateCurrent),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksQueued], metadata.AttributeTaskStateQueued),
+			s.mb.RecordSqlserverThreadPoolTasksCountDataPoint(now, row[tasksWaitingForThreadpool], metadata.AttributeTaskStateWaitingForThreadpool),
+		)
+
+		if utilStr := row[workersUtilization]; utilStr != "" {
+			val, parseErr := retrieveFloat(row, workersUtilization)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s: %w", workersUtilization, parseErr))
+			} else {
+				s.mb.RecordSqlserverThreadPoolWorkersUtilizationDataPoint(now, val.(float64))
+			}
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordTempDBMetrics(ctx context.Context) error {
+	const (
+		bytesUserObjects     = "bytes_user_objects"
+		bytesInternalObjects = "bytes_internal_objects"
+		bytesVersionStore    = "bytes_version_store"
+		bytesFree            = "bytes_free"
+		dataFileCount        = "data_file_count"
+		pagelatchWaiters     = "pagelatch_waiters"
+		gamMs                = "gam_ms"
+		sgamMs               = "sgam_ms"
+		pfsMs                = "pfs_ms"
+		otherMs              = "other_ms"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		errs = append(errs,
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesUserObjects], metadata.AttributeTempdbSpaceKindUserObjects),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesInternalObjects], metadata.AttributeTempdbSpaceKindInternalObjects),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesVersionStore], metadata.AttributeTempdbSpaceKindVersionStore),
+			s.mb.RecordSqlserverTempdbSpaceUsageDataPoint(now, row[bytesFree], metadata.AttributeTempdbSpaceKindFree),
+			s.mb.RecordSqlserverTempdbDataFilesCountDataPoint(now, row[dataFileCount]),
+			s.mb.RecordSqlserverTempdbContentionWaitersCountDataPoint(now, row[pagelatchWaiters]),
+		)
+
+		for _, w := range []struct {
+			col   string
+			value metadata.AttributeAllocationPageType
+		}{
+			{gamMs, metadata.AttributeAllocationPageTypeGam},
+			{sgamMs, metadata.AttributeAllocationPageTypeSgam},
+			{pfsMs, metadata.AttributeAllocationPageTypePfs},
+			{otherMs, metadata.AttributeAllocationPageTypeOther},
+		} {
+			val, parseErr := retrieveFloat(row, w.col)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", w.col, i, parseErr))
+				continue
+			}
+			s.mb.RecordSqlserverTempdbAllocationWaitTimeTotalDataPoint(now, val.(float64)/1e3, w.value)
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordTempDBFileMetrics(ctx context.Context) error {
+	const (
+		fileID    = "file_id"
+		fileType  = "file_type"
+		sizeBytes = "size_bytes"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		idVal, parseErr := retrieveInt(row, fileID)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", fileID, i, parseErr))
+			continue
+		}
+		errs = append(errs, s.mb.RecordSqlserverTempdbFileSizeDataPoint(now, row[sizeBytes], row[fileType], idVal.(int64)))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+var failoverClusterAGClusterTypeMap = map[string]metadata.AttributeAgClusterType{
+	"wsfc":     metadata.AttributeAgClusterTypeWsfc,
+	"external": metadata.AttributeAgClusterTypeExternal,
+	"none":     metadata.AttributeAgClusterTypeNone,
+}
+
+var failoverClusterReplicaRoleMap = map[string]metadata.AttributeReplicaRole{
+	"primary":   metadata.AttributeReplicaRolePrimary,
+	"secondary": metadata.AttributeReplicaRoleSecondary,
+	"resolving": metadata.AttributeReplicaRoleResolving,
+}
+
+var failoverClusterReplicaSyncHealthMap = map[string]metadata.AttributeReplicaSyncHealth{
+	"healthy":           metadata.AttributeReplicaSyncHealthHealthy,
+	"partially_healthy": metadata.AttributeReplicaSyncHealthPartiallyHealthy,
+	"not_healthy":       metadata.AttributeReplicaSyncHealthNotHealthy,
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterAGMetrics(ctx context.Context) error {
+	const (
+		agName                  = "ag_name"
+		clusterType             = "cluster_type"
+		failureConditionLevel   = "failure_condition_level"
+		healthCheckTimeout      = "health_check_timeout"
+		requiredSyncSecondaries = "required_sync_secondaries"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		ct, ok := failoverClusterAGClusterTypeMap[row[clusterType]]
+		if !ok {
+			ct = metadata.AttributeAgClusterTypeUnknown
+		}
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterAgClusterTypeDataPoint(now, "1", row[agName], ct),
+			s.mb.RecordSqlserverFailoverClusterAgFailureConditionLevelDataPoint(now, row[failureConditionLevel], row[agName]),
+			s.mb.RecordSqlserverFailoverClusterAgHealthCheckTimeoutDataPoint(now, row[healthCheckTimeout], row[agName]),
+			s.mb.RecordSqlserverFailoverClusterAgRequiredSyncSecondariesDataPoint(now, row[requiredSyncSecondaries], row[agName]),
+		)
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterReplicaMetrics(ctx context.Context) error {
+	const (
+		agName            = "ag_name"
+		replicaServerName = "replica_server_name"
+		role              = "role"
+		syncHealth        = "sync_health"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		r, ok := failoverClusterReplicaRoleMap[row[role]]
+		if !ok {
+			r = metadata.AttributeReplicaRoleUnknown
+		}
+		sh, ok := failoverClusterReplicaSyncHealthMap[row[syncHealth]]
+		if !ok {
+			sh = metadata.AttributeReplicaSyncHealthUnknown
+		}
+
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterReplicaRoleDataPoint(now, "1", row[agName], row[replicaServerName], r),
+			s.mb.RecordSqlserverFailoverClusterReplicaSynchronizationHealthDataPoint(now, "1", row[agName], row[replicaServerName], sh),
+		)
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordFailoverClusterReplicaDatabaseMetrics(ctx context.Context) error {
+	const (
+		agName              = "ag_name"
+		replicaServerName   = "replica_server_name"
+		databaseName        = "db_name"
+		logSendQueueBytes   = "log_send_queue_bytes"
+		redoQueueBytes      = "redo_queue_bytes"
+		redoRateBytesPerSec = "redo_rate_bytes_per_sec"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+
+		errs = append(errs,
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(now, row[logSendQueueBytes], row[agName], row[replicaServerName], row[databaseName], metadata.AttributeReplicaQueueKindLogSend),
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseQueueSizeDataPoint(now, row[redoQueueBytes], row[agName], row[replicaServerName], row[databaseName], metadata.AttributeReplicaQueueKindRedo),
+		)
+
+		rateVal, parseErr := retrieveFloat(row, redoRateBytesPerSec)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", redoRateBytesPerSec, i, parseErr))
+		} else {
+			s.mb.RecordSqlserverFailoverClusterReplicaDatabaseRedoRateDataPoint(now, rateVal.(float64), row[agName], row[replicaServerName], row[databaseName])
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabasePrincipalsMetrics(ctx context.Context) error {
+	const (
+		databaseName            = "db_name"
+		sqlUser                 = "sql_user"
+		windowsUser             = "windows_user"
+		roleCol                 = "role"
+		applicationRole         = "application_role"
+		certificateMappedUser   = "certificate_mapped_user"
+		asymmetricKeyMappedUser = "asymmetric_key_mapped_user"
+		recentlyCreated         = "recently_created"
+		old                     = "old"
+		orphanedUsers           = "orphaned_users"
+	)
+	principalTypeCols := []struct {
+		col   string
+		value metadata.AttributePrincipalType
+	}{
+		{sqlUser, metadata.AttributePrincipalTypeSQLUser},
+		{windowsUser, metadata.AttributePrincipalTypeWindowsUser},
+		{roleCol, metadata.AttributePrincipalTypeRole},
+		{applicationRole, metadata.AttributePrincipalTypeApplicationRole},
+		{certificateMappedUser, metadata.AttributePrincipalTypeCertificateMappedUser},
+		{asymmetricKeyMappedUser, metadata.AttributePrincipalTypeAsymmetricKeyMappedUser},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range principalTypeCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabasePrincipalsCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		errs = append(errs,
+			s.mb.RecordSqlserverDatabasePrincipalsRecentlyCreatedDataPoint(now, row[recentlyCreated], row[databaseName]),
+			s.mb.RecordSqlserverDatabasePrincipalsOldDataPoint(now, row[old], row[databaseName]),
+			s.mb.RecordSqlserverDatabasePrincipalsOrphanedUsersDataPoint(now, row[orphanedUsers], row[databaseName]),
+		)
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabaseRoleMembershipMetrics(ctx context.Context) error {
+	const databaseName = "db_name"
+	memberCols := []struct {
+		col   string
+		value metadata.AttributeMemberKind
+	}{
+		{"members_app_role", metadata.AttributeMemberKindAppRole},
+		{"members_cross_role", metadata.AttributeMemberKindCrossRole},
+		{"members_high_privilege", metadata.AttributeMemberKindHighPrivilege},
+		{"members_unique", metadata.AttributeMemberKindUnique},
+	}
+	membershipCols := []struct {
+		col   string
+		value metadata.AttributeMembershipKind
+	}{
+		{"memberships_active", metadata.AttributeMembershipKindActive},
+		{"memberships_custom", metadata.AttributeMembershipKindCustom},
+		{"memberships_nested", metadata.AttributeMembershipKindNested},
+		{"memberships_users", metadata.AttributeMembershipKindUsers},
+	}
+	roleCols := []struct {
+		col   string
+		value metadata.AttributeRoleState
+	}{
+		{"roles_empty", metadata.AttributeRoleStateEmpty},
+		{"roles_with_members", metadata.AttributeRoleStateWithMembers},
+	}
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		for _, c := range memberCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleMembersCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range membershipCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleMembershipsCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		for _, c := range roleCols {
+			errs = append(errs, s.mb.RecordSqlserverDatabaseRoleRolesCountDataPoint(now, row[c.col], row[databaseName], c.value))
+		}
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabaseRoleRiskLevelMetrics(ctx context.Context) error {
+	const (
+		databaseName = "db_name"
+		roleName     = "role_name"
+		riskLevel    = "risk_level"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for _, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+		rb.SetSqlserverDatabaseName(row[databaseName])
+		errs = append(errs, s.mb.RecordSqlserverDatabaseRolePermissionRiskLevelDataPoint(now, row[riskLevel], row[databaseName], row[roleName]))
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordLongestRunningTransactionMetrics(ctx context.Context) error {
+	const longestSeconds = "longest_running_seconds"
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		if !errors.Is(err, sqlquery.ErrNullValueWarning) {
+			return fmt.Errorf("sqlServerScraperHelper: %w", err)
+		}
+		s.logger.Warn("problems encountered getting metric rows", zap.Error(err))
+	}
+
+	var errs []error
+	now := pcommon.NewTimestampFromTime(time.Now())
+	for i, row := range rows {
+		rb := s.setupResourceBuilder(s.mb.NewResourceBuilder(), row)
+
+		val, parseErr := retrieveFloat(row, longestSeconds)
+		if parseErr != nil {
+			errs = append(errs, fmt.Errorf("failed to parse %s for row %d: %w", longestSeconds, i, parseErr))
+		} else {
+			s.mb.RecordSqlserverTransactionLongestRunningTimeDataPoint(now, val.(float64))
 		}
 
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))

--- a/receiver/sqlserverreceiver/testdata/perfCounterQueryWithInstanceName.txt
+++ b/receiver/sqlserverreceiver/testdata/perfCounterQueryWithInstanceName.txt
@@ -77,6 +77,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'

--- a/receiver/sqlserverreceiver/testdata/perfCounterQueryWithoutInstanceName.txt
+++ b/receiver/sqlserverreceiver/testdata/perfCounterQueryWithoutInstanceName.txt
@@ -77,6 +77,8 @@ SELECT DISTINCT
 			,'Temp Tables For Destruction'
 			,'Free Space in tempdb (KB)'
 			,'Version Store Size (KB)'
+			,'Version Generation rate (KB/s)'
+			,'Version Cleanup rate (KB/s)'
 			,'Memory Grants Pending'
 			,'Memory Grants Outstanding'
 			,'Free list stalls/sec'


### PR DESCRIPTION
All new metrics disabled by default, stability=development, direct-DB connection only. Same set added to both receiver/sqlserver and receiver/nrsqlserver.

      # NEW in this branch — Lock metrics (2 metrics, covers 20 audit entries)
      # ====================================================================
      sqlserver.lock.by_mode.count:                              # attrs: db.namespace, lock.mode ∈ {shared, exclusive, update, intent, schema, bulk_update, shared_intent_exclusive}
        enabled: true
      sqlserver.lock.by_resource.count:                          # attrs: db.namespace, lock.resource ∈ {key, page, row, table, extent, file, hobt, metadata, application, allocation_unit, database_level}
        enabled: true

      # NEW — Thread pool metrics (4 metrics, covers 7 audit entries)
      # ====================================================================
      sqlserver.thread_pool.workers.count:                       # attrs: worker.state ∈ {running, suspended_or_sleeping}
        enabled: true
      sqlserver.thread_pool.workers.max:                         # no attributes
        enabled: true
      sqlserver.thread_pool.workers.utilization:                 # no attributes (fraction 0-1)
        enabled: true
      sqlserver.thread_pool.tasks.count:                         # attrs: task.state ∈ {current, queued, waiting_for_threadpool}
        enabled: true

      # NEW — TempDB metrics (5 metrics, covers 3 audit entries + diagnostics)
      # ====================================================================
      sqlserver.tempdb.allocation.wait_time.total:               # attrs: allocation.page_type ∈ {gam, sgam, pfs, other}
        enabled: true
      sqlserver.tempdb.contention.waiters.count:                 # no attributes
        enabled: true
      sqlserver.tempdb.data_files.count:                         # no attributes
        enabled: true
      sqlserver.tempdb.file.size:                                # attrs: file_type ∈ {data, log}, tempdb.file.id (int)
        enabled: true
      sqlserver.tempdb.space.usage:                              # attrs: tempdb.space_kind ∈ {user_objects, internal_objects, version_store, free}
        enabled: true

      # NEW — Failover cluster (9 metrics, covers 10 audit entries)
      # ====================================================================
      sqlserver.failover_cluster.ag.cluster_type:                       # attrs: ag.name, ag.cluster_type
        enabled: true
      sqlserver.failover_cluster.ag.failure_condition_level:            # attrs: ag.name
        enabled: true
      sqlserver.failover_cluster.ag.health_check_timeout:               # attrs: ag.name
        enabled: true
      sqlserver.failover_cluster.ag.required_sync_secondaries:          # attrs: ag.name
        enabled: true
      sqlserver.failover_cluster.replica.role:                          # attrs: ag.name, replica.server_name, replica.role
        enabled: true
      sqlserver.failover_cluster.replica.synchronization_health:        # attrs: ag.name, replica.server_name, replica.sync_health
        enabled: true
      sqlserver.failover_cluster.replica.flow_control_time:             # no attrs
        enabled: true
      sqlserver.failover_cluster.replica.database.queue_size:           # attrs: ag.name, replica.server_name, db.namespace, replica.queue_kind
        enabled: true
      sqlserver.failover_cluster.replica.database.redo.rate:            # attrs: ag.name, replica.server_name, db.namespace
        enabled: true

      # NEW — Database principals (4 metrics, covers 8 audit entries)
      # ====================================================================
      sqlserver.database.principals.count:                              # attrs: db.namespace, principal.type
        enabled: true
      sqlserver.database.principals.recently_created:                   # attrs: db.namespace
        enabled: true
      sqlserver.database.principals.old:                                # attrs: db.namespace
        enabled: true
      sqlserver.database.principals.orphaned_users:                     # attrs: db.namespace
        enabled: true

      # NEW — Database role membership (4 metrics, covers 11 audit entries)
      # ====================================================================
      sqlserver.database.role.members.count:                            # attrs: db.namespace, member.kind
        enabled: true
      sqlserver.database.role.memberships.count:                        # attrs: db.namespace, membership.kind
        enabled: true
      sqlserver.database.role.roles.count:                              # attrs: db.namespace, role.state
        enabled: true
      sqlserver.database.role.permission.risk_level:                    # attrs: db.namespace, role
        enabled: true

      # NEW — Transaction / version-store metrics (3 metrics, dashboard fill-in)
      # ====================================================================
      sqlserver.transaction.longest_running_time:                       # no attrs (server-wide max age in seconds)
        enabled: true
      sqlserver.transaction.version_generation.rate:                    # no attrs (bytes/sec)
        enabled: true
      sqlserver.transaction.version_cleanup.rate:                       # no attrs (bytes/sec)
        enabled: true
        
  
<img width="1878" height="771" alt="Screenshot 2026-06-24 at 12 13 52 PM" src="https://github.com/user-attachments/assets/5ea7776d-a445-4ae8-9948-591201f9cd0a" />
<img width="1885" height="793" alt="Screenshot 2026-06-24 at 12 13 21 PM" src="https://github.com/user-attachments/assets/76729f39-aa87-4257-9855-0801bfdb1c2b" />
<img width="1884" height="768" alt="Screenshot 2026-06-24 at 12 13 00 PM" src="https://github.com/user-attachments/assets/5f3096bf-2ebf-4ba4-b830-e3041bfebffe" />
<img width="1895" height="826" alt="Screenshot 2026-06-24 at 11 21 51 AM" src="https://github.com/user-attachments/assets/087fb49d-aa7a-448d-8a43-9247091cd4c8" />
<img width="1878" height="766" alt="Screenshot 2026-06-24 at 11 21 23 AM" src="https://github.com/user-attachments/assets/59658058-4529-4fd6-b148-c923641ae2f0" />
<img width="1886" height="829" alt="Screenshot 2026-06-24 at 11 20 50 AM" src="https://github.com/user-attachments/assets/294c229d-0399-4e16-9c96-26315a016c71" />
<img width="1885" height="843" alt="Screenshot 2026-06-24 at 11 20 38 AM" src="https://github.com/user-attachments/assets/878977f7-65b8-49f2-b233-9f4f746d20da" />
<img width="1877" height="766" alt="Screenshot 2026-06-24 at 11 17 12 AM" src="https://github.com/user-attachments/assets/b84840c6-b773-42bb-9cf0-e5ab8969baef" />
<img width="1874" height="784" alt="Screenshot 2026-06-24 at 11 16 30 AM" src="https://github.com/user-attachments/assets/83563c7f-1307-4961-9828-49c4fef51456" />
<img width="1892" height="793" alt="Screenshot 2026-06-24 at 11 16 17 AM" src="https://github.com/user-attachments/assets/cb63a705-33df-497e-9ae3-c46b8e301d9c" />
<img width="1909" height="843" alt="Screenshot 2026-06-24 at 11 14 28 AM" src="https://github.com/user-attachments/assets/9b139e17-300f-4cf9-ad1e-d5c42d085933" />
