### PR TITLE
Sync nr receiver dependencies to v0.158.0

### DIFF
--- a/NR_CHANGELOG.md
+++ b/NR_CHANGELOG.md
@@ -5,6 +5,34 @@ including confirmation of which breaking changes from [CHANGELOG.md](./CHANGELOG
 
 <!-- next version -->
 
+## v0.158.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/nroracledb` (upstream [#48643](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48643)):
+  `oracle.db.pdb` moved from a resource attribute to an opt-in data-point attribute. Already defined
+  as a data-point attribute in the fork's `metadata.yaml` — no fork change was required.
+
+- `receiver/nrpostgresql` (upstream [#49206](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49206)):
+  `postgresql.database.locks` is now collected per configured database via a dedicated
+  `getSharedRelationLocks` query for shared catalogs plus a database-scoped `getDatabaseLocks`
+  query, and the lock count switched from `COUNT(pid)` to `COUNT(*)` so locks held by prepared
+  transactions (NULL `pid`) are counted. **Not yet ported** — the fork's `getDatabaseLocks` in
+  `client.go` still runs the old unscoped, `COUNT(pid)`-based query with no `getSharedRelationLocks`
+  counterpart. Needs `sync-and-port-nr-receivers` before this behavior lands in the fork.
+
+### 🚩 New components 🚩
+
+- `receiver/nrpostgresql`: First tagged release. Forked from upstream `receiver/postgresql`; adds
+  `db_auth` credential provider support (e.g. AWS IAM), EXPLAIN-via-`SECURITY DEFINER`-function
+  support with per-database probe caching, pgvector similarity-search metrics, NR correlation
+  attribute extraction from SQL comments, and the `postgresql.query.execution.time` metric.
+
+- `receiver/nrmysql`: First tagged release. Forked from upstream `receiver/mysql`; adds NR
+  correlation attribute extraction and redaction on `db.query.text`, blocking-session detection and
+  client program name on `db.server.query_sample`, `explain_mode` for EXPLAIN-via-definer-procedure,
+  and rows examined/sent on `db.server.top_query`.
+
 ## v0.157.1
 
 ### 🛑 Breaking changes 🛑

--- a/receiver/nrmysqlreceiver/go.mod
+++ b/receiver/nrmysqlreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.156.1
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.158.0
 	github.com/stretchr/testify v1.11.1

--- a/receiver/nroracledbreceiver/go.mod
+++ b/receiver/nroracledbreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.157.1
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.158.0
 	github.com/sijms/go-ora/v2 v2.9.0

--- a/receiver/nrpostgresqlreceiver/go.mod
+++ b/receiver/nrpostgresqlreceiver/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/lib/pq v1.12.3
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.157.1
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrsqlquery v0.157.1
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.158.0
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrsqlquery v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.158.0
 	github.com/stretchr/testify v1.11.1

--- a/receiver/nrsqlserverreceiver/go.mod
+++ b/receiver/nrsqlserverreceiver/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/microsoft/go-mssqldb v1.9.6
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.157.1
-	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrsqlquery v0.157.1
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrcommon v0.158.0
+	github.com/newrelic-forks/opentelemetry-collector-contrib/internal/nrsqlquery v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.158.0
@@ -18,7 +18,6 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.158.1-0.20260813201048-a4a8565f65e7
 	go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260813201048-a4a8565f65e7
 	go.opentelemetry.io/collector/confmap v1.64.1-0.20260813201048-a4a8565f65e7
-	go.opentelemetry.io/collector/confmap/xconfmap v0.158.1-0.20260813201048-a4a8565f65e7
 	go.opentelemetry.io/collector/consumer v1.64.1-0.20260813201048-a4a8565f65e7
 	go.opentelemetry.io/collector/consumer/consumertest v0.158.1-0.20260813201048-a4a8565f65e7
 	go.opentelemetry.io/collector/featuregate v1.64.1-0.20260813201048-a4a8565f65e7

--- a/receiver/nrsqlserverreceiver/go.sum
+++ b/receiver/nrsqlserverreceiver/go.sum
@@ -219,8 +219,6 @@ go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260813201048-a4a85
 go.opentelemetry.io/collector/config/configopaque v1.64.1-0.20260813201048-a4a8565f65e7/go.mod h1:v1u94dp/WqAEZ7g9QutqWe46IjaQuRDXmYdvK02vqvs=
 go.opentelemetry.io/collector/confmap v1.64.1-0.20260813201048-a4a8565f65e7 h1:0yI/MOaMbPbg/4Z8ISfBYiwm9zFT3wxQ+3NFHSjcJdM=
 go.opentelemetry.io/collector/confmap v1.64.1-0.20260813201048-a4a8565f65e7/go.mod h1:vAwdZZ81VsgHzLYaHaT7y9OqCGaum+SEdGBhMadv+xo=
-go.opentelemetry.io/collector/confmap/xconfmap v0.158.1-0.20260813201048-a4a8565f65e7 h1:2YN9fLNyYT4/+/lQ+H7MudVfXJOugFfF4M1Qc+M4ioM=
-go.opentelemetry.io/collector/confmap/xconfmap v0.158.1-0.20260813201048-a4a8565f65e7/go.mod h1:6bbSW7mn0XW0cT/nBqWTt2lxrFOMm2bruSD2daT/1/o=
 go.opentelemetry.io/collector/consumer v1.64.1-0.20260813201048-a4a8565f65e7 h1:k2sCsPny49mTbXOE8K1oO15/MFUXvf4SWLS97C8wdDY=
 go.opentelemetry.io/collector/consumer v1.64.1-0.20260813201048-a4a8565f65e7/go.mod h1:PZali8XcmKh7I6UR17iu+pHsWddVbppQ4kFrrilB7X4=
 go.opentelemetry.io/collector/consumer/consumererror v0.158.1-0.20260813201048-a4a8565f65e7 h1:lxMvCZMJ/ZFkGyF5ku+Wka0udL4t0haVFtCKt+Pjooc=


### PR DESCRIPTION
## Description
Aligns `internal/nrcommon` and `internal/nrsqlquery` to `v0.158.0` across all four nr-prefixed receivers (`nroracledb, `nrsqlserver`, `nrpostgresql`, `nrmysql`), matching the versions already merged in PR #258. Also drops the unused xconfmap require left over from the earlier xconfmap.Validate to confmap.Validate migration in nrsqlserverreceiver's go.mod/go.sum.

Adds the v0.158.0 entry to `NR_CHANGELOG.md` covering the breaking change review for `nroracledb` and `nrpostgresql`, and documenting the first tagged releases of `nrpostgresql and nrmysql`.

## Testing
Ran build, test, make generate, make fmt (gofumpt/gci), make lint, and schema regeneration (schemagen) for all four receivers. No drift, all green.

## Documentation
NR_CHANGELOG.md updated as part of this PR.