### PR TITLE
fix: Revert host metric dependency change

### DIFF
--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 	"go.uber.org/multierr"
 
@@ -33,7 +34,7 @@ type Config struct {
 }
 
 var (
-	_ confmap.Validator   = (*Config)(nil)
+	_ xconfmap.Validator  = (*Config)(nil)
 	_ confmap.Unmarshaler = (*Config)(nil)
 )
 


### PR DESCRIPTION
#### Description

Reverts an unnecessary change to `receiver/hostmetricsreceiver/config.go` (`xconfmap.Validator` → `confmap.Validator`) that was introduced in #242 as part of syncing `receiver/nrmysqlreceiver`'s `go.mod` to match upstream `mysqlreceiver`.

That change was only needed to compile a local, untracked test harness that happens to bundle `nrmysqlreceiver` and `hostmetricsreceiver` into one binary for local end-to-end testing — it has no bearing on `nrmysqlreceiver`'s own dependency sync. `hostmetricsreceiver` is an independent Go module with its own `go.mod`/`go.sum`, unaffected by `nrmysqlreceiver`'s dependency versions in any real build or CI context. It was out of scope for that change and is reverted here to keep `hostmetricsreceiver` untouched.

#### Testing

- `go build ./...`, `go vet ./...`, and full `go test ./...` all pass in `receiver/hostmetricsreceiver` with the revert applied.
- `go build ./...` and `go test -count=1 -race ./...` pass in `receiver/nrmysqlreceiver`, confirming it's unaffected by this revert (it never depended on `hostmetricsreceiver`).

#### Documentation

No documentation changes.