### PR TITLE
fix(internal/nrsqlquery): close sql.Rows to release driver connection

### DIFF
--- a/internal/nrsqlquery/db_client.go
+++ b/internal/nrsqlquery/db_client.go
@@ -39,6 +39,7 @@ func (cl DbSQLClient) QueryRows(ctx context.Context, args ...any) ([]StringMap, 
 	if err != nil {
 		return nil, err
 	}
+	defer sqlRows.Close()
 	var out []StringMap
 	colTypes, err := sqlRows.ColumnTypes()
 	if err != nil {

--- a/internal/nrsqlquery/db_client_test.go
+++ b/internal/nrsqlquery/db_client_test.go
@@ -142,6 +142,10 @@ func (r *fakeRows) Scan(dest ...any) error {
 	return nil
 }
 
+func (*fakeRows) Close() error {
+	return nil
+}
+
 type fakeCol struct {
 	name string
 }

--- a/internal/nrsqlquery/db_wrappers.go
+++ b/internal/nrsqlquery/db_wrappers.go
@@ -18,6 +18,7 @@ type rows interface {
 	ColumnTypes() ([]colType, error)
 	Next() bool
 	Scan(dest ...any) error
+	Close() error
 }
 
 type colType interface {
@@ -55,6 +56,10 @@ func (r rowsWrapper) Next() bool {
 
 func (r rowsWrapper) Scan(dest ...any) error {
 	return r.rows.Scan(dest...)
+}
+
+func (r rowsWrapper) Close() error {
+	return r.rows.Close()
 }
 
 type colWrapper struct {


### PR DESCRIPTION
**Description:** Fixes a memory leak in internal/nrsqlquery where sql.Rows was never closed on early-return and error paths (e.g. ColumnTypes() failure, scan error, context cancellation). Without defer sqlRows.Close(), the underlying driver connection stays marked in-use in the *sql.DB pool. On drivers that allocate per-connection buffers (e.g. go-mssqldb's 64 KiB TDS buffer), this manifests as steady RSS growth under long-running scrapes. Also adds Close() error to the rows interface and implements it on rowsWrapper to satisfy the contract.

**Link to tracking Issue:** Mirrors upstream open-telemetry/opentelemetry-collector-contrib#49463 (issue #49462)

Testing: Existing unit tests in internal/nrsqlquery pass. Added Close() error stub to fakeRows in db_client_test.go to satisfy the updated interface. No new test cases needed as the fix is a deferred cleanup with no branching logic.

**Documentation:** No documentation changes required — this is an internal package bug fix with no API surface changes.