### PR TITLE
 Populate service.instance.id in Windows Performance Counter mode

### DIFF
--- a/receiver/nrsqlserverreceiver/documentation.md
+++ b/receiver/nrsqlserverreceiver/documentation.md
@@ -1736,7 +1736,7 @@ top query
 | host.name | The host name of SQL Server | Any Str | true | - | - |
 | server.address | Name of the database host. | Any Str | false | - | - |
 | server.port | Server port number. | Any Int | false | - | - |
-| service.instance.id | A unique identifier of the SQL Server instance in the format host:port. This resource attribute is only available when the receiver is configured to directly connect to SQL Server. | Any Str | true | - | - |
+| service.instance.id | A unique identifier of the SQL Server instance in the format host:port. In Windows Performance Counter mode the host is derived from computer_name (falling back to the collector host when monitoring locally), with a default port of 1433. | Any Str | true | - | - |
 | service.name | Logical name of the service. When enabled, defaults to unknown_service:microsoft.sql_server. | Any Str | false | - | - |
 | service.namespace | Logical namespace for the service (for example team or environment). When enabled, defaults to an empty string until set via configuration. | Any Str | false | - | - |
 | sqlserver.computer.name | The name of the SQL Server instance being monitored. | Any Str | false | - | - |

--- a/receiver/nrsqlserverreceiver/metadata.yaml
+++ b/receiver/nrsqlserverreceiver/metadata.yaml
@@ -34,7 +34,7 @@ resource_attributes:
     enabled: false
     type: int
   service.instance.id:
-    description: A unique identifier of the SQL Server instance in the format host:port. This resource attribute is only available when the receiver is configured to directly connect to SQL Server.
+    description: A unique identifier of the SQL Server instance in the format host:port. In Windows Performance Counter mode the host is derived from computer_name (falling back to the collector host when monitoring locally), with a default port of 1433.
     enabled: true
     type: string
   service.name:

--- a/receiver/nrsqlserverreceiver/scraper_windows.go
+++ b/receiver/nrsqlserverreceiver/scraper_windows.go
@@ -22,10 +22,11 @@ import (
 
 // SQL Server Perf Counter (PC) Scraper. This is used to scrape metrics from Windows Perf Counters.
 type sqlServerPCScraper struct {
-	logger           *zap.Logger
-	config           *Config
-	watcherRecorders []watcherRecorder
-	mb               *metadata.MetricsBuilder
+	logger            *zap.Logger
+	config            *Config
+	watcherRecorders  []watcherRecorder
+	mb                *metadata.MetricsBuilder
+	serviceInstanceID string
 }
 
 // watcherRecorder is a struct containing perf counter watcher along with corresponding value recorder.
@@ -47,10 +48,16 @@ const (
 
 // newSQLServerPCScraper returns a new sqlServerPCScraper.
 func newSQLServerPCScraper(params receiver.Settings, cfg *Config) *sqlServerPCScraper {
+	serviceInstanceID, err := computeServiceInstanceID(cfg)
+	if err != nil {
+		params.Logger.Warn("Failed to compute service.instance.id", zap.Error(err))
+		serviceInstanceID = "unknown:1433"
+	}
 	return &sqlServerPCScraper{
-		logger: params.Logger,
-		config: cfg,
-		mb:     metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, params),
+		logger:            params.Logger,
+		config:            cfg,
+		mb:                metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, params),
+		serviceInstanceID: serviceInstanceID,
 	}
 }
 
@@ -151,6 +158,7 @@ func (s *sqlServerPCScraper) emitMetricGroup(recorders []curriedRecorder, databa
 	rb := s.mb.NewResourceBuilder()
 	rb.SetServiceName(defaultServiceName)
 	rb.SetServiceNamespace("")
+	rb.SetServiceInstanceID(s.serviceInstanceID)
 	if databaseName != "" {
 		rb.SetSqlserverDatabaseName(databaseName)
 	}

--- a/receiver/nrsqlserverreceiver/scraper_windows_test.go
+++ b/receiver/nrsqlserverreceiver/scraper_windows_test.go
@@ -151,7 +151,8 @@ func TestScrape(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, scrapeData,
-			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp(),
+			pmetrictest.IgnoreResourceAttributeValue("service.instance.id")))
 	})
 
 	t.Run("named", func(t *testing.T) {
@@ -160,6 +161,9 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig = metadata.MetricsBuilderConfig{
 			Metrics: metadata.DefaultMetricsConfig(),
 			ResourceAttributes: metadata.ResourceAttributesConfig{
+				ServiceInstanceID: metadata.ServiceInstanceIDResourceAttributeConfig{
+					Enabled: true,
+				},
 				ServiceName: metadata.ServiceNameResourceAttributeConfig{
 					Enabled: true,
 				},

--- a/receiver/nrsqlserverreceiver/service_instance_id.go
+++ b/receiver/nrsqlserverreceiver/service_instance_id.go
@@ -39,6 +39,9 @@ func computeServiceInstanceID(cfg *Config) (string, error) {
 		host, port = h, p
 	case cfg.Server != "":
 		host, port = cfg.Server, int(cfg.Port)
+	case cfg.ComputerName != "":
+		// Windows Performance Counter mode with remote computer: use ComputerName as host
+		host, port = cfg.ComputerName, defaultSQLServerPort
 	default:
 		// No server specified, use hostname with default port
 		hostname, err := os.Hostname()

--- a/receiver/nrsqlserverreceiver/service_instance_id_test.go
+++ b/receiver/nrsqlserverreceiver/service_instance_id_test.go
@@ -130,6 +130,30 @@ func TestComputeServiceInstanceID(t *testing.T) {
 			expected: fmt.Sprintf("%s:1433", hostname),
 		},
 		{
+			name: "computer name only (Windows PC mode remote)",
+			config: &Config{
+				ComputerName: "db-server",
+			},
+			expected: "db-server:1433",
+		},
+		{
+			name: "computer name takes lower priority than server",
+			config: &Config{
+				Server:       "direct-host",
+				Port:         5000,
+				ComputerName: "db-server",
+			},
+			expected: "direct-host:5000",
+		},
+		{
+			name: "computer name takes lower priority than datasource",
+			config: &Config{
+				DataSource:   "server=datasource-host,5000;user id=sa",
+				ComputerName: "db-server",
+			},
+			expected: "datasource-host:5000",
+		},
+		{
 			name: "datasource with named instance",
 			config: &Config{
 				DataSource: "server=myserver\\SQLEXPRESS,5000;user id=sa",

--- a/receiver/nrsqlserverreceiver/testdata/golden_named_instance_scrape.yaml
+++ b/receiver/nrsqlserverreceiver/testdata/golden_named_instance_scrape.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: service.instance.id
+          value:
+            stringValue: CustomServer:1433
         - key: service.name
           value:
             stringValue: unknown_service:microsoft.sql_server

--- a/receiver/nrsqlserverreceiver/testdata/golden_scrape.yaml
+++ b/receiver/nrsqlserverreceiver/testdata/golden_scrape.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: service.instance.id
+          value:
+            stringValue: placeholder
         - key: service.name
           value:
             stringValue: unknown_service:microsoft.sql_server


### PR DESCRIPTION
Previously, service.instance.id was only set by the direct connection scraper and was absent from metrics emitted in Windows Performance Counter mode, despite being enabled: true in the default config.

Add serviceInstanceID field to sqlServerPCScraper, compute it once at initialization using computeServiceInstanceID (mirroring the direct connection scraper), and emit it in emitMetricGroup. Also extend computeServiceInstanceID to honor computer_name so remote PC monitoring produces <computer_name>:1433.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>