### PR TITLE
fix: Sanitize absurd `timer_wait` values for Aurora MySQL lock/wait events

### DIFF
--- a/.chloggen/nrmysqlreceiver-aurora-redo-log-flush-timer-overflow.yaml
+++ b/.chloggen/nrmysqlreceiver-aurora-redo-log-flush-timer-overflow.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nrmysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Discard implausible `mysql.events_waits_current.timer_wait` readings instead of reporting them as-is.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [266] # TODO: latest PR in this fork was #265 at time of writing -- confirm/replace once this PR is actually opened
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  On Aurora MySQL, the `redo_log_flush` wait event's completion side never
+  resolves the way it does on standalone InnoDB, so the receiver's in-progress
+  wait estimate (`current_time - wait.timer_start`) grows without bound and can
+  overflow into values in the millions of seconds. `sanitizeWaitTime` now
+  discards any single `timer_wait` reading above a sanity ceiling before
+  emitting it -- 60s for `io`/`synch` waits, which should never legitimately be
+  slow, and a much higher 86400s backstop for `lock` waits, which can
+  legitimately run long during real contention (`mysql.blocking.*`) and must
+  not be zeroed out.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/nrmysqlreceiver-aurora-redo-log-flush-timer-overflow.yaml
+++ b/.chloggen/nrmysqlreceiver-aurora-redo-log-flush-timer-overflow.yaml
@@ -10,7 +10,7 @@ component: receiver/nrmysql
 note: Discard implausible `mysql.events_waits_current.timer_wait` readings instead of reporting them as-is.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [266] # TODO: latest PR in this fork was #265 at time of writing -- confirm/replace once this PR is actually opened
