### PR TITLE
sqlserverreceiver: add db.server.procedure_metrics event collection

### DIFF
--- a/receiver/sqlserverreceiver/config.go
+++ b/receiver/sqlserverreceiver/config.go
@@ -40,6 +40,10 @@ type ConnectionPool struct {
 	_ struct{}
 }
 
+type ProcedureMetrics struct {
+	TopProcedureCount int64 `mapstructure:"top_procedure_count"`
+}
+
 type TopQueryCollection struct {
 	// Enabled enables the collection of the top queries by the execution time.
 	// It will collect the top N queries based on totalElapsedTimeDiffs during the last collection interval.
@@ -65,6 +69,8 @@ type Config struct {
 	TopQueryCollection TopQueryCollection `mapstructure:"top_query_collection"`
 
 	QuerySample QuerySample `mapstructure:"query_sample_collection"`
+
+	ProcedureMetrics ProcedureMetrics `mapstructure:"procedure_metrics"`
 
 	// ConnectionPool tunes the shared database connection pool used by all
 	// scrapers of this receiver.

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -1253,6 +1253,34 @@ events:
     enabled: true
 ```
 
+### db.server.procedure_metrics
+
+Aggregated performance metrics for stored procedures, with delta computation on cumulative counters.
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| db.system.name | The database management system (DBMS) product as identified by the client instrumentation. | Any Str | - |
+| db.namespace | The database name. | Any Str | - |
+| server.address | The network address of the server hosting the database. | Any Str | - |
+| server.port | The port number on which the server is listening. | Any Int | - |
+| sqlserver.procedure_id | The SQL Server ID of the stored procedure, if any | Any Str | - |
+| sqlserver.procedure_name | The name of the stored procedure, if any | Any Str | - |
+| sqlserver.procedure.schema_name | Schema of the stored procedure. | Any Str | - |
+| sqlserver.procedure.database_name | Database containing the stored procedure. | Any Str | - |
+| sqlserver.procedure_execution_count | Number of times that the procedure has been executed since it was last compiled, reported in delta value. | Any Int | - |
+| sqlserver.total_worker_time | Total amount of CPU time that was consumed by executions of this plan since it was compiled, reported in delta seconds. | Any Double | - |
+| sqlserver.total_elapsed_time | Total elapsed time for completed executions of this plan, reported in delta seconds. | Any Double | - |
+| sqlserver.total_logical_reads | Total number of logical reads performed by executions of this plan since it was compiled, reported in delta value. | Any Int | - |
+| sqlserver.total_logical_writes | Total number of logical writes performed by executions of this plan since it was compiled, reported in delta value. | Any Int | - |
+| sqlserver.total_physical_reads | Total number of physical reads performed by executions of this plan since it was compiled, reported in delta value. | Any Int | - |
+| sqlserver.procedure.total_spills | Total tempdb spills caused by the procedure, reported in delta value. | Any Int | - |
+| sqlserver.procedure.avg_elapsed_time_ms | Average elapsed time per execution in milliseconds. | Any Double | - |
+| sqlserver.procedure.max_elapsed_time_ms | Maximum elapsed time across executions in milliseconds. | Any Double | - |
+| sqlserver.procedure.min_elapsed_time_ms | Minimum elapsed time across executions in milliseconds. | Any Double | - |
+| sqlserver.procedure.last_execution_time | ISO 8601 timestamp of the last execution of the procedure. | Any Str | - |
+
 ### db.server.query_sample
 
 query sample

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -62,6 +62,9 @@ func createDefaultConfig() component.Config {
 			TopQueryCount:       250,
 			CollectionInterval:  time.Minute,
 		},
+		ProcedureMetrics: ProcedureMetrics{
+			TopProcedureCount: 250,
+		},
 	}
 }
 
@@ -116,6 +119,10 @@ func setupLogQueries(cfg *Config) []string {
 
 	if cfg.LogsBuilderConfig.Events.DbServerTopQuery.Enabled {
 		queries = append(queries, getSQLServerQueryTextAndPlanQuery())
+	}
+
+	if cfg.LogsBuilderConfig.Events.DbServerProcedureMetrics.Enabled {
+		queries = append(queries, getSQLServerProcedureMetricsQuery(cfg.ProcedureMetrics.TopProcedureCount, cfg.InstanceName))
 	}
 
 	return queries
@@ -337,6 +344,10 @@ func setupSQLServerLogsScrapers(params receiver.Settings, cfg *Config) ([]*sqlSe
 
 		if query == getSQLServerQuerySamplesQuery() {
 			cache = newCache(1)
+		}
+
+		if query == getSQLServerProcedureMetricsQuery(cfg.ProcedureMetrics.TopProcedureCount, cfg.InstanceName) {
+			cache = newCache(int(cfg.ProcedureMetrics.TopProcedureCount * 7 * 2))
 		}
 
 		sqlServerScraper := newSQLServerScraper(id, query,

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -51,6 +51,9 @@ func TestFactory(t *testing.T) {
 					QuerySample: QuerySample{
 						MaxRowsPerQuery: 100,
 					},
+					ProcedureMetrics: ProcedureMetrics{
+						TopProcedureCount: 250,
+					},
 					MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
 					LogsBuilderConfig:    metadata.DefaultLogsBuilderConfig(),
 				}

--- a/receiver/sqlserverreceiver/generated_package_test.go
+++ b/receiver/sqlserverreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package sqlserverreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/sqlserverreceiver/internal/metadata/generated_config.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_config.go
@@ -3463,12 +3463,16 @@ func (ec *EventConfig) Unmarshal(parser *confmap.Conf) error {
 
 // EventsConfig provides config for sqlserver events.
 type EventsConfig struct {
-	DbServerQuerySample EventConfig `mapstructure:"db.server.query_sample"`
-	DbServerTopQuery    EventConfig `mapstructure:"db.server.top_query"`
+	DbServerProcedureMetrics EventConfig `mapstructure:"db.server.procedure_metrics"`
+	DbServerQuerySample      EventConfig `mapstructure:"db.server.query_sample"`
+	DbServerTopQuery         EventConfig `mapstructure:"db.server.top_query"`
 }
 
 func DefaultEventsConfig() EventsConfig {
 	return EventsConfig{
+		DbServerProcedureMetrics: EventConfig{
+			Enabled: false,
+		},
 		DbServerQuerySample: EventConfig{
 			Enabled: false,
 		},

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -12,6 +11,60 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/otel/trace"
 )
+
+type eventDbServerProcedureMetrics struct {
+	data   plog.LogRecordSlice // data buffer for generated log records.
+	config EventConfig         // event config provided by user.
+}
+
+func (e *eventDbServerProcedureMetrics) recordEvent(ctx context.Context, timestamp pcommon.Timestamp, dbSystemNameAttributeValue string, dbNamespaceAttributeValue string, serverAddressAttributeValue string, serverPortAttributeValue int64, sqlserverProcedureIDAttributeValue string, sqlserverProcedureNameAttributeValue string, sqlserverProcedureSchemaNameAttributeValue string, sqlserverProcedureDatabaseNameAttributeValue string, sqlserverProcedureExecutionCountAttributeValue int64, sqlserverTotalWorkerTimeAttributeValue float64, sqlserverTotalElapsedTimeAttributeValue float64, sqlserverTotalLogicalReadsAttributeValue int64, sqlserverTotalLogicalWritesAttributeValue int64, sqlserverTotalPhysicalReadsAttributeValue int64, sqlserverProcedureTotalSpillsAttributeValue int64, sqlserverProcedureAvgElapsedTimeMsAttributeValue float64, sqlserverProcedureMaxElapsedTimeMsAttributeValue float64, sqlserverProcedureMinElapsedTimeMsAttributeValue float64, sqlserverProcedureLastExecutionTimeAttributeValue string) {
+	if !e.config.Enabled {
+		return
+	}
+	dp := e.data.AppendEmpty()
+	dp.SetEventName("db.server.procedure_metrics")
+	dp.SetTimestamp(timestamp)
+
+	if span := trace.SpanContextFromContext(ctx); span.IsValid() {
+		dp.SetTraceID(pcommon.TraceID(span.TraceID()))
+		dp.SetSpanID(pcommon.SpanID(span.SpanID()))
+	}
+	dp.Attributes().PutStr("db.system.name", dbSystemNameAttributeValue)
+	dp.Attributes().PutStr("db.namespace", dbNamespaceAttributeValue)
+	dp.Attributes().PutStr("server.address", serverAddressAttributeValue)
+	dp.Attributes().PutInt("server.port", serverPortAttributeValue)
+	dp.Attributes().PutStr("sqlserver.procedure_id", sqlserverProcedureIDAttributeValue)
+	dp.Attributes().PutStr("sqlserver.procedure_name", sqlserverProcedureNameAttributeValue)
+	dp.Attributes().PutStr("sqlserver.procedure.schema_name", sqlserverProcedureSchemaNameAttributeValue)
+	dp.Attributes().PutStr("sqlserver.procedure.database_name", sqlserverProcedureDatabaseNameAttributeValue)
+	dp.Attributes().PutInt("sqlserver.procedure_execution_count", sqlserverProcedureExecutionCountAttributeValue)
+	dp.Attributes().PutDouble("sqlserver.total_worker_time", sqlserverTotalWorkerTimeAttributeValue)
+	dp.Attributes().PutDouble("sqlserver.total_elapsed_time", sqlserverTotalElapsedTimeAttributeValue)
+	dp.Attributes().PutInt("sqlserver.total_logical_reads", sqlserverTotalLogicalReadsAttributeValue)
+	dp.Attributes().PutInt("sqlserver.total_logical_writes", sqlserverTotalLogicalWritesAttributeValue)
+	dp.Attributes().PutInt("sqlserver.total_physical_reads", sqlserverTotalPhysicalReadsAttributeValue)
+	dp.Attributes().PutInt("sqlserver.procedure.total_spills", sqlserverProcedureTotalSpillsAttributeValue)
+	dp.Attributes().PutDouble("sqlserver.procedure.avg_elapsed_time_ms", sqlserverProcedureAvgElapsedTimeMsAttributeValue)
+	dp.Attributes().PutDouble("sqlserver.procedure.max_elapsed_time_ms", sqlserverProcedureMaxElapsedTimeMsAttributeValue)
+	dp.Attributes().PutDouble("sqlserver.procedure.min_elapsed_time_ms", sqlserverProcedureMinElapsedTimeMsAttributeValue)
+	dp.Attributes().PutStr("sqlserver.procedure.last_execution_time", sqlserverProcedureLastExecutionTimeAttributeValue)
+
+}
+
+// emit appends recorded event data to a events slice and prepares it for recording another set of log records.
+func (e *eventDbServerProcedureMetrics) emit(lrs plog.LogRecordSlice) {
+	if e.config.Enabled && e.data.Len() > 0 {
+		e.data.MoveAndAppendTo(lrs)
+	}
+}
+
+func newEventDbServerProcedureMetrics(cfg EventConfig) eventDbServerProcedureMetrics {
+	e := eventDbServerProcedureMetrics{config: cfg}
+	if cfg.Enabled {
+		e.data = plog.NewLogRecordSlice()
+	}
+	return e
+}
 
 type eventDbServerQuerySample struct {
 	data   plog.LogRecordSlice // data buffer for generated log records.
@@ -154,6 +207,7 @@ type LogsBuilder struct {
 	buildInfo                      component.BuildInfo // contains version information.
 	resourceAttributeIncludeFilter map[string]filter.Filter
 	resourceAttributeExcludeFilter map[string]filter.Filter
+	eventDbServerProcedureMetrics  eventDbServerProcedureMetrics
 	eventDbServerQuerySample       eventDbServerQuerySample
 	eventDbServerTopQuery          eventDbServerTopQuery
 }
@@ -169,6 +223,7 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 		logsBuffer:                     plog.NewLogs(),
 		logRecordsBuffer:               plog.NewLogRecordSlice(),
 		buildInfo:                      settings.BuildInfo,
+		eventDbServerProcedureMetrics:  newEventDbServerProcedureMetrics(lbc.Events.DbServerProcedureMetrics),
 		eventDbServerQuerySample:       newEventDbServerQuerySample(lbc.Events.DbServerQuerySample),
 		eventDbServerTopQuery:          newEventDbServerTopQuery(lbc.Events.DbServerTopQuery),
 		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
@@ -271,6 +326,7 @@ func (lb *LogsBuilder) EmitForResource(options ...ResourceLogsOption) {
 	ils := rl.ScopeLogs().AppendEmpty()
 	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(lb.buildInfo.Version)
+	lb.eventDbServerProcedureMetrics.emit(ils.LogRecords())
 	lb.eventDbServerQuerySample.emit(ils.LogRecords())
 	lb.eventDbServerTopQuery.emit(ils.LogRecords())
 
@@ -307,6 +363,11 @@ func (lb *LogsBuilder) Emit(options ...ResourceLogsOption) plog.Logs {
 	logs := lb.logsBuffer
 	lb.logsBuffer = plog.NewLogs()
 	return logs
+}
+
+// RecordDbServerProcedureMetricsEvent adds a log record of db.server.procedure_metrics event.
+func (lb *LogsBuilder) RecordDbServerProcedureMetricsEvent(ctx context.Context, timestamp pcommon.Timestamp, dbSystemNameAttributeValue string, dbNamespaceAttributeValue string, serverAddressAttributeValue string, serverPortAttributeValue int64, sqlserverProcedureIDAttributeValue string, sqlserverProcedureNameAttributeValue string, sqlserverProcedureSchemaNameAttributeValue string, sqlserverProcedureDatabaseNameAttributeValue string, sqlserverProcedureExecutionCountAttributeValue int64, sqlserverTotalWorkerTimeAttributeValue float64, sqlserverTotalElapsedTimeAttributeValue float64, sqlserverTotalLogicalReadsAttributeValue int64, sqlserverTotalLogicalWritesAttributeValue int64, sqlserverTotalPhysicalReadsAttributeValue int64, sqlserverProcedureTotalSpillsAttributeValue int64, sqlserverProcedureAvgElapsedTimeMsAttributeValue float64, sqlserverProcedureMaxElapsedTimeMsAttributeValue float64, sqlserverProcedureMinElapsedTimeMsAttributeValue float64, sqlserverProcedureLastExecutionTimeAttributeValue string) {
+	lb.eventDbServerProcedureMetrics.recordEvent(ctx, timestamp, dbSystemNameAttributeValue, dbNamespaceAttributeValue, serverAddressAttributeValue, serverPortAttributeValue, sqlserverProcedureIDAttributeValue, sqlserverProcedureNameAttributeValue, sqlserverProcedureSchemaNameAttributeValue, sqlserverProcedureDatabaseNameAttributeValue, sqlserverProcedureExecutionCountAttributeValue, sqlserverTotalWorkerTimeAttributeValue, sqlserverTotalElapsedTimeAttributeValue, sqlserverTotalLogicalReadsAttributeValue, sqlserverTotalLogicalWritesAttributeValue, sqlserverTotalPhysicalReadsAttributeValue, sqlserverProcedureTotalSpillsAttributeValue, sqlserverProcedureAvgElapsedTimeMsAttributeValue, sqlserverProcedureMaxElapsedTimeMsAttributeValue, sqlserverProcedureMinElapsedTimeMsAttributeValue, sqlserverProcedureLastExecutionTimeAttributeValue)
 }
 
 // RecordDbServerQuerySampleEvent adds a log record of db.server.query_sample event.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_logs_test.go
@@ -4,9 +4,6 @@ package metadata
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 type eventsTestDataSet int
@@ -137,6 +136,9 @@ func TestLogsBuilder(t *testing.T) {
 			allEventsCount := 0
 
 			allEventsCount++
+			lb.RecordDbServerProcedureMetricsEvent(ctx, timestamp, "db.system.name-val", "db.namespace-val", "server.address-val", 11, "sqlserver.procedure_id-val", "sqlserver.procedure_name-val", "sqlserver.procedure.schema_name-val", "sqlserver.procedure.database_name-val", 35, 27.100000, 28.100000, 29, 30, 30, 32, 39.100000, 39.100000, 39.100000, "sqlserver.procedure.last_execution_time-val")
+
+			allEventsCount++
 			lb.RecordDbServerQuerySampleEvent(ctx, timestamp, "client.address-val", 11, "db.namespace-val", "db.query.text-val", "db.system.name-val", "network.peer.address-val", 17, 29, "sqlserver.blocking.start_time-val", "sqlserver.client.app.name-val", "sqlserver.context_info-val", "sqlserver.command-val", 18.100000, 27, 35.100000, 22.100000, 23, 32, 26.100000, "sqlserver.query_hash-val", "sqlserver.query_plan_hash-val", "sqlserver.query_start-val", 15, "sqlserver.request_status-val", "sqlserver.wait.resource.id-val", "sqlserver.wait.resource.type-val", 19, 26.100000, "sqlserver.session.start_time-val", 20, "sqlserver.session_status-val", 28.100000, 24, 37, "sqlserver.wait_resource-val", 19.100000, "sqlserver.wait_type-val", 16, "user.name-val", "sqlserver.procedure_id-val", "sqlserver.procedure_name-val")
 
 			allEventsCount++
@@ -174,6 +176,70 @@ func TestLogsBuilder(t *testing.T) {
 			validatedEvents := make(map[string]bool)
 			for i := 0; i < lrs.Len(); i++ {
 				switch lrs.At(i).EventName() {
+				case "db.server.procedure_metrics":
+					assert.False(t, validatedEvents["db.server.procedure_metrics"], "Found a duplicate in the events slice: db.server.procedure_metrics")
+					validatedEvents["db.server.procedure_metrics"] = true
+					lr := lrs.At(i)
+					assert.Equal(t, timestamp, lr.Timestamp())
+					assert.Equal(t, pcommon.TraceID(traceID), lr.TraceID())
+					assert.Equal(t, pcommon.SpanID(spanID), lr.SpanID())
+					attrVal, ok := lr.Attributes().Get("db.system.name")
+					assert.True(t, ok)
+					assert.Equal(t, "db.system.name-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("db.namespace")
+					assert.True(t, ok)
+					assert.Equal(t, "db.namespace-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("server.address")
+					assert.True(t, ok)
+					assert.Equal(t, "server.address-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("server.port")
+					assert.True(t, ok)
+					assert.EqualValues(t, 11, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure_id")
+					assert.True(t, ok)
+					assert.Equal(t, "sqlserver.procedure_id-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure_name")
+					assert.True(t, ok)
+					assert.Equal(t, "sqlserver.procedure_name-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.schema_name")
+					assert.True(t, ok)
+					assert.Equal(t, "sqlserver.procedure.schema_name-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.database_name")
+					assert.True(t, ok)
+					assert.Equal(t, "sqlserver.procedure.database_name-val", attrVal.Str())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure_execution_count")
+					assert.True(t, ok)
+					assert.EqualValues(t, 35, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.total_worker_time")
+					assert.True(t, ok)
+					assert.Equal(t, 27.100000, attrVal.Double())
+					attrVal, ok = lr.Attributes().Get("sqlserver.total_elapsed_time")
+					assert.True(t, ok)
+					assert.Equal(t, 28.100000, attrVal.Double())
+					attrVal, ok = lr.Attributes().Get("sqlserver.total_logical_reads")
+					assert.True(t, ok)
+					assert.EqualValues(t, 29, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.total_logical_writes")
+					assert.True(t, ok)
+					assert.EqualValues(t, 30, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.total_physical_reads")
+					assert.True(t, ok)
+					assert.EqualValues(t, 30, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.total_spills")
+					assert.True(t, ok)
+					assert.EqualValues(t, 32, attrVal.Int())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.avg_elapsed_time_ms")
+					assert.True(t, ok)
+					assert.Equal(t, 39.100000, attrVal.Double())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.max_elapsed_time_ms")
+					assert.True(t, ok)
+					assert.Equal(t, 39.100000, attrVal.Double())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.min_elapsed_time_ms")
+					assert.True(t, ok)
+					assert.Equal(t, 39.100000, attrVal.Double())
+					attrVal, ok = lr.Attributes().Get("sqlserver.procedure.last_execution_time")
+					assert.True(t, ok)
+					assert.Equal(t, "sqlserver.procedure.last_execution_time-val", attrVal.Str())
 				case "db.server.query_sample":
 					assert.False(t, validatedEvents["db.server.query_sample"], "Found a duplicate in the events slice: db.server.query_sample")
 					validatedEvents["db.server.query_sample"] = true

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -4,15 +4,14 @@ package metadata
 
 import (
 	"fmt"
-	"slices"
-	"strconv"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"slices"
+	"strconv"
+	"time"
 )
 
 const (

--- a/receiver/sqlserverreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 )
 

--- a/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/sqlserverreceiver/internal/metadata/testdata/config.yaml
@@ -235,6 +235,8 @@ all_set:
     sqlserver.worktable.cache.hit_ratio:
       enabled: true
   events:
+    db.server.procedure_metrics:
+      enabled: true
     db.server.query_sample:
       enabled: true
     db.server.top_query:
@@ -494,6 +496,8 @@ reaggregate_set:
     sqlserver.worktable.cache.hit_ratio:
       enabled: true
   events:
+    db.server.procedure_metrics:
+      enabled: true
     db.server.query_sample:
       enabled: true
     db.server.top_query:
@@ -753,6 +757,8 @@ none_set:
     sqlserver.worktable.cache.hit_ratio:
       enabled: false
   events:
+    db.server.procedure_metrics:
+      enabled: false
     db.server.query_sample:
       enabled: false
     db.server.top_query:

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -282,6 +282,34 @@ attributes:
     requirement_level: recommended
     enum: [guided, misguided]
   # Stored Procedures
+  sqlserver.procedure.avg_elapsed_time_ms:
+    description: Average elapsed time per execution in milliseconds.
+    type: double
+    requirement_level: recommended
+  sqlserver.procedure.database_name:
+    description: Database containing the stored procedure.
+    type: string
+    requirement_level: recommended
+  sqlserver.procedure.last_execution_time:
+    description: ISO 8601 timestamp of the last execution of the procedure.
+    type: string
+    requirement_level: recommended
+  sqlserver.procedure.max_elapsed_time_ms:
+    description: Maximum elapsed time across executions in milliseconds.
+    type: double
+    requirement_level: recommended
+  sqlserver.procedure.min_elapsed_time_ms:
+    description: Minimum elapsed time across executions in milliseconds.
+    type: double
+    requirement_level: recommended
+  sqlserver.procedure.schema_name:
+    description: Schema of the stored procedure.
+    type: string
+    requirement_level: recommended
+  sqlserver.procedure.total_spills:
+    description: Total tempdb spills caused by the procedure, reported in delta value.
+    type: int
+    requirement_level: recommended
   sqlserver.procedure_execution_count:
     description: Number of times that the procedure has been executed since it was last compiled, reported in delta value.
     type: int
@@ -471,6 +499,30 @@ attributes:
   # attributes for events
   ## common
 events:
+  db.server.procedure_metrics:
+    enabled: false
+    description: Aggregated performance metrics for stored procedures, with delta computation on cumulative counters.
+    attributes:
+      - db.system.name
+      - db.namespace
+      - server.address
+      - server.port
+      - sqlserver.procedure_id
+      - sqlserver.procedure_name
+      - sqlserver.procedure.schema_name
+      - sqlserver.procedure.database_name
+      - sqlserver.procedure_execution_count
+      - sqlserver.total_worker_time
+      - sqlserver.total_elapsed_time
+      - sqlserver.total_logical_reads
+      - sqlserver.total_logical_writes
+      - sqlserver.total_physical_reads
+      - sqlserver.procedure.total_spills
+      - sqlserver.procedure.avg_elapsed_time_ms
+      - sqlserver.procedure.max_elapsed_time_ms
+      - sqlserver.procedure.min_elapsed_time_ms
+      - sqlserver.procedure.last_execution_time
+
   db.server.query_sample:
     enabled: false
     description: query sample

--- a/receiver/sqlserverreceiver/queries.go
+++ b/receiver/sqlserverreceiver/queries.go
@@ -460,6 +460,17 @@ func getSQLServerPropertiesQuery(instanceName string) string {
 	return fmt.Sprintf(sqlServerProperties, "")
 }
 
+//go:embed templates/procedureMetricsQuery.tmpl
+var sqlServerProcedureMetricsQueryTemplate string
+
+func getSQLServerProcedureMetricsQuery(topCount int64, instanceName string) string {
+	instanceFilter := ""
+	if instanceName != "" {
+		instanceFilter = fmt.Sprintf("  AND @@SERVERNAME = '%s'", instanceName)
+	}
+	return fmt.Sprintf(sqlServerProcedureMetricsQueryTemplate, topCount, instanceFilter)
+}
+
 //go:embed templates/dbQueryAndTextQuery.tmpl
 var sqlServerQueryTextAndPlanQueryTemplate string
 

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -162,6 +162,11 @@ func (s *sqlServerScraperHelper) ScrapeLogs(ctx context.Context) (plog.Logs, err
 	case getSQLServerQuerySamplesQuery():
 		isQuerySample = true
 		resources, err = s.recordDatabaseSampleQuery(ctx)
+	case getSQLServerProcedureMetricsQuery(s.config.ProcedureMetrics.TopProcedureCount, s.config.InstanceName):
+		resources, err = s.recordDatabaseProcedureMetrics(ctx)
+		if err != nil {
+			s.logger.Error("ProcedureMetrics: scrape failed", zap.Error(err))
+		}
 	default:
 		return plog.Logs{}, fmt.Errorf("Attempted to get logs from unsupported query: %s", s.sqlQuery)
 	}
@@ -2290,4 +2295,102 @@ func (s *sqlServerScraperHelper) recordDiskIOMetrics(ctx context.Context) error 
 	}
 
 	return errors.Join(errs...)
+}
+
+func (s *sqlServerScraperHelper) recordDatabaseProcedureMetrics(ctx context.Context) (pcommon.Resource, error) {
+	const (
+		colDatabaseName     = "database_name"
+		colSchemaName       = "schema_name"
+		colProcedureName    = "procedure_name"
+		colProcedureID      = "procedure_id"
+		colDatabaseID       = "database_id"
+		colExecutionCount   = "execution_count"
+		colTotalWorkerTime  = "total_worker_time"
+		colTotalElapsedTime = "total_elapsed_time"
+		colTotalPhysReads   = "total_physical_reads"
+		colTotalLogReads    = "total_logical_reads"
+		colTotalLogWrites   = "total_logical_writes"
+		colTotalSpills      = "total_spills"
+		colMinElapsedTime   = "min_elapsed_time"
+		colMaxElapsedTime   = "max_elapsed_time"
+		colLastExecTime     = "last_execution_time"
+	)
+
+	rows, err := s.client.QueryRows(ctx)
+	if err != nil {
+		return pcommon.Resource{}, err
+	}
+
+	var resources pcommon.Resource
+	var resourcesAdded bool
+	var errs []error
+	timestamp := pcommon.NewTimestampFromTime(time.Now())
+	dbSystemName := "mssql"
+
+	for _, row := range rows {
+		procedureID := row[colProcedureID]
+		databaseID := row[colDatabaseID]
+
+		executionCountRaw := s.retrieveValue(row, colExecutionCount, &errs, retrieveInt)
+		totalWorkerTimeRaw := s.retrieveValue(row, colTotalWorkerTime, &errs, retrieveInt)
+		totalElapsedTimeRaw := s.retrieveValue(row, colTotalElapsedTime, &errs, retrieveInt)
+		totalPhysReadsRaw := s.retrieveValue(row, colTotalPhysReads, &errs, retrieveInt)
+		totalLogReadsRaw := s.retrieveValue(row, colTotalLogReads, &errs, retrieveInt)
+		totalLogWritesRaw := s.retrieveValue(row, colTotalLogWrites, &errs, retrieveInt)
+		totalSpillsRaw := s.retrieveValue(row, colTotalSpills, &errs, retrieveInt)
+		minElapsedTimeRaw := s.retrieveValue(row, colMinElapsedTime, &errs, retrieveInt)
+		maxElapsedTimeRaw := s.retrieveValue(row, colMaxElapsedTime, &errs, retrieveInt)
+
+		if executionCountRaw == nil || totalElapsedTimeRaw == nil {
+			continue
+		}
+
+		cached, execCountDelta := s.cacheAndDiff(databaseID, procedureID, "0", colExecutionCount, executionCountRaw.(int64))
+		_, workerTimeDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalWorkerTime, totalWorkerTimeRaw.(int64))
+		_, elapsedTimeDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalElapsedTime, totalElapsedTimeRaw.(int64))
+		_, physReadsDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalPhysReads, totalPhysReadsRaw.(int64))
+		_, logReadsDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalLogReads, totalLogReadsRaw.(int64))
+		_, logWritesDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalLogWrites, totalLogWritesRaw.(int64))
+		_, spillsDelta := s.cacheAndDiff(databaseID, procedureID, "0", colTotalSpills, totalSpillsRaw.(int64))
+
+		if !cached || execCountDelta == 0 {
+			continue
+		}
+
+		totalWorkerTimeSec := float64(workerTimeDelta) / 1_000_000
+		totalElapsedTimeSec := float64(elapsedTimeDelta) / 1_000_000
+		avgElapsedTimeMs := float64(elapsedTimeDelta) / float64(execCountDelta) / 1_000.0
+		minElapsedTimeMs := float64(minElapsedTimeRaw.(int64)) / 1_000.0
+		maxElapsedTimeMs := float64(maxElapsedTimeRaw.(int64)) / 1_000.0
+
+		if !resourcesAdded {
+			resources = s.setupResourceBuilder(s.lb.NewResourceBuilder(), row).Emit()
+			resourcesAdded = true
+		}
+
+		s.lb.RecordDbServerProcedureMetricsEvent(
+			context.Background(),
+			timestamp,
+			dbSystemName,
+			row[colDatabaseName],
+			s.config.Server,
+			int64(s.config.Port),
+			procedureID,
+			row[colProcedureName],
+			row[colSchemaName],
+			row[colDatabaseName],
+			execCountDelta,
+			totalWorkerTimeSec,
+			totalElapsedTimeSec,
+			logReadsDelta,
+			logWritesDelta,
+			physReadsDelta,
+			spillsDelta,
+			avgElapsedTimeMs,
+			maxElapsedTimeMs,
+			minElapsedTimeMs,
+			row[colLastExecTime],
+		)
+	}
+	return resources, errors.Join(errs...)
 }

--- a/receiver/sqlserverreceiver/templates/procedureMetricsQuery.tmpl
+++ b/receiver/sqlserverreceiver/templates/procedureMetricsQuery.tmpl
@@ -1,0 +1,30 @@
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4,5,8) BEGIN
+    DECLARE @ErrorMessage AS nvarchar(500) = 'Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard, Enterprise, Express, Azure SQL Database or Azure SQL Managed Instance. This query is only supported on these editions.';
+    RAISERROR (@ErrorMessage,11,1)
+    RETURN
+END
+
+SELECT TOP (%d)
+    DB_NAME(ps.database_id) AS database_name,
+    OBJECT_SCHEMA_NAME(ps.object_id, ps.database_id) AS schema_name,
+    QUOTENAME(OBJECT_SCHEMA_NAME(ps.object_id, ps.database_id)) + N'.' + QUOTENAME(OBJECT_NAME(ps.object_id, ps.database_id)) AS procedure_name,
+    CAST(ps.object_id AS nvarchar(50)) AS procedure_id,
+    ps.database_id,
+    ps.execution_count,
+    ps.total_worker_time,
+    ps.total_elapsed_time,
+    ps.total_physical_reads,
+    ps.total_logical_reads,
+    ps.total_logical_writes,
+    ps.total_spills,
+    ps.min_elapsed_time,
+    ps.max_elapsed_time,
+    CONVERT(varchar(30), ps.last_execution_time, 127) AS last_execution_time
+FROM sys.dm_exec_procedure_stats AS ps
+WHERE ps.database_id > 4
+  AND ps.execution_count > 0
+  AND DB_NAME(ps.database_id) IS NOT NULL
+  AND OBJECT_NAME(ps.object_id, ps.database_id) IS NOT NULL
+%s
+ORDER BY ps.total_elapsed_time DESC


### PR DESCRIPTION
#### Description

Adds stored procedure performance metrics collection from `sys.dm_exec_procedure_stats` with delta computation on cumulative counters via `cacheAndDiff`. Emits `db.server.procedure_metrics` log events with per-interval deltas for execution count, CPU time, elapsed time, logical reads, physical reads/writes, and spills.

The event is disabled by default and can be enabled via `logs_builder_config` when `db.server.procedure_metrics` is set to `enabled: true`. Configurable `top_procedure_count` (default 250) controls how many procedures are collected per scrape.

#### Link to tracking issue

#### Testing

- Unit tests pass (`go test ./...` for `receiver/sqlserverreceiver`)
- Factory test updated to include new `ProcedureMetrics` config field
- Generated metadata tests pass with new event definition

#### Documentation

- `metadata.yaml` updated with `db.server.procedure_metrics` event definition and 20 attributes
- `documentation.md` auto-generated from metadata

#### Authorship

- [ ] I, a human, wrote this pull request description myself.