### PR TITLE
[receiver/nrpostgresql] Normalize backend_start to UTC on query_sample events

### DIFF
--- a/.chloggen/nrpostgresql-backend-start-utc.yaml
+++ b/.chloggen/nrpostgresql-backend-start-utc.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nrpostgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Normalize `postgresql.backend_start` to UTC on `db.server.query_sample`, matching `postgresql.blocking.start_time`'s existing UTC formatting, so the two are directly comparable regardless of the connecting session's timezone.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50113]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/nrpostgresqlreceiver/templates/querySampleTemplate.tmpl
+++ b/receiver/nrpostgresqlreceiver/templates/querySampleTemplate.tmpl
@@ -5,7 +5,9 @@
     COALESCE(sa.client_hostname, '') AS client_hostname,
     COALESCE(sa.client_port::TEXT, '') AS client_port,
     COALESCE(sa.query_start::TEXT, '') AS query_start,
-    COALESCE(sa.backend_start::TEXT, '') AS backend_start,
+    CASE WHEN sa.backend_start IS NOT NULL
+         THEN to_char(sa.backend_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+         ELSE '' END AS backend_start,
     COALESCE(EXTRACT(EPOCH FROM (clock_timestamp() - sa.backend_start))::BIGINT, 0) AS session_duration,
     COALESCE(sa.wait_event_type, '') AS wait_event_type,
     COALESCE(sa.wait_event, '') AS wait_event,

--- a/receiver/nrpostgresqlreceiver/testdata/scraper/query-sample/expectedSql.sql
+++ b/receiver/nrpostgresqlreceiver/testdata/scraper/query-sample/expectedSql.sql
@@ -5,7 +5,9 @@
     COALESCE(sa.client_hostname, '') AS client_hostname,
     COALESCE(sa.client_port::TEXT, '') AS client_port,
     COALESCE(sa.query_start::TEXT, '') AS query_start,
-    COALESCE(sa.backend_start::TEXT, '') AS backend_start,
+    CASE WHEN sa.backend_start IS NOT NULL
+         THEN to_char(sa.backend_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+         ELSE '' END AS backend_start,
     COALESCE(EXTRACT(EPOCH FROM (clock_timestamp() - sa.backend_start))::BIGINT, 0) AS session_duration,
     COALESCE(sa.wait_event_type, '') AS wait_event_type,
     COALESCE(sa.wait_event, '') AS wait_event,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
`postgresql.backend_start` on `db.server.query_sample` was a raw `::TEXT` cast of `pg_stat_activity.backend_start`, so its format depends on the connecting session's timezone. `postgresql.blocking.start_time` on the
same event already normalizes to UTC via `to_char(bl.waitstart AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`.

This PR applies the same UTC normalization to `backend_start`, so the two fields are always directly comparable regardless of session timezone. This matters for consumers that compare `backend_start` against `blocking.start_time` to resolve which session instance was blocking at the time of a lock wait (PIDs get reused, so pid alone isn't enough).

Reproduced live: setting a session to a non-UTC timezone and running the receiver's own expressions side by side showed two different string formats for the same instant before this fix (`2026-08-24 05:55:46.568699-04` vs `2026-08-24T09:55:46Z`).
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50113

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Updated testdata/scraper/query-sample/expectedSql.sql to match the new template SQL.
- go test ./... passes for receiver/nrpostgresqlreceiver.
- Verified live against a running PostgreSQL container: set session timezone to America/New_York and confirmed backend_start now emits UTC-normalized, ISO8601 output matching blocking.start_time's format.
<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