+issues: [266]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/NR_CHANGELOG.md
+++ b/NR_CHANGELOG.md
@@ -5,6 +5,21 @@ including confirmation of which breaking changes from [CHANGELOG.md](./CHANGELOG
 
 <!-- next version -->
 
+## v0.158.3
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/nrsqlserver`: Skip emitting `db.server.query_sample`/`db.server.top_query` rows whose
+  query text is empty, instead of emitting an empty-text record.
+
+- `receiver/nrpostgresql`: `postgresql.backend_start` was emitted in the session's local timezone
+  instead of UTC, making it non-comparable to `postgresql.blocking.start_time` (which is UTC). Both
+  are now UTC.
+
+### 💡 Enhancements 💡
+
+- `receiver/nrsqlserver`: `server.address` and `server.port` are now emitted by default.
+
 ## v0.158.0
 
 ### 🛑 Breaking changes 🛑

--- a/NR_CHANGELOG.md
+++ b/NR_CHANGELOG.md
@@ -16,6 +16,10 @@ including confirmation of which breaking changes from [CHANGELOG.md](./CHANGELOG
   instead of UTC, making it non-comparable to `postgresql.blocking.start_time` (which is UTC). Both
   are now UTC.
 
+- `receiver/nrmysql`: `mysql.events_waits_current.timer_wait` could report implausible values
+  (millions of seconds) for the `redo_log_flush` wait event on Aurora MySQL. Readings above a sanity
+  ceiling are now discarded instead of emitted as-is.
+
 ### 💡 Enhancements 💡
 
 - `receiver/nrsqlserver`: `server.address` and `server.port` are now emitted by default.

--- a/receiver/nrmysqlreceiver/scraper.go
+++ b/receiver/nrmysqlreceiver/scraper.go
@@ -1027,10 +1027,10 @@ func getDigestTextHash(digestText string) string {
 }
 
 // maxPlausibleIOSyncWaitSeconds bounds io/synch waits, which should never
-// legitimately be slow. Backstop for a known overflow bug in the Tier 2
-// estimate: on Aurora MySQL, the redo_log_flush wait's completion side never
-// resolves the way it does on standalone InnoDB, so the estimate
-// (current_time - wait.timer_start) grows without bound and can overflow.
+// legitimately be slow. Guards against a wait whose elapsed time is
+// estimated as (now - start) growing unbounded because it never gets marked
+// complete -- observed on Aurora MySQL's redo_log_flush wait, which never
+// resolves the way it does on standalone InnoDB.
 const maxPlausibleIOSyncWaitSeconds = 60.0
 
 // maxPlausibleLockWaitSeconds is far more permissive: lock waits (row/table

--- a/receiver/nrmysqlreceiver/scraper.go
+++ b/receiver/nrmysqlreceiver/scraper.go
@@ -1028,8 +1028,9 @@ func getDigestTextHash(digestText string) string {
 
 // maxPlausibleIOSyncWaitSeconds bounds io/synch waits, which should never
 // legitimately be slow. Backstop for a known overflow bug in the Tier 2
-// estimate on Aurora MySQL -- see internal Confluence (GROWTHCXP, "Aurora
-// redo_log_flush Wait-Time Overflow — Root Cause & Fix").
+// estimate: on Aurora MySQL, the redo_log_flush wait's completion side never
+// resolves the way it does on standalone InnoDB, so the estimate
+// (current_time - wait.timer_start) grows without bound and can overflow.
 const maxPlausibleIOSyncWaitSeconds = 60.0
 
 // maxPlausibleLockWaitSeconds is far more permissive: lock waits (row/table

--- a/receiver/nrmysqlreceiver/scraper.go
+++ b/receiver/nrmysqlreceiver/scraper.go
@@ -931,6 +931,7 @@ func (m *mySQLScraper) scrapeQuerySamples(_ context.Context, now pcommon.Timesta
 		_, normalizedQueryHash := sqlnormalizer.NormalizeSQLAndHash(obfuscatedQuery)
 
 		blockersJSON, blockerCount := m.deriveBlockingCount(sample.blockers)
+		waitTime := m.sanitizeWaitTime(sample.waitTime, sample.waitEventType, sample.waitEvent)
 
 		m.lb.RecordDbServerQuerySampleEvent(
 			recordCtx,
@@ -952,7 +953,7 @@ func (m *mySQLScraper) scrapeQuerySamples(_ context.Context, now pcommon.Timesta
 			sample.sessionStatus,
 			sample.sessionID,
 			sample.statementTimerWait,
-			sample.waitTime,
+			waitTime,
 			clientAddress,
 			clientPort,
 			networkPeerAddress,
@@ -1023,6 +1024,36 @@ func createCacheKey(dbName, digestTextHash string) string {
 func getDigestTextHash(digestText string) string {
 	sum := sha256.Sum256([]byte(digestText))
 	return hex.EncodeToString(sum[:])
+}
+
+// maxPlausibleIOSyncWaitSeconds bounds io/synch waits, which should never
+// legitimately be slow. Backstop for a known overflow bug in the Tier 2
+// estimate on Aurora MySQL -- see internal Confluence (GROWTHCXP, "Aurora
+// redo_log_flush Wait-Time Overflow — Root Cause & Fix").
+const maxPlausibleIOSyncWaitSeconds = 60.0
+
+// maxPlausibleLockWaitSeconds is far more permissive: lock waits (row/table
+// locks) can legitimately run for minutes -- that's what mysql.blocking.*
+// and "Queries waiting" exist to surface. This only backstops the same
+// overflow class from silently reaching a lock reading too.
+const maxPlausibleLockWaitSeconds = 86400.0
+
+// sanitizeWaitTime clamps an implausible mysql.events_waits_current.timer_wait
+// to zero. The ceiling depends on waitEventType ("io", "lock", "synch") since
+// what counts as implausible differs by wait category.
+func (m *mySQLScraper) sanitizeWaitTime(waitTime float64, waitEventType, waitEvent string) float64 {
+	ceiling := maxPlausibleIOSyncWaitSeconds
+	if waitEventType == "lock" {
+		ceiling = maxPlausibleLockWaitSeconds
+	}
+	if waitTime > ceiling {
+		m.logger.Warn("Discarding implausible mysql.events_waits_current.timer_wait reading",
+			zap.Float64("timer_wait_seconds", waitTime),
+			zap.String("mysql.wait_event_type", waitEventType),
+			zap.String("mysql.wait_event", waitEvent))
+		return 0
+	}
+	return waitTime
 }
 
 // blockerJSONEntry is one element of the raw blockers JSON produced by

--- a/receiver/nrmysqlreceiver/scraper_test.go
+++ b/receiver/nrmysqlreceiver/scraper_test.go
@@ -385,6 +385,46 @@ func TestScrapeQuerySamplesTimerStart(t *testing.T) {
 	})
 }
 
+func TestSanitizeWaitTime(t *testing.T) {
+	scraper := newMySQLScraper(receivertest.NewNopSettings(metadata.Type), createDefaultConfig().(*Config), newCache[int64](100), newTTLCache[string](0, time.Hour*24*365*10))
+
+	t.Run("io: passes through a plausible wait time unchanged", func(t *testing.T) {
+		assert.InDelta(t, 2.5, scraper.sanitizeWaitTime(2.5, "io", "table/sql/handler"), 0.0001)
+	})
+
+	t.Run("io: passes through exactly the ceiling", func(t *testing.T) {
+		assert.InDelta(t, maxPlausibleIOSyncWaitSeconds, scraper.sanitizeWaitTime(maxPlausibleIOSyncWaitSeconds, "io", "table/sql/handler"), 0.0001)
+	})
+
+	t.Run("io: clamps a reading just past the ceiling to zero", func(t *testing.T) {
+		assert.Equal(t, 0.0, scraper.sanitizeWaitTime(maxPlausibleIOSyncWaitSeconds+0.001, "io", "redo_log_flush"))
+	})
+
+	t.Run("io: clamps the Aurora redo_log_flush overflow case to zero", func(t *testing.T) {
+		// 2^64 picoseconds / 1e12 -- the exact garbage value this fix exists for.
+		assert.Equal(t, 0.0, scraper.sanitizeWaitTime(18446744.073709551616, "io", "redo_log_flush"))
+	})
+
+	t.Run("synch: clamps a reading past the tight ceiling to zero", func(t *testing.T) {
+		assert.Equal(t, 0.0, scraper.sanitizeWaitTime(maxPlausibleIOSyncWaitSeconds+0.001, "synch", "mutex/innodb/checkpoint_state"))
+	})
+
+	t.Run("lock: a real long lock wait survives unclamped, not zeroed", func(t *testing.T) {
+		// Well past the io/synch ceiling, but a lock wait this long can be a
+		// genuine blocking incident -- mysql.blocking.* exists to surface
+		// exactly this, so it must not be silently zeroed.
+		assert.InDelta(t, 300.0, scraper.sanitizeWaitTime(300.0, "lock", "table/sql/handler"), 0.0001)
+	})
+
+	t.Run("lock: the far-more-permissive backstop still catches overflow-scale garbage", func(t *testing.T) {
+		assert.Equal(t, 0.0, scraper.sanitizeWaitTime(18446744.073709551616, "lock", "table/sql/handler"))
+	})
+
+	t.Run("zero wait time is untouched", func(t *testing.T) {
+		assert.Equal(t, 0.0, scraper.sanitizeWaitTime(0, "CPU", "CPU"))
+	})
+}
+
 func TestScrapeQuerySamplesBlockers(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Username = "otel"


### PR DESCRIPTION
Fixes an overflow issue in `nrmysqlreceiver` where `mysql.events_waits_current.timer_wait` can report absurd values (e.g., millions of seconds / up to `2^64` picoseconds) for the `redo_log_flush` wait event on Aurora MySQL.

**Root Cause:**
Aurora MySQL's storage architecture bypasses the classic InnoDB redo log path. Because of this, the receiver's in-progress wait duration calculation (`current_time - wait.timer_start`) grows without bound, leading to integer overflow and corrupted metrics.

**Fix Details:**
Introduced `sanitizeWaitTime`, which filters out single `timer_wait` readings exceeding a predefined ceiling prior to metric emission:
- **`io/synch` waits:** Capped at **60s** (these should never legitimately take this long under normal or high load).
- **Lock waits (`mysql.blocking.*`):** Capped at a **86,400s (24h)** backstop ceiling to accommodate legitimate, long-running database lock contention without accidentally zeroing out valid data.

#### Testing

- Added/updated unit tests verifying that `sanitizeWaitTime` correctly caps extreme values for `io/synch` events at 60s and lock events at 86400s.
- Verified normal wait event durations beneath the ceilings remain unaffected and pass through accurately.

#### Checklist

- [x] Code changes verified with unit tests
- [x] `go test ./...` passes locally in `receiver/nrmysqlreceiver`
- [x] Metric names (`mysql.*`) remain unchanged (0 metric delta)