### PR TITLE
[receiver/nrsqlserver] skip comment-only SQL statements

### DIFF
--- a/.chloggen/sqlserver-skip-comment-only-statements.yaml
+++ b/.chloggen/sqlserver-skip-comment-only-statements.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nrsqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip comment-only masked and empty statements so they no longer emit empty `db.query.text` events or produce obfuscation error log spam.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50220]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -2452,6 +2452,11 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 		queryPlanHashVal := hex.EncodeToString([]byte(row[queryPlanHash]))
 		procID := row[storedProcedureID]
 
+		if strings.HasPrefix(row[queryText], "--") {
+			s.logger.Debug(fmt.Sprintf("skipping comment-only SQL statement: %v", row[queryText]))
+			continue
+		}
+
 		queryTextVal := s.retrieveValue(row, queryText, &errs, func(row sqlquery.StringMap, columnName string) (any, error) {
 			statement := row[columnName]
 			obfuscated, err := s.obfuscator.obfuscateSQLString(statement)
@@ -2846,6 +2851,10 @@ func (s *sqlServerScraperHelper) recordDatabaseSampleQuery(ctx context.Context) 
 	for _, row := range rows {
 		queryHashVal := hex.EncodeToString([]byte(row[queryHash]))
 		if queryHashVal == "0000000000000000" {
+			continue
+		}
+		if strings.HasPrefix(row[statementText], "--") {
+			s.logger.Debug(fmt.Sprintf("skipping comment-only SQL statement: %v", row[statementText]))
 			continue
 		}
 		queryPlanHashVal := hex.EncodeToString([]byte(row[queryPlanHash]))

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -2877,12 +2877,8 @@ func (s *sqlServerScraperHelper) recordDatabaseSampleQuery(ctx context.Context) 
 			return obfuscated, nil
 		}).(string)
 
-		if queryTextVal == "" {
-			trimmedStatement := strings.TrimSpace(row[statementText])
-			idleBlockerEmptyOrComment := row[command] == "IDLE_BLOCKER" && (trimmedStatement == "" || strings.HasPrefix(trimmedStatement, "--"))
-			if !idleBlockerEmptyOrComment {
-				continue
-			}
+		if queryTextVal == "" && row[command] != "IDLE_BLOCKER" {
+			continue
 		}
 
 		var fullQueryTextVal, dbSQLCommentsVal, nrServiceGUIDVal, dbQueryTextNormalizedHashVal string

--- a/receiver/nrsqlserverreceiver/scraper.go
+++ b/receiver/nrsqlserverreceiver/scraper.go
@@ -2452,8 +2452,9 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 		queryPlanHashVal := hex.EncodeToString([]byte(row[queryPlanHash]))
 		procID := row[storedProcedureID]
 
-		if strings.HasPrefix(row[queryText], "--") {
-			s.logger.Debug(fmt.Sprintf("skipping comment-only SQL statement: %v", row[queryText]))
+		trimmedQueryText := strings.TrimSpace(row[queryText])
+		if trimmedQueryText == "" || strings.HasPrefix(trimmedQueryText, "--") {
+			s.logger.Debug(fmt.Sprintf("skipping empty or comment-only SQL statement: %v", row[queryText]))
 			continue
 		}
 
@@ -2461,12 +2462,16 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 			statement := row[columnName]
 			obfuscated, err := s.obfuscator.obfuscateSQLString(statement)
 			if err != nil {
-				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement: %v", statement))
+				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement, skipping event: %v, error: %v", statement, err))
 				return "", nil
 			}
 
 			return obfuscated, nil
 		})
+
+		if queryTextVal.(string) == "" {
+			continue
+		}
 
 		databaseNameVal := row[databaseName]
 
@@ -2853,8 +2858,9 @@ func (s *sqlServerScraperHelper) recordDatabaseSampleQuery(ctx context.Context) 
 		if queryHashVal == "0000000000000000" {
 			continue
 		}
-		if strings.HasPrefix(row[statementText], "--") {
-			s.logger.Debug(fmt.Sprintf("skipping comment-only SQL statement: %v", row[statementText]))
+		trimmedStatementText := strings.TrimSpace(row[statementText])
+		if row[command] != "IDLE_BLOCKER" && (trimmedStatementText == "" || strings.HasPrefix(trimmedStatementText, "--")) {
+			s.logger.Debug(fmt.Sprintf("skipping empty or comment-only SQL statement: %v", row[statementText]))
 			continue
 		}
 		queryPlanHashVal := hex.EncodeToString([]byte(row[queryPlanHash]))
@@ -2865,11 +2871,19 @@ func (s *sqlServerScraperHelper) recordDatabaseSampleQuery(ctx context.Context) 
 			statement := row[columnName]
 			obfuscated, err := s.obfuscator.obfuscateSQLString(statement)
 			if err != nil {
-				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement: %v", statement))
+				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement, skipping event: %v, error: %v", statement, err))
 				return "", nil
 			}
 			return obfuscated, nil
 		}).(string)
+
+		if queryTextVal == "" {
+			trimmedStatement := strings.TrimSpace(row[statementText])
+			idleBlockerEmptyOrComment := row[command] == "IDLE_BLOCKER" && (trimmedStatement == "" || strings.HasPrefix(trimmedStatement, "--"))
+			if !idleBlockerEmptyOrComment {
+				continue
+			}
+		}
 
 		var fullQueryTextVal, dbSQLCommentsVal, nrServiceGUIDVal, dbQueryTextNormalizedHashVal string
 		if s.config.CollectFullQueryText {

--- a/receiver/nrsqlserverreceiver/testdata/expectedRecordDatabaseSampleQueryWithInvalidData.yaml
+++ b/receiver/nrsqlserverreceiver/testdata/expectedRecordDatabaseSampleQueryWithInvalidData.yaml
@@ -39,7 +39,7 @@ resourceLogs:
                   stringValue: master
               - key: db.query.text
                 value:
-                  stringValue: ""
+                  stringValue: SELECT cpu_time
               - key: db.system.name
                 value:
                   stringValue: microsoft.sql_server

--- a/receiver/nrsqlserverreceiver/testdata/queryTextAndPlanQueryInvalidData.txt
+++ b/receiver/nrsqlserverreceiver/testdata/queryTextAndPlanQueryInvalidData.txt
@@ -13,7 +13,7 @@
 		"total_logical_writes": "4A",
 		"total_rows": "2A",
 		"total_grant_kb": "3096A",
-		"query_text": "SELECT cpu_time AS [CPU Usage (time)",
+		"query_text": "SELECT cpu_time AS [CPU Usage (time)]",
 		"query_plan": "<ShowPlanXML",
 		"procedure_id": "0",
 		"procedure_name": "",

--- a/receiver/nrsqlserverreceiver/testdata/recordInvalidDatabaseSampleQueryData.txt
+++ b/receiver/nrsqlserverreceiver/testdata/recordInvalidDatabaseSampleQueryData.txt
@@ -11,7 +11,7 @@
     "request_status": "running",
     "host_name": "DESKTOP-GHAEGRD",
     "command": "SELECT",
-    "statement_text": "SELECT cpu_time AS [CPU Usage (time)",
+    "statement_text": "SELECT cpu_time AS [CPU Usage (time)]",
     "blocking_session_id": "a71",
     "blocking_start_time": "2025-02-12T16:37:52.393+08:00",
     "resource_id": "72057594043359232",


### PR DESCRIPTION
SQL Server masks credential-bearing OPENROWSET statements as a placeholder comment (`--*UPDATE----`) in sys.dm_exec_sql_text. The obfuscator strips `--` comments to empty, producing empty db.query.text and a "?" full text. Skip any extracted statement starting with `--` in both the top-query and active query-sample paths.